### PR TITLE
perf(decode): ship the verified tree-free decoder as Inflate.inflate

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -39,6 +39,7 @@ import Zip.Spec.InflateComplete
 import Zip.Native.Adler32
 import Zip.Native.Crc32
 import Zip.Native.Inflate
+import Zip.Native.InflateTreeFree
 import Zip.Native.Gzip
 import Zip.Native.BitWriter
 import Zip.Native.Deflate

--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -3,6 +3,7 @@ import Zip.Checksum
 import ZipCommon.Handle
 import Zip.RawDeflate
 import Zip.Native.Inflate
+import Zip.Native.InflateTreeFree
 import Zip.Native.Crc32
 
 /-! ZIP archive construction and extraction: entry metadata, local/central headers,
@@ -1216,8 +1217,8 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
     if entry.method == 0 then pure compData
     else if entry.method == 8 then
       if useNative then
-        -- `Zip.Native.Inflate.inflate` treats `0` as "reject any non-empty
-        -- output", unlike the FFI path where `0` means unlimited. Callers
+        -- `Zip.Native.Inflate.inflate` treats `0` as "reject any
+        -- non-empty output", unlike the FFI path where `0` means unlimited. Callers
         -- that opt into `maxEntrySize := 0` for unlimited FFI decompression
         -- therefore get an immediate rejection on the native backend.
         --

--- a/Zip/Native/Gzip.lean
+++ b/Zip/Native/Gzip.lean
@@ -1,4 +1,5 @@
 import Zip.Native.Inflate
+import Zip.Native.InflateTreeFree
 import Zip.Native.DeflateDynamic
 import Zip.Native.Crc32
 import Zip.Native.Adler32
@@ -34,8 +35,8 @@ termination_by data.size - pos
     non-empty output (the inner inflate guards compare
     `output.size + len > maxOutputSize`). The outer-loop guard raises an
     `Except` error containing `"Gzip: total output exceeds maximum size"`;
-    the inner per-member `Inflate.inflateRaw` call also enforces the bound
-    and may surface `"Inflate: output exceeds maximum size"` first.
+    the inner per-member `Inflate.inflateRaw` call also enforces the
+    bound and may surface `"Inflate: output exceeds maximum size"` first.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
     Except String ByteArray := do

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -110,6 +110,27 @@ def fromLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
     else
       .ok (fromLengthsTree lengths maxBits)
 
+/-- The code-length validity check that `fromLengths` performs, factored out so a
+    decoder that builds no tree (the canonical tree-free path) can reject exactly
+    the malformed length sets `fromLengths` rejects, with the same error messages:
+    `"Inflate: code length exceeds maximum"` for any length `> maxBits`, and
+    `"Inflate: oversubscribed Huffman code"` when the Kraft sum overflows. Computed
+    cheaply from the lengths alone — no tree, no `count` array, no insertion pass.
+    `fromLengths = (validateLengths …).map (fun _ => fromLengthsTree …)`
+    (`Zip.Spec.InflateTreeFreeCorrect.fromLengths_eq_validate`). -/
+def validateLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
+    Except String Unit :=
+  if lengths.any (fun l => l.toNat > maxBits) then
+    .error "Inflate: code length exceeds maximum"
+  else
+    let lsList := lengths.toList.map UInt8.toNat
+    let kraft := (lsList.filter (· != 0)).foldl
+      (fun acc l => acc + 2 ^ (maxBits - l)) 0
+    if kraft > 2 ^ maxBits then
+      .error "Inflate: oversubscribed Huffman code"
+    else
+      .ok ()
+
 /-- Decode one symbol from the bit reader using this Huffman tree. -/
 def decode (tree : HuffTree) (br : BitReader) :
     Except String (UInt16 × BitReader) :=
@@ -1265,7 +1286,7 @@ decreasing_by all_goals omega
     affects the produced bytes or the `maxOutputSize` bomb guard, so every inflate
     correctness proof transfers unchanged (`ByteArray.emptyWithCapacity n` is
     definitionally `{ data := Array.empty }` for every `n`). -/
-def inflateRaw (data : ByteArray) (startPos : Nat := 0)
+def inflateRawReference (data : ByteArray) (startPos : Nat := 0)
     (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
     Except String (ByteArray × Nat) := do
   let br : BitReader := { data, pos := startPos, bitOff := 0 }
@@ -1284,26 +1305,25 @@ def inflateRaw (data : ByteArray) (startPos : Nat := 0)
 
     `sizeHint` pre-reserves output capacity when the decompressed size is known;
     `0` (the default) reserves nothing. See `inflateRaw`. -/
-def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
+def inflateReference (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
     (sizeHint : Nat := 0) :
     Except String ByteArray := do
-  let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
+  let (output, _) ← inflateRawReference data 0 maxOutputSize sizeHint
   return output
 
-/-- The output capacity hint is computationally inert: `inflateRaw` with any
-    `sizeHint` equals `inflateRaw` with the default `sizeHint := 0`, because
+/-- The output capacity hint is computationally inert: `inflateRawReference` with any
+    `sizeHint` equals it with the default `sizeHint := 0`, because
     `ByteArray.emptyWithCapacity n` reduces to `{ data := Array.empty }` for every
-    `n` (capacity is a runtime-only allocation hint). So every theorem proved about
-    the `sizeHint := 0` form — correctness, suffix invariance, end-position bounds —
-    transfers verbatim to any hinted call (e.g. the ZIP decoder's). -/
-@[simp] theorem inflateRaw_sizeHint_eq (data : ByteArray) (startPos maxOutputSize sizeHint : Nat) :
-    inflateRaw data startPos maxOutputSize sizeHint = inflateRaw data startPos maxOutputSize :=
+    `n` (capacity is a runtime-only allocation hint). -/
+@[simp] theorem inflateRawReference_sizeHint_eq (data : ByteArray)
+    (startPos maxOutputSize sizeHint : Nat) :
+    inflateRawReference data startPos maxOutputSize sizeHint
+      = inflateRawReference data startPos maxOutputSize :=
   rfl
 
-/-- `inflate` with any `sizeHint` equals `inflate` with the default `0`; see
-    `inflateRaw_sizeHint_eq`. -/
-@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
-    inflate data maxOutputSize sizeHint = inflate data maxOutputSize :=
+/-- `inflateReference` with any `sizeHint` equals it with the default `0`. -/
+@[simp] theorem inflateReference_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
+    inflateReference data maxOutputSize sizeHint = inflateReference data maxOutputSize :=
   rfl
 
 end Inflate

--- a/Zip/Native/InflateBuf.lean
+++ b/Zip/Native/InflateBuf.lean
@@ -9,8 +9,10 @@ import Zip.Native.Inflate
   can call them. This file provides the *parallel* block loop and entry point
   (`inflateLoopBuf`, `InflateBuf.inflate`) built directly on the buffered decoder;
   `Zip.Spec.InflateBufCorrect` proves `inflateLoopBuf = Inflate.inflateLoop` and
-  `InflateBuf.inflate = Inflate.inflate`, which (now that `inflateLoop` itself runs
-  the buffered decoder) is essentially a sanity bridge between the two spellings.
+  `InflateBuf.inflate = Inflate.inflateReference` (the verified tree-building
+  reference, of which the production `Inflate.inflate` is the tree-free counterpart),
+  which (now that `inflateLoop` itself runs the buffered decoder) is essentially a
+  sanity bridge between the two spellings.
 -/
 
 namespace Zip.Native
@@ -43,7 +45,8 @@ decreasing_by all_goals omega
 
 /-- Wide-buffer `inflate` (entry point). `sizeHint` pre-reserves output capacity
     when the decompressed size is known (`0`, the default, reserves nothing); it is
-    a capacity hint only, so `InflateBuf.inflate = Inflate.inflate` is unaffected. -/
+    a capacity hint only, so `InflateBuf.inflate = Inflate.inflateReference` is
+    unaffected. -/
 def inflate (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024)
     (sizeHint : Nat := 0) :
     Except String ByteArray := do

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -1,22 +1,27 @@
 import Zip.Native.Inflate
 
 /-!
-# Tree-free canonical decode (conformance/benchmark prototype)
+# Tree-free canonical decode — the production DEFLATE decoder
 
-A DEFLATE Huffman decoder that builds **no** Huffman tree: the fast ≤9-bit codes
-go through the canonical 9-bit table (`buildTableCanonicalFast`), and the rare
->9-bit codes go through a canonical bit-by-bit decode keyed off the per-length
-`count` / `firstCode` / sorted-symbol arrays — never a tree walk. This isolates
-the *build-phase* win (skip `fromLengths`/`insertLoop`).
+This file defines the **production** decoders `Inflate.inflate` / `inflateRaw`: a
+DEFLATE Huffman decode that builds **no** Huffman tree. The fast ≤9-bit codes go
+through the canonical 9-bit table (`buildTableCanonicalFast`), and the rare >9-bit
+codes go through a canonical bit-by-bit decode keyed off the per-length
+`count` / `firstCode` / sorted-symbol arrays — never a tree walk. This skips the
+`fromLengths`/`insertLoop` build entirely (the ~7% decode win).
 
 The decode loops are well-founded (`termination_by`, mirroring the verified
 `goFusedP`/`goFusedPU`/`inflateLoop`); the canonical structures and their
-correctness are proven in `Zip.Spec.InflateTreeFreeCorrect`: whenever the
-verified decoder succeeds, this decoder produces identical output
-(`inflateTreeFree_of_inflate`). This is forward correctness, not an `iff` — on
-malformed dynamic code lengths the tree-free path is more lenient (it skips the
-lit/dist `fromLengths` Kraft check), so it accepts some inputs the tree path
-rejects. It must not replace the trusted decoder where strict rejection matters.
+correctness are proven in `Zip.Spec.InflateTreeFreeCorrect`.
+
+`decodeDynamicLengthsOnly` runs the same `HuffTree.validateLengths`
+(`maxBits`/Kraft) check `decodeDynamicTrees` does, so the production decoder's
+accept-set is **exactly** the verified reference's
+(`Inflate.inflateReference` / `inflateRawReference`, in `Zip.Native.Inflate`) —
+proven as the two-sided `inflate_ok_iff_reference`
+(`inflate data = .ok out ↔ inflateReference data = .ok out`) and
+`inflateRaw_ok_iff_reference`. Every decode-correctness theorem about the
+reference therefore transfers, and the `native ⊆ FFI` posture is preserved.
 -/
 
 namespace Zip.Native
@@ -307,7 +312,15 @@ namespace Inflate
 /-- Like `decodeDynamicTrees`, but returns only the code-length vectors — it never
     builds the lit/dist Huffman trees (the whole point of the tree-free path). The
     small code-length tree (`clTree`, 19 symbols) is still built to decode the
-    length symbols. -/
+    length symbols.
+
+    The lit/dist length vectors are still run through `HuffTree.validateLengths`
+    (the `maxBits`/Kraft check `fromLengths` performs) so this rejects exactly the
+    malformed code-length sets `decodeDynamicTrees` rejects, with identical error
+    messages — closing the strictness gap the tree-free path would otherwise open
+    (`Zip.Spec.InflateTreeFreeCorrect.decodeDynamicTrees_of_lengthsOnly`, the
+    converse of `decodeDynamicTrees_extract`). The check is computable from the
+    lengths alone — no tree is built. -/
 def decodeDynamicLengthsOnly (br : BitReader) :
     Except String (Array UInt8 × Array UInt8 × BitReader) := do
   let (hlit, br) ← br.readBits 5
@@ -322,6 +335,8 @@ def decodeDynamicLengthsOnly (br : BitReader) :
   let (codeLengths, br) ← decodeCLSymbols clTree br (.replicate totalCodes 0) 0 totalCodes
   let litLenLengths := codeLengths.extract 0 numLitLen
   let distLengths := codeLengths.extract numLitLen totalCodes
+  let _ ← HuffTree.validateLengths litLenLengths 15
+  let _ ← HuffTree.validateLengths distLengths 15
   return (litLenLengths, distLengths, br)
 
 /-- Tree-free block loop (mirrors `inflateLoop`): fixed and dynamic Huffman blocks
@@ -351,13 +366,42 @@ def inflateLoopTreeFree (br : BitReader) (output : ByteArray) (maxOut dataSize :
   termination_by dataSize * 8 - br.bitPos
   decreasing_by all_goals omega
 
-/-- Tree-free `inflate` (no Huffman tree built anywhere on the decode path).
-    Conformance-checked against `Inflate.inflate`. -/
-def inflateTreeFree (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024) :
+/-- Inflate a raw DEFLATE stream starting at byte offset `startPos`, returning the
+    decompressed data and the byte-aligned position after the last block. **This is
+    the production decoder**: a tree-free canonical Huffman decode that builds no
+    Huffman tree anywhere on the decode path (the loop reads `fixedLit/DistLengths`
+    directly and decodes through the canonical table + `walkCanonical` fallback).
+    Proven accept-set equal to the verified reference `inflateRawReference`
+    (`Zip.Spec.InflateTreeFreeCorrect.inflateRaw_ok_iff_reference`), so every downstream
+    correctness theorem transfers. `maxOutputSize` (default 1 GiB) caps output;
+    `sizeHint` pre-reserves capacity (computationally inert — see
+    `inflateRaw_sizeHint_eq`). -/
+def inflateRaw (data : ByteArray) (startPos : Nat := 0)
+    (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
+    Except String (ByteArray × Nat) := do
+  let br : BitReader := { data, pos := startPos, bitOff := 0 }
+  inflateLoopTreeFree br (ByteArray.emptyWithCapacity sizeHint) maxOutputSize data.size
+
+/-- Inflate a raw DEFLATE stream (whole buffer). **The production decoder** — the
+    tree-free counterpart of the reference `inflateReference`, proven accept-set
+    equal to it (`Zip.Spec.InflateTreeFreeCorrect.inflate_ok_iff_reference`). -/
+def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
+    (sizeHint : Nat := 0) :
     Except String ByteArray := do
-  let br : BitReader := { data, pos := 0, bitOff := 0 }
-  let (output, _) ← inflateLoopTreeFree br ByteArray.empty maxOut data.size
+  let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
   return output
+
+/-- The output capacity hint is computationally inert (`ByteArray.emptyWithCapacity n`
+    reduces to `{ data := Array.empty }` for every `n`). -/
+@[simp] theorem inflateRaw_sizeHint_eq (data : ByteArray)
+    (startPos maxOutputSize sizeHint : Nat) :
+    inflateRaw data startPos maxOutputSize sizeHint = inflateRaw data startPos maxOutputSize :=
+  rfl
+
+/-- `inflate` with any `sizeHint` equals it with the default `0`. -/
+@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
+    inflate data maxOutputSize sizeHint = inflate data maxOutputSize :=
+  rfl
 
 end Inflate
 end Zip.Native

--- a/Zip/Spec/Deflate.lean
+++ b/Zip/Spec/Deflate.lean
@@ -16,7 +16,7 @@ The specification is structured in layers:
 4. **Stream decode**: sequence of blocks terminated by a final block
 
 The key correctness theorem `inflate_correct` (in `Zip.Spec.InflateCorrect`)
-proves that `Zip.Native.Inflate.inflate` agrees with this specification.
+proves that `Zip.Native.Inflate.inflateReference` agrees with this specification.
 -/
 
 namespace Deflate.Spec

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -587,7 +587,7 @@ theorem decode_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (leve
     input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksSC data chunkSize level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksSC data chunkSize level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -759,7 +759,7 @@ theorem decode_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (l
     input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksShared data tokChunk level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksShared data tokChunk level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -1138,7 +1138,7 @@ theorem decode_deflateDynamicBlocksSharedAt (data : ByteArray)
 theorem inflate_deflateDynamicBlocksSharedAt (data : ByteArray)
     (choose : Array LZ77Token → List Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksSharedAt data choose level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksSharedAt data choose level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -1312,7 +1312,7 @@ theorem decode_deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) :
     recovers the input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksOptimal data tokChunk) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksOptimal data tokChunk) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -515,7 +515,7 @@ theorem inflate_deflateDynamicBlock (data : ByteArray) (tokens : Array LZ77Token
     (hempty : data.size = 0 → tokens = #[])
     (hresolve : Deflate.Spec.resolveLZ77 (tokensToSymbols tokens) [] = some data.data.toList)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlock data tokens) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlock data tokens) maxOutputSize = .ok data := by
   have hspec := deflateDynamicBlock_spec data tokens htok_enc hempty
   match hspec with
   | ⟨litLens, distLens, headerBits, symBits, hv_lit, hv_dist,
@@ -557,7 +557,7 @@ theorem inflate_deflateDynamicBlock (data : ByteArray) (tokens : Array LZ77Token
     large enough to hold the input. -/
 theorem inflate_deflateDynamic (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamic data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateDynamic data) maxOutputSize = .ok data := by
   unfold deflateDynamic
   exact inflate_deflateDynamicBlock data (lz77GreedyIter data)
     (fun t ht => lz77Greedy_encodable data 32768 (by omega) (by omega) t

--- a/Zip/Spec/DeflateFixedCorrect.lean
+++ b/Zip/Spec/DeflateFixedCorrect.lean
@@ -335,12 +335,12 @@ theorem inflate_complete (bytes : ByteArray) (result : List UInt8)
     (maxOutputSize : Nat)
     (hsize : result.length ≤ maxOutputSize)
     (hdec : decode (bytesToBits bytes) = some result) :
-    Zip.Native.Inflate.inflate bytes maxOutputSize =
+    Zip.Native.Inflate.inflateReference bytes maxOutputSize =
     .ok ⟨⟨result⟩⟩ := by
   -- Unfold inflate: it calls inflateRaw then discards endPos
-  simp only [Inflate.inflate, bind, Except.bind]
+  simp only [Inflate.inflateReference, bind, Except.bind]
   -- Unfold inflateRaw
-  simp only [Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty, bind, Except.bind]
+  simp only [Inflate.inflateRawReference, ByteArray.emptyWithCapacity_eq_empty, bind, Except.bind]
   -- Build fixed Huffman trees (computationally verified to succeed)
   obtain ⟨fixedLit, hflit⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
   obtain ⟨fixedDist, hfdist⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
@@ -374,7 +374,7 @@ private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     (hspec : ∃ bits, Deflate.Spec.encodeFixed syms = some bits ∧
       Deflate.Spec.bytesToBits compressed = bits ++
         List.replicate ((8 - bits.length % 8) % 8) false) :
-    Zip.Native.Inflate.inflate compressed maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference compressed maxOutputSize = .ok data := by
   obtain ⟨bits_enc, henc_fixed, hbytes⟩ := hspec
   simp only [Deflate.Spec.encodeFixed] at henc_fixed
   cases henc_syms : Deflate.Spec.encodeSymbols Deflate.Spec.fixedLitLengths
@@ -401,7 +401,7 @@ private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateFixed (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixed data) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateFixed data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateFixed data) data
     (tokensToSymbols (lz77Greedy data)) maxOutputSize hsize
     (lz77Greedy_resolves data 32768 (by omega))
@@ -599,7 +599,7 @@ theorem lz77GreedyIter_eq_lz77Greedy (data : ByteArray) (ws : Nat) :
     Follows from `lz77GreedyIter_eq_lz77Greedy` + `inflate_deflateFixed`. -/
 theorem inflate_deflateFixedIter (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixedIter data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateFixedIter data) maxOutputSize = .ok data := by
   unfold deflateFixedIter
   rw [lz77GreedyIter_eq_lz77Greedy]
   exact inflate_deflateFixed data maxOutputSize hsize
@@ -617,7 +617,7 @@ theorem inflate_deflateFixedBlock (data : ByteArray) (tokens : Array LZ77Token)
     (hempty : data.size = 0 → tokens = #[])
     (hresolve : resolveLZ77 (tokensToSymbols tokens) [] = some data.data.toList)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixedBlock data tokens) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateFixedBlock data tokens) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateFixedBlock data tokens) data (tokensToSymbols tokens)
     maxOutputSize hsize hresolve (tokensToSymbols_validSymbolList _)
     (deflateFixedBlock_spec data tokens
@@ -663,7 +663,7 @@ theorem deflateLazy_spec (data : ByteArray) :
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateLazy (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateLazy data) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateLazy data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateLazy data) data
     (tokensToSymbols (lz77Lazy data)) maxOutputSize hsize
     (lz77Lazy_resolves data 32768 (by omega))
@@ -824,7 +824,7 @@ theorem deflateLazyIter_eq_deflateLazy (data : ByteArray) :
     Follows from `deflateLazyIter_eq_deflateLazy` + `inflate_deflateLazy`. -/
 theorem inflate_deflateLazyIter (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateLazyIter data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateLazyIter data) maxOutputSize = .ok data := by
   rw [deflateLazyIter_eq_deflateLazy]
   exact inflate_deflateLazy data maxOutputSize hsize
 

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -55,9 +55,9 @@ private theorem cRes (data : ByteArray) (level : UInt8) :
 set_option maxRecDepth 8000 in
 /-- `pickSmaller` of two byte arrays that both roundtrip also roundtrips. -/
 theorem inflate_pickSmaller (a b dataOut : ByteArray) (m : Nat)
-    (ha : Zip.Native.Inflate.inflate a m = .ok dataOut)
-    (hb : Zip.Native.Inflate.inflate b m = .ok dataOut) :
-    Zip.Native.Inflate.inflate (pickSmaller a b) m = .ok dataOut := by
+    (ha : Zip.Native.Inflate.inflateReference a m = .ok dataOut)
+    (hb : Zip.Native.Inflate.inflateReference b m = .ok dataOut) :
+    Zip.Native.Inflate.inflateReference (pickSmaller a b) m = .ok dataOut := by
   unfold pickSmaller; split <;> assumption
 
 /-- `pickSmaller` preserves any predicate on the bit stream both candidates meet. -/
@@ -70,7 +70,7 @@ theorem pickSmaller_bytesToBits {P : List Bool → Prop} (a b : ByteArray)
     `deflateRaw` cases without the stored-block fallback. -/
 theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateCompressed data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateCompressed data level) maxOutputSize = .ok data := by
   unfold deflateCompressed
   dsimp only []
   split
@@ -88,7 +88,7 @@ set_option maxRecDepth 8000 in
     elaborator to whnf the nested size comparison. -/
 theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateRawBase data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateRawBase data level) maxOutputSize = .ok data := by
   rw [← deflateRawBase_def]
   unfold deflateRawBaseTokens
   dsimp only []
@@ -111,7 +111,7 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     block-split candidates are covered by the `pickSmaller` cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
   rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,

--- a/Zip/Spec/DeflateStoredCorrect.lean
+++ b/Zip/Spec/DeflateStoredCorrect.lean
@@ -751,8 +751,8 @@ theorem deflateStoredPure_size (data : ByteArray) :
 theorem inflate_deflateStoredPure (data : ByteArray)
     (maxOutputSize : Nat)
     (h : data.size ≤ maxOutputSize) :
-    Inflate.inflate (deflateStoredPure data) maxOutputSize = .ok data := by
-  simp only [Inflate.inflate, Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty,
+    Inflate.inflateReference (deflateStoredPure data) maxOutputSize = .ok data := by
+  simp only [Inflate.inflateReference, Inflate.inflateRawReference, ByteArray.emptyWithCapacity_eq_empty,
     bind, Except.bind]
   -- Handle fromLengths calls
   have ⟨fixedLit, hfl⟩ := fromLengths_fixedLit_ok

--- a/Zip/Spec/GzipCorrect.lean
+++ b/Zip/Spec/GzipCorrect.lean
@@ -37,7 +37,7 @@ def decompressSingle (data : ByteArray)
   unless flg == 0 do throw "Gzip: unsupported flags (single-member only)"
   -- Skip MTIME (4) + XFL (1) + OS (1) = 6 bytes at offset 4–9
   -- Inflate the DEFLATE stream starting at byte 10
-  let (decompressed, endPos) ← Inflate.inflateRaw data 10 maxOutputSize
+  let (decompressed, endPos) ← Inflate.inflateRawReference data 10 maxOutputSize
   -- Parse trailer at endPos: CRC32 (4 bytes LE) + ISIZE (4 bytes LE)
   if endPos + 8 > data.size then throw "Gzip: truncated trailer"
   let expectedCrc := Binary.readUInt32LE data endPos
@@ -143,12 +143,12 @@ theorem bytesToBits_drop_prefix_three (a b c : ByteArray) :
     `bytesToBits deflated`. -/
 theorem inflate_to_spec_decode (deflated : ByteArray) (result : ByteArray)
     (maxOutputSize : Nat)
-    (h : Inflate.inflate deflated maxOutputSize = .ok result) :
+    (h : Inflate.inflateReference deflated maxOutputSize = .ok result) :
     Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
       some result.data.toList := by
-  simp only [Inflate.inflate, bind, Except.bind] at h
-  cases hinf : Inflate.inflateRaw deflated 0 maxOutputSize with
+  simp only [Inflate.inflateReference, bind, Except.bind] at h
+  cases hinf : Inflate.inflateRawReference deflated 0 maxOutputSize with
   | error e => exact nomatch (hinf ▸ h)
   | ok p =>
     simp only [hinf, pure, Except.pure, Except.ok.injEq] at h
@@ -177,7 +177,7 @@ theorem inflateRaw_framing (data : ByteArray) (level : UInt8) (maxOutputSize : N
     (hspec_go : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList) :
-    Inflate.inflateRaw (header ++ Deflate.deflateRaw data level ++ trailer) H maxOutputSize =
+    Inflate.inflateRawReference (header ++ Deflate.deflateRaw data level ++ trailer) H maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, H + (Deflate.deflateRaw data level).size) := by
   -- Spec decode on (header ++ deflated) at offset H, via prefix drop
   have hspec_hd : Deflate.Spec.decode.go
@@ -191,7 +191,7 @@ theorem inflateRaw_framing (data : ByteArray) (level : UInt8) (maxOutputSize : N
       data.data.toList hdata_le hspec_hd
   -- endPos' is exactly the size of (header ++ deflated)
   have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
-    have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
+    have h' : Inflate.inflateRawReference (header ++ Deflate.deflateRaw data level)
         header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
       rw [hhsz]; exact hinflRaw'
     exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
@@ -211,7 +211,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     GzipDecode.decompressSingle (GzipEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
+  have hinfl : Inflate.inflateReference (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
@@ -226,7 +226,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
     rw [GzipEncode.compress_size]; omega
   -- Native inflate at offset 10 consumes exactly the DEFLATE stream (framing lemma)
   obtain ⟨header, trailer, hhsz, _, hceq⟩ := GzipEncode.compress_eq data level
-  have hinflRaw : Inflate.inflateRaw (GzipEncode.compress data level) 10 maxOutputSize =
+  have hinflRaw : Inflate.inflateRawReference (GzipEncode.compress data level) 10 maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, 10 + (Deflate.deflateRaw data level).size) := by
     rw [hceq]
     exact inflateRaw_framing data level maxOutputSize header trailer 10 hhsz hdata_le hspec_go

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -2019,11 +2019,11 @@ theorem inflateLoopBuf_eq (fixedLit fixedDist : HuffTree) (maxOut dataSize : Nat
           simp only [hhf]; exact tail o' br' hp' hl' (by rw [hd', hd3]; exact hdata₂)
     · simp only [bind, Except.bind]
 
-/-- **`InflateBuf.inflate` equals the verified `Inflate.inflate`.** The wide-buffer
+/-- **`InflateBuf.inflate` equals the verified `Inflate.inflateReference`.** The wide-buffer
     decoder is a drop-in replacement with no trust gap. -/
 theorem inflate_eq (data : ByteArray) (maxOut : Nat) (sizeHint : Nat := 0) :
-    InflateBuf.inflate data maxOut sizeHint = Inflate.inflate data maxOut sizeHint := by
-  unfold InflateBuf.inflate Inflate.inflate Inflate.inflateRaw
+    InflateBuf.inflate data maxOut sizeHint = Inflate.inflateReference data maxOut sizeHint := by
+  unfold InflateBuf.inflate Inflate.inflateReference Inflate.inflateRawReference
   cases hfl : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hfl, bind, Except.bind]
   | ok fixedLit =>

--- a/Zip/Spec/InflateBufRoundtrip.lean
+++ b/Zip/Spec/InflateBufRoundtrip.lean
@@ -6,7 +6,7 @@ import Zip.Spec.DeflateFixedCorrect
 
 `InflateBuf.inflate` (the wide-buffer DEFLATE decompressor) inverts the native
 fixed-Huffman compressor `deflateFixed`, by transferring `Inflate`'s roundtrip
-theorem across the proven equality `InflateBuf.inflate = Inflate.inflate`.
+theorem across the proven equality `InflateBuf.inflate = Inflate.inflateReference`.
 -/
 
 namespace Zip.Native.InflateBuf

--- a/Zip/Spec/InflateCorrect.lean
+++ b/Zip/Spec/InflateCorrect.lean
@@ -6,7 +6,7 @@ import Zip.Spec.InflateBufCorrect
 # DEFLATE Stream-Level Correctness
 
 Proves the main correctness theorem: the native pure-Lean DEFLATE
-decompressor (`Zip.Native.Inflate.inflateRaw`) agrees with the formal
+decompressor (`Zip.Native.Inflate.inflateRawReference`) agrees with the formal
 bitstream specification (`Deflate.Spec.decode`).
 
 This file handles the block loop (`inflateLoop_correct`) and the
@@ -659,13 +659,13 @@ theorem inflateLoop_correct (br : ZipCommon.BitReader)
     the formal specification also succeeds and produces the same output. -/
 theorem inflate_correct (data : ByteArray) (startPos maxOutputSize : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Zip.Native.Inflate.inflateRaw data startPos maxOutputSize =
+    (h : Zip.Native.Inflate.inflateRawReference data startPos maxOutputSize =
       .ok (result, endPos)) :
     Deflate.Spec.decode
       ((Deflate.Spec.bytesToBits data).drop (startPos * 8)) =
       some result.data.toList := by
   -- Unfold inflateRaw
-  simp only [Zip.Native.Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Zip.Native.Inflate.inflateRawReference, bind, Except.bind] at h
   -- Build fixed trees
   cases hflit : Zip.Native.HuffTree.fromLengths
       Zip.Native.Inflate.fixedLitLengths with
@@ -692,11 +692,11 @@ theorem inflate_correct (data : ByteArray) (startPos maxOutputSize : Nat)
     the spec `decode` applied to the full bitstream. -/
 theorem inflate_correct' (data : ByteArray) (maxOutputSize : Nat)
     (result : ByteArray)
-    (h : Zip.Native.Inflate.inflate data maxOutputSize = .ok result) :
+    (h : Zip.Native.Inflate.inflateReference data maxOutputSize = .ok result) :
     Deflate.Spec.decode (Deflate.Spec.bytesToBits data) =
       some result.data.toList := by
-  simp only [Zip.Native.Inflate.inflate, bind, Except.bind] at h
-  cases hinf : Zip.Native.Inflate.inflateRaw data 0 maxOutputSize with
+  simp only [Zip.Native.Inflate.inflateReference, bind, Except.bind] at h
+  cases hinf : Zip.Native.Inflate.inflateRawReference data 0 maxOutputSize with
   | error e => exact nomatch (hinf ▸ h)
   | ok p =>
     simp only [hinf, pure, Except.pure, Except.ok.injEq] at h

--- a/Zip/Spec/InflateLoopBounds.lean
+++ b/Zip/Spec/InflateLoopBounds.lean
@@ -416,9 +416,9 @@ theorem inflateLoop_complete_ext (br : BitReader) (output : ByteArray)
 /-- After a successful `inflateRaw`, the returned endPos ≤ data.size. -/
 theorem inflateRaw_endPos_le (data : ByteArray) (startPos maxOut : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw data startPos maxOut = .ok (result, endPos)) :
+    (h : Inflate.inflateRawReference data startPos maxOut = .ok (result, endPos)) :
     endPos ≤ data.size := by
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>
@@ -481,7 +481,7 @@ private theorem alignToByte_pos_ge_of_toBits_short (br : BitReader)
     endPos = `(prefix ++ deflated).size` exactly. -/
 theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
     (maxOut : Nat) (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw (pfx ++ deflated) pfx.size maxOut =
+    (h : Inflate.inflateRawReference (pfx ++ deflated) pfx.size maxOut =
       .ok (result, endPos))
     (hspec : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
@@ -493,7 +493,7 @@ theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
     (hmax : result.data.toList.length ≤ maxOut) :
     endPos ≥ (pfx ++ deflated).size := by
   obtain ⟨pad_remaining, hgoR_pad, hpadlen⟩ := hpad
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>
@@ -541,7 +541,7 @@ theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
 /-- endPos exactness: combining ≤ and ≥ gives equality. -/
 theorem inflateRaw_endPos_eq (pfx deflated : ByteArray)
     (maxOut : Nat) (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw (pfx ++ deflated) pfx.size maxOut =
+    (h : Inflate.inflateRawReference (pfx ++ deflated) pfx.size maxOut =
       .ok (result, endPos))
     (hspec : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
@@ -568,9 +568,9 @@ theorem inflateRaw_complete (data : ByteArray) (startPos maxOutputSize : Nat)
         ((Deflate.Spec.bytesToBits data).drop (startPos * 8)) [] =
         some result) :
     ∃ endPos,
-      Inflate.inflateRaw data startPos maxOutputSize =
+      Inflate.inflateRawReference data startPos maxOutputSize =
         .ok (⟨⟨result⟩⟩, endPos) := by
-  simp only [Inflate.inflateRaw, bind, Except.bind]
+  simp only [Inflate.inflateRawReference, bind, Except.bind]
   obtain ⟨fixedLit, hflit⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
   obtain ⟨fixedDist, hfdist⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
   rw [hflit, hfdist]

--- a/Zip/Spec/InflateRawSuffix.lean
+++ b/Zip/Spec/InflateRawSuffix.lean
@@ -577,9 +577,9 @@ private theorem inflateLoop_append_suffix (br : BitReader) (suffix : ByteArray)
     succeeds on data ++ suffix with the same result and endPos. -/
 theorem inflateRaw_append_suffix (data suffix : ByteArray) (startPos maxOut : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw data startPos maxOut = .ok (result, endPos)) :
-    Inflate.inflateRaw (data ++ suffix) startPos maxOut = .ok (result, endPos) := by
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h ⊢
+    (h : Inflate.inflateRawReference data startPos maxOut = .ok (result, endPos)) :
+    Inflate.inflateRawReference (data ++ suffix) startPos maxOut = .ok (result, endPos) := by
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h ⊢
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -6,14 +6,21 @@ import Zip.Native.InflateTreeFree
 /-!
 # Tree-free canonical decode: correctness
 
-Proves that whenever the verified `Inflate.inflate` succeeds, the tree-free
-canonical decoder (`Zip.Native.InflateTreeFree`) produces identical output
-(`inflateTreeFree_of_inflate`), with the tree (`fromLengthsTree lengths`) as a
-**proof-only** object — never built at runtime. This is the forward direction:
-for *valid* code lengths the two decoders agree exactly (the internal
-`_ok_iff_` lemmas), but the full `iff` fails because the tree-free path accepts
-some malformed dynamic length sets that the tree path's `fromLengths` rejects.
-The chain, bottom-up:
+Proves that the production tree-free decoder (`Inflate.inflate` / `inflateRaw`,
+defined in `Zip.Native.InflateTreeFree`) has **exactly the same accept-set** as the
+verified reference (`Inflate.inflateReference` / `inflateRawReference`), producing
+identical output, with the tree (`fromLengthsTree lengths`) as a **proof-only**
+object — never built at runtime. The top-level statements are the two-sided
+`inflate_ok_iff_reference` (`inflate data = .ok out ↔ inflateReference data = .ok
+out`) and `inflateRaw_ok_iff_reference`, built from the forward direction
+(`inflate_of_inflateReference`, present since #2681) and the backward direction
+(`inflateReference_of_inflate`) the closed code-length validation gap enables:
+`decodeDynamicLengthsOnly` now runs the same `validateLengths` (`maxBits`/Kraft)
+check `decodeDynamicTrees` does, so on malformed dynamic length sets both paths
+reject. The chain, bottom-up:
+
+0. `validateLengths` ↔ `fromLengths` (`fromLengths_eq_validate`,
+   `validateLengths_ok_iff_fromLengths`) — the factored code-length check.
 
 1. `buildFirstIndex` / `buildSymbols` structure invariants (counting sort places
    each symbol at `firstIndex[len] + offset`).
@@ -27,6 +34,59 @@ Reuses the `#2679` foundation: `nextCodes` / `countLengths` / `codeFor` /
 -/
 
 namespace Zip.Native.HuffTree
+
+/-! ## `validateLengths` ↔ `fromLengths` correspondence
+
+`validateLengths` is exactly the `maxBits`/Kraft check `fromLengths` runs before
+building the tree, factored out for the tree-free path. These lemmas certify that
+running `validateLengths` rejects (and accepts) precisely the length sets
+`fromLengths` does, with identical error messages — the foundation of closing the
+tree-free code-length validation gap. -/
+
+/-- `fromLengths` is `validateLengths` followed by the validation-free tree build:
+    they share the identical `maxBits`/Kraft `if`-cascade, so `fromLengths` errors
+    exactly when `validateLengths` errors, with the same message. -/
+theorem fromLengths_eq_validate (lengths : Array UInt8) (maxBits : Nat) :
+    fromLengths lengths maxBits
+      = (validateLengths lengths maxBits).map (fun _ => fromLengthsTree lengths maxBits) := by
+  unfold fromLengths validateLengths
+  by_cases h1 : lengths.any (fun l => l.toNat > maxBits) = true
+  · rw [if_pos h1, if_pos h1]; rfl
+  · rw [if_neg h1, if_neg h1]
+    by_cases h2 : ((lengths.toList.map UInt8.toNat).filter (· != 0)).foldl
+        (fun acc l => acc + 2 ^ (maxBits - l)) 0 > 2 ^ maxBits
+    · rw [if_pos h2, if_pos h2]; rfl
+    · rw [if_neg h2, if_neg h2]; rfl
+
+/-- `validateLengths` succeeds iff `fromLengths` succeeds (with the canonical tree). -/
+theorem validateLengths_ok_iff_fromLengths (lengths : Array UInt8) (maxBits : Nat) :
+    validateLengths lengths maxBits = .ok () ↔
+      fromLengths lengths maxBits = .ok (fromLengthsTree lengths maxBits) := by
+  rw [fromLengths_eq_validate]
+  cases h : validateLengths lengths maxBits with
+  | error e => simp [Except.map]
+  | ok u => cases u; simp [Except.map]
+
+/-- A successful `validateLengths` certifies `ValidLengths`. -/
+theorem validateLengths_valid {lengths : Array UInt8} {maxBits : Nat}
+    (h : validateLengths lengths maxBits = .ok ()) :
+    Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) maxBits :=
+  Deflate.Correctness.fromLengths_valid lengths maxBits _
+    ((validateLengths_ok_iff_fromLengths lengths maxBits).mp h)
+
+/-- `fromLengths` success yields `validateLengths` success. -/
+theorem validateLengths_of_fromLengths {lengths : Array UInt8} {maxBits : Nat} {t : HuffTree}
+    (h : fromLengths lengths maxBits = .ok t) : validateLengths lengths maxBits = .ok () := by
+  rw [fromLengths_eq_validate] at h
+  cases hv : validateLengths lengths maxBits with
+  | error e => rw [hv] at h; simp [Except.map] at h
+  | ok u => cases u; rfl
+
+/-- A failing `validateLengths` makes `fromLengths` fail with the same message. -/
+theorem fromLengths_error_of_validate {lengths : Array UInt8} {maxBits : Nat} {e : String}
+    (h : validateLengths lengths maxBits = .error e) :
+    fromLengths lengths maxBits = .error e := by
+  rw [fromLengths_eq_validate, h]; rfl
 
 /-! ## `buildFirstIndex` structure invariant -/
 
@@ -1520,7 +1580,49 @@ theorem decodeDynamicTrees_extract {br : BitReader} {litTree distTree : HuffTree
   have hdistb : hdist.toNat < 32 := readBits_lt (n := 5) (by omega) he2
   refine ⟨_, _, ?_, hlitT, hdistT, ?_, ?_⟩
   · unfold decodeDynamicLengthsOnly
-    simp [he1, he2, he3, he4, he5, he6, bind, Except.bind, pure, Except.pure]
+    simp [he1, he2, he3, he4, he5, he6,
+      HuffTree.validateLengths_of_fromLengths hlitT,
+      HuffTree.validateLengths_of_fromLengths hdistT,
+      bind, Except.bind, pure, Except.pure]
+  · rw [Array.size_extract]
+    exact Nat.le_trans (Nat.le_trans (Nat.sub_le _ _) (Nat.min_le_left _ _))
+      (Nat.le_trans (by omega : hlit.toNat + 257 ≤ 288) (by decide : 288 ≤ UInt16.size))
+  · rw [Array.size_extract]
+    exact Nat.le_trans (Nat.le_trans (Nat.sub_le _ _) (Nat.min_le_left _ _))
+      (Nat.le_trans (by omega : hlit.toNat + 257 + (hdist.toNat + 1) ≤ 320)
+        (by decide : 320 ≤ UInt16.size))
+
+/-- **`decodeDynamicLengthsOnly` → `decodeDynamicTrees`.** The converse of
+    `decodeDynamicTrees_extract`: once the tree-free length extractor's added
+    `validateLengths` check passes, the lengths are `ValidLengths`, so
+    `decodeDynamicTrees` rebuilds the canonical trees and succeeds with the same
+    reader. This is exactly what closing the code-length validation gap buys. -/
+theorem decodeDynamicTrees_of_lengthsOnly {br : BitReader} {litLens distLens : Array UInt8}
+    {br' : BitReader}
+    (h : decodeDynamicLengthsOnly br = .ok (litLens, distLens, br')) :
+    decodeDynamicTrees br
+        = .ok (HuffTree.fromLengthsTree litLens 15, HuffTree.fromLengthsTree distLens 15, br') ∧
+      Huffman.Spec.ValidLengths (litLens.toList.map UInt8.toNat) 15 ∧
+      Huffman.Spec.ValidLengths (distLens.toList.map UInt8.toNat) 15 ∧
+      litLens.size ≤ UInt16.size ∧ distLens.size ≤ UInt16.size := by
+  unfold decodeDynamicLengthsOnly at h
+  obtain ⟨a1, he1, h⟩ := bindOk h; obtain ⟨hlit, br1⟩ := a1
+  obtain ⟨a2, he2, h⟩ := bindOk h; obtain ⟨hdist, br2⟩ := a2
+  obtain ⟨a3, he3, h⟩ := bindOk h; obtain ⟨hclen, br3⟩ := a3
+  obtain ⟨a4, he4, h⟩ := bindOk h; obtain ⟨clLengths, br4⟩ := a4
+  obtain ⟨a5, he5, h⟩ := bindOk h
+  obtain ⟨a6, he6, h⟩ := bindOk h; obtain ⟨codeLengths, br6⟩ := a6
+  obtain ⟨u1, hv1, h⟩ := bindOk h; cases u1
+  obtain ⟨u2, hv2, h⟩ := bindOk h; cases u2
+  simp only [pure, Except.pure, Except.ok.injEq, Prod.mk.injEq] at h
+  obtain ⟨rfl, rfl, rfl⟩ := h
+  have hlitb : hlit.toNat < 32 := readBits_lt (n := 5) (by omega) he1
+  have hdistb : hdist.toNat < 32 := readBits_lt (n := 5) (by omega) he2
+  have hflt := (HuffTree.validateLengths_ok_iff_fromLengths _ 15).mp hv1
+  have hfdt := (HuffTree.validateLengths_ok_iff_fromLengths _ 15).mp hv2
+  refine ⟨?_, HuffTree.validateLengths_valid hv1, HuffTree.validateLengths_valid hv2, ?_, ?_⟩
+  · unfold decodeDynamicTrees
+    simp [he1, he2, he3, he4, he5, he6, hflt, hfdt, bind, Except.bind, pure, Except.pure]
   · rw [Array.size_extract]
     exact Nat.le_trans (Nat.le_trans (Nat.sub_le _ _) (Nat.min_le_left _ _))
       (Nat.le_trans (by omega : hlit.toNat + 257 ≤ 288) (by decide : 288 ≤ UInt16.size))
@@ -1645,16 +1747,174 @@ theorem inflateLoopTreeFree_of_inflateLoop (data : ByteArray)
       exact absurd h (by simp)
 
 set_option maxRecDepth 4096 in
-/-- **Top-level forward correctness.** Whenever the verified `Inflate.inflate`
-    succeeds, the tree-free `Inflate.inflateTreeFree` produces the same bytes — so
+open InflateBuf in
+/-- **Tree-free block loop backward.** With the code-length validation gap closed
+    (`decodeDynamicLengthsOnly` now runs the same `validateLengths` check
+    `decodeDynamicTrees` does), whenever the tree-free `inflateLoopTreeFree`
+    succeeds, the verified `inflateLoop` (with the proof-only fixed trees) succeeds
+    with the *same* result. Dynamic blocks rebuild via `decodeDynamicTrees_of_lengthsOnly`;
+    the block correspondence `decodeHuffmanFastBufTreeFree_ok_iff` is already an `iff`.
+    Together with `inflateLoopTreeFree_of_inflateLoop` this gives accept-set equality. -/
+theorem inflateLoop_of_inflateLoopTreeFree (data : ByteArray)
+    (hflv : Huffman.Spec.ValidLengths (fixedLitLengths.toList.map UInt8.toNat) 15)
+    (hflb : fixedLitLengths.size ≤ UInt16.size)
+    (hfdv : Huffman.Spec.ValidLengths (fixedDistLengths.toList.map UInt8.toNat) 15)
+    (hfdb : fixedDistLengths.size ≤ UInt16.size) (maxOut : Nat) :
+    ∀ (br : BitReader) (output : ByteArray),
+      (br.bitOff = 0 ∨ br.pos < br.data.size) → br.pos ≤ br.data.size → br.data.size = data.size →
+      ∀ r, inflateLoopTreeFree br output maxOut data.size = .ok r →
+        inflateLoop br output (HuffTree.fromLengthsTree fixedLitLengths 15)
+          (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut data.size = .ok r := by
+  intro br output
+  induction br, output using inflateLoopTreeFree.induct (dataSize := data.size) with
+  | _ br output ih =>
+    intro hpos hple hds r h
+    rw [inflateLoopTreeFree] at h
+    obtain ⟨p1, hrb1, h⟩ := bindOk h; obtain ⟨bfinal, br₁⟩ := p1; simp only [] at h
+    obtain ⟨p2, hrb2, h⟩ := bindOk h; obtain ⟨btype, br₂⟩ := p2; simp only [] at h
+    have hbo₂ : br₂.bitOff < 8 := readBits_bitOff_lt_pos (by omega) hrb2
+    obtain ⟨_, hp₁, hl₁⟩ := ZipCommon.readBits_inv br br₁ 1 bfinal hrb1 hpos hple
+    obtain ⟨hd₂, hp₂, hl₂⟩ := ZipCommon.readBits_inv br₁ br₂ 2 btype hrb2 hp₁ hl₁
+    have hdata₂ : br₂.data.size = data.size := by
+      rw [hd₂, ZipCommon.readBits_data_eq br br₁ 1 bfinal hrb1]; exact hds
+    have hwf₂ : br₂.bitPos ≤ br₂.data.size * 8 := by
+      simp only [ZipCommon.BitReader.bitPos]; rcases hp₂ with h' | h' <;> omega
+    have hldep := InflateBuf.fromLengths_depthLE (HuffTree.fromLengths_ok_of_valid fixedLitLengths 15 hflv)
+    have hddep := InflateBuf.fromLengths_depthLE (HuffTree.fromLengths_ok_of_valid fixedDistLengths 15 hfdv)
+    have tailbwd : ∀ (o' : ByteArray) (br'' : BitReader),
+        (br''.bitOff = 0 ∨ br''.pos < br''.data.size) → br''.pos ≤ br''.data.size →
+        br''.data.size = data.size →
+        (if bfinal == 1 then pure (o', br''.alignToByte.pos)
+         else if _h : br''.bitPos ≤ br.bitPos then throw "Inflate: no progress in inflate loop"
+              else if _h : data.size * 8 < br''.bitPos then throw "Inflate: bit position out of range"
+              else inflateLoopTreeFree br'' o' maxOut data.size) = .ok r →
+        (if bfinal == 1 then pure (o', br''.alignToByte.pos)
+         else if _h : br''.bitPos ≤ br.bitPos then throw "Inflate: no progress in inflate loop"
+              else if _h : data.size * 8 < br''.bitPos then throw "Inflate: bit position out of range"
+              else inflateLoop br'' o' (HuffTree.fromLengthsTree fixedLitLengths 15)
+                    (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut data.size) = .ok r := by
+      intro o' br'' hp'' hl'' hd'' ht
+      by_cases hbf : (bfinal == 1) = true
+      · rw [if_pos hbf] at ht ⊢; exact ht
+      · rw [if_neg hbf] at ht ⊢
+        by_cases hg1 : br''.bitPos ≤ br.bitPos
+        · rw [dif_pos hg1] at ht; exact absurd ht (by simp)
+        · rw [dif_neg hg1] at ht ⊢
+          by_cases hg2 : data.size * 8 < br''.bitPos
+          · rw [dif_pos hg2] at ht; exact absurd ht (by simp)
+          · rw [dif_neg hg2] at ht ⊢
+            exact ih o' br'' hg1 hg2 hp'' hl'' hd'' r ht
+    rw [inflateLoop]
+    simp only [hrb1, hrb2, bind, Except.bind]
+    have hbtv : btype = 0 ∨ btype = 1 ∨ btype = 2 ∨ btype = 3 := by
+      have hb4 : btype.toNat < 4 := readBits_lt (n := 2) (by omega) hrb2
+      rcases (show btype.toNat = 0 ∨ btype.toNat = 1 ∨ btype.toNat = 2 ∨ btype.toNat = 3 from by omega)
+        with h' | h' | h' | h'
+      · exact Or.inl (UInt32.toNat_inj.mp (by rw [h']; rfl))
+      · exact Or.inr (Or.inl (UInt32.toNat_inj.mp (by rw [h']; rfl)))
+      · exact Or.inr (Or.inr (Or.inl (UInt32.toNat_inj.mp (by rw [h']; rfl))))
+      · exact Or.inr (Or.inr (Or.inr (UInt32.toNat_inj.mp (by rw [h']; rfl))))
+    rcases hbtv with rfl | rfl | rfl | rfl
+    · -- stored block (identical)
+      obtain ⟨pb, hblock, htail⟩ := bindOk h; obtain ⟨output', br'⟩ := pb
+      obtain ⟨hd', hp', hl'⟩ := Zip.Native.decodeStored_inv br₂ br' output output' maxOut hblock
+      rw [hblock]; dsimp only [bind, Except.bind]
+      exact tailbwd output' br' hp' hl' (by rw [hd']; exact hdata₂) htail
+    · -- fixed Huffman block
+      obtain ⟨pb, hblock, htail⟩ := bindOk h; obtain ⟨output', br'⟩ := pb
+      have hbuf := (decodeHuffmanFastBufTreeFree_ok_iff br₂ output fixedLitLengths fixedDistLengths
+        hflv hflb hfdv hfdb maxOut hbo₂ hwf₂ (output', br')).mp hblock
+      have hfast : Inflate.decodeHuffmanFast br₂ output (HuffTree.fromLengthsTree fixedLitLengths 15)
+          (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut = .ok (output', br') := hbuf
+      have hhf' : Inflate.decodeHuffman br₂ output (HuffTree.fromLengthsTree fixedLitLengths 15)
+          (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut = .ok (output', br') := by
+        rw [← decodeHuffmanFast_eq br₂ output _ _ maxOut hldep hddep hbo₂ hwf₂]; exact hfast
+      obtain ⟨hd', hp', hl'⟩ := Zip.Native.decodeHuffman_inv _ _ br₂ br' output output' maxOut hhf' hp₂ hl₂
+      rw [hfast]; dsimp only [bind, Except.bind]
+      exact tailbwd output' br' hp' hl' (by rw [hd']; exact hdata₂) htail
+    · -- dynamic Huffman block
+      obtain ⟨pdt, hlonly, h⟩ := bindOk h; obtain ⟨ll, dl, br₃⟩ := pdt; simp only [] at h
+      obtain ⟨pb, hblock, htail⟩ := bindOk h; obtain ⟨output', br'⟩ := pb
+      obtain ⟨hdt, hllv, hdlv, hllb, hdlb⟩ := decodeDynamicTrees_of_lengthsOnly hlonly
+      obtain ⟨hd3, hp3, hl3⟩ := Zip.Native.decodeDynamicTrees_inv br₂ br₃ _ _ hdt hp₂ hl₂
+      have hbo3 := InflateBuf.decodeDynamicTrees_bitOff_pres hbo₂ hdt
+      have hwf3 : br₃.bitPos ≤ br₃.data.size * 8 := by
+        simp only [ZipCommon.BitReader.bitPos]; rcases hp3 with h' | h' <;> omega
+      have hbuf := (decodeHuffmanFastBufTreeFree_ok_iff br₃ output ll dl hllv hllb hdlv hdlb
+        maxOut hbo3 hwf3 (output', br')).mp hblock
+      have hfast : Inflate.decodeHuffmanFast br₃ output (HuffTree.fromLengthsTree ll 15)
+          (HuffTree.fromLengthsTree dl 15) maxOut = .ok (output', br') := hbuf
+      have hhf' : Inflate.decodeHuffman br₃ output (HuffTree.fromLengthsTree ll 15)
+          (HuffTree.fromLengthsTree dl 15) maxOut = .ok (output', br') := by
+        rw [← decodeHuffmanFast_eq br₃ output _ _ maxOut
+          (InflateBuf.fromLengths_depthLE (HuffTree.fromLengths_ok_of_valid ll 15 hllv))
+          (InflateBuf.fromLengths_depthLE (HuffTree.fromLengths_ok_of_valid dl 15 hdlv)) hbo3 hwf3]
+        exact hfast
+      obtain ⟨hd', hp', hl'⟩ := Zip.Native.decodeHuffman_inv _ _ br₃ br' output output' maxOut hhf' hp3 hl3
+      rw [hdt]; dsimp only [bind, Except.bind]
+      rw [hfast]; dsimp only [bind, Except.bind]
+      exact tailbwd output' br' hp' hl' (by rw [hd', hd3]; exact hdata₂) htail
+    · -- reserved block type 3
+      simp only [bind, Except.bind] at h
+      exact absurd h (by simp)
+
+/-- **Tree-free block loop ↔ verified block loop (accept set).** -/
+theorem inflateLoopTreeFree_ok_iff (data : ByteArray)
+    (hflv : Huffman.Spec.ValidLengths (fixedLitLengths.toList.map UInt8.toNat) 15)
+    (hflb : fixedLitLengths.size ≤ UInt16.size)
+    (hfdv : Huffman.Spec.ValidLengths (fixedDistLengths.toList.map UInt8.toNat) 15)
+    (hfdb : fixedDistLengths.size ≤ UInt16.size) (maxOut : Nat)
+    (br : BitReader) (output : ByteArray)
+    (hpos : br.bitOff = 0 ∨ br.pos < br.data.size) (hple : br.pos ≤ br.data.size)
+    (hds : br.data.size = data.size) (r : ByteArray × Nat) :
+    inflateLoopTreeFree br output maxOut data.size = .ok r ↔
+      inflateLoop br output (HuffTree.fromLengthsTree fixedLitLengths 15)
+        (HuffTree.fromLengthsTree fixedDistLengths 15) maxOut data.size = .ok r :=
+  ⟨inflateLoop_of_inflateLoopTreeFree data hflv hflb hfdv hfdb maxOut br output hpos hple hds r,
+   inflateLoopTreeFree_of_inflateLoop data hflv hflb hfdv hfdb maxOut br output hpos hple hds r⟩
+
+/-- The fixed lit/dist code lengths are valid (the `fromLengths` of the fixed
+    tables always succeeds), packaged for the bridge lemmas below. -/
+private theorem fixedLitLengths_valid' :
+    Huffman.Spec.ValidLengths (fixedLitLengths.toList.map UInt8.toNat) 15 := by
+  obtain ⟨fixedLit, hfl⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
+  exact Deflate.Correctness.fromLengths_valid fixedLitLengths 15 fixedLit hfl
+
+private theorem fixedDistLengths_valid' :
+    Huffman.Spec.ValidLengths (fixedDistLengths.toList.map UInt8.toNat) 15 := by
+  obtain ⟨fixedDist, hfd⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
+  exact Deflate.Correctness.fromLengths_valid fixedDistLengths 15 fixedDist hfd
+
+/-- The verified reference `inflateRawReference` is the fixed-tree-built block loop
+    (the `fromLengths` of the fixed code lengths always succeeds, yielding the
+    canonical trees). The concrete `fromLengthsTree` term stays opaque. -/
+theorem inflateRawReference_eq_loop (data : ByteArray) (sp mo sh : Nat) :
+    Inflate.inflateRawReference data sp mo sh
+      = Inflate.inflateLoop { data, pos := sp, bitOff := 0 } (ByteArray.emptyWithCapacity sh)
+          (HuffTree.fromLengthsTree fixedLitLengths 15) (HuffTree.fromLengthsTree fixedDistLengths 15)
+          mo data.size := by
+  rw [Inflate.inflateRawReference,
+      HuffTree.fromLengths_ok_of_valid fixedLitLengths 15 fixedLitLengths_valid',
+      HuffTree.fromLengths_ok_of_valid fixedDistLengths 15 fixedDistLengths_valid']
+  rfl
+
+/-- The production `inflateRaw` is the tree-free block loop. -/
+theorem inflateRaw_eq_loop (data : ByteArray) (sp mo sh : Nat) :
+    Inflate.inflateRaw data sp mo sh
+      = Inflate.inflateLoopTreeFree { data, pos := sp, bitOff := 0 }
+          (ByteArray.emptyWithCapacity sh) mo data.size := rfl
+
+set_option maxRecDepth 4096 in
+/-- **Top-level forward correctness.** Whenever the verified `Inflate.inflateReference`
+    succeeds, the tree-free `Inflate.inflate` produces the same bytes — so
     the tree-free decoder (which never builds a Huffman tree at runtime) is a
     correct drop-in for the trusted decoder on every successful decode. The fixed
     Huffman trees exist only in the proof; `fromLengths fixedLitLengths` succeeding
     inside `inflateRaw` supplies their validity. -/
-theorem inflateTreeFree_of_inflate (data : ByteArray) (maxOut sizeHint : Nat) {out : ByteArray}
-    (h : Inflate.inflate data maxOut sizeHint = .ok out) :
-    Inflate.inflateTreeFree data maxOut = .ok out := by
-  rw [Inflate.inflate, Inflate.inflateRaw] at h
+theorem inflate_of_inflateReference (data : ByteArray) (maxOut sizeHint : Nat) {out : ByteArray}
+    (h : Inflate.inflateReference data maxOut sizeHint = .ok out) :
+    Inflate.inflate data maxOut = .ok out := by
+  rw [Inflate.inflateReference, Inflate.inflateRawReference] at h
   simp only [bind, Except.bind] at h
   obtain ⟨pr, hraw, hret⟩ := bindOk h; obtain ⟨output, restPos⟩ := pr
   simp only [pure, Except.pure, Except.ok.injEq] at hret; subst hret
@@ -1671,7 +1931,61 @@ theorem inflateTreeFree_of_inflate (data : ByteArray) (maxOut sizeHint : Nat) {o
   have hbody := inflateLoopTreeFree_of_inflateLoop data hflv (by decide) hfdv (by decide) maxOut
     { data, pos := 0, bitOff := 0 } ByteArray.empty (Or.inl rfl) (Nat.zero_le _) rfl
     (output, restPos) (by rw [hfleq, hfdeq] at hloop; exact hloop)
-  rw [Inflate.inflateTreeFree]
-  simp only [hbody, bind, Except.bind, pure, Except.pure]
+  -- fold the tree-free loop result back through the production `inflateRaw`
+  have hrawp : Inflate.inflateRaw data 0 maxOut 0 = .ok (output, restPos) := by
+    rw [inflateRaw_eq_loop,
+        show ByteArray.emptyWithCapacity 0 = ByteArray.empty from by
+          simp [ByteArray.emptyWithCapacity, ByteArray.empty]]
+    exact hbody
+  rw [Inflate.inflate]
+  simp only [hrawp, bind, Except.bind, pure, Except.pure]
+
+set_option maxRecDepth 4096 in
+/-- **Top-level backward correctness.** Whenever the tree-free decoder succeeds,
+    the verified `Inflate.inflateReference` succeeds with the same bytes. With the validation
+    gap closed this is the converse of `inflate_of_inflateReference`, so the two
+    decoders accept exactly the same inputs (`native ⊆ FFI` is preserved). -/
+theorem inflateReference_of_inflate (data : ByteArray) (maxOut : Nat) {out : ByteArray}
+    (h : Inflate.inflate data maxOut = .ok out) :
+    Inflate.inflateReference data maxOut = .ok out := by
+  rw [Inflate.inflate] at h
+  simp only [bind, Except.bind] at h
+  obtain ⟨pr, hloop, hret⟩ := bindOk h; obtain ⟨output, restPos⟩ := pr
+  simp only [pure, Except.pure, Except.ok.injEq] at hret; subst hret
+  have hbody := inflateLoop_of_inflateLoopTreeFree data fixedLitLengths_valid' (by decide)
+    fixedDistLengths_valid' (by decide) maxOut
+    { data, pos := 0, bitOff := 0 } ByteArray.empty (Or.inl rfl) (Nat.zero_le _) rfl
+    (output, restPos) hloop
+  -- fold the verified-decoder result back through `inflateRaw` without evaluating
+  -- the concrete fixed `fromLengthsTree` (kept opaque via `exact hbody`)
+  have hraw : Inflate.inflateRawReference data 0 maxOut 0 = .ok (output, restPos) := by
+    rw [inflateRawReference_eq_loop,
+        show ByteArray.emptyWithCapacity 0 = ByteArray.empty from by
+          simp [ByteArray.emptyWithCapacity, ByteArray.empty]]
+    exact hbody
+  rw [Inflate.inflateReference]
+  simp only [hraw, bind, Except.bind, pure, Except.pure]
+
+/-- **Top-level accept-set equality.** The production `inflate` and the verified
+    reference `inflateReference` succeed on exactly the same inputs with the same
+    output. This is the bridge every downstream theorem rides on: any property of
+    the reference's success set transfers to the production tree-free decoder, and
+    `native ⊆ FFI` is preserved. -/
+theorem inflate_ok_iff_reference (data : ByteArray) (maxOut : Nat) (out : ByteArray) :
+    Inflate.inflate data maxOut = .ok out ↔ Inflate.inflateReference data maxOut = .ok out :=
+  ⟨inflateReference_of_inflate data maxOut,
+   fun h => inflate_of_inflateReference data maxOut 0 h⟩
+
+set_option maxRecDepth 4096 in
+/-- **`inflateRaw` accept-set equality.** For an in-bounds start position the
+    production `inflateRaw` and the verified reference `inflateRawReference` succeed
+    on exactly the same inputs with the same output and end position. -/
+theorem inflateRaw_ok_iff_reference (data : ByteArray) (sp mo sh : Nat)
+    (hle : sp ≤ data.size) (p : ByteArray × Nat) :
+    Inflate.inflateRaw data sp mo sh = .ok p ↔ Inflate.inflateRawReference data sp mo sh = .ok p := by
+  rw [inflateRaw_eq_loop, inflateRawReference_eq_loop]
+  exact inflateLoopTreeFree_ok_iff data fixedLitLengths_valid' (by decide)
+    fixedDistLengths_valid' (by decide) mo
+    { data, pos := sp, bitOff := 0 } (ByteArray.emptyWithCapacity sh) (Or.inl rfl) hle rfl p
 
 end Zip.Native.Inflate

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -33,7 +33,7 @@ def decompressSingle (data : ByteArray)
   unless cmf &&& 0x0F == 8 do throw "Zlib: unsupported compression method"
   unless cmf >>> 4 ≤ 7 do throw "Zlib: invalid window size"
   unless flg &&& 0x20 == 0 do throw "Zlib: preset dictionaries not supported"
-  let (decompressed, endPos) ← Inflate.inflateRaw data 2 maxOutputSize
+  let (decompressed, endPos) ← Inflate.inflateRawReference data 2 maxOutputSize
   if endPos + 4 > data.size then throw "Zlib: truncated trailer"
   let b0 := data[endPos]!.toUInt32
   let b1 := data[endPos + 1]!.toUInt32
@@ -148,7 +148,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     ZlibDecode.decompressSingle (ZlibEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
+  have hinfl : Inflate.inflateReference (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
@@ -163,7 +163,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
     rw [ZlibEncode.compress_size]; omega
   -- Native inflate at offset 2 consumes exactly the DEFLATE stream (framing lemma)
   obtain ⟨header, trailer, hhsz, _, hceq⟩ := ZlibEncode.compress_eq data level
-  have hinflRaw : Inflate.inflateRaw (ZlibEncode.compress data level) 2 maxOutputSize =
+  have hinflRaw : Inflate.inflateRawReference (ZlibEncode.compress data level) 2 maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, 2 + (Deflate.deflateRaw data level).size) := by
     rw [hceq]
     exact inflateRaw_framing data level maxOutputSize header trailer 2 hhsz hdata_le hspec_go

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -179,6 +179,7 @@ def nativeCompress (data : ByteArray) (level : Nat) : IO ByteArray :=
   pure (Zip.Native.Deflate.deflateRaw data level.toUInt8)
 
 def nativeDecompress (data : ByteArray) (origSize : Nat) : IO ByteArray :=
+  -- `Inflate.inflate` is the shipped production decode path (tree-free).
   match Zip.Native.Inflate.inflate data (sizeHint := origSize) with
   | .ok b => pure b
   | .error e => throw (IO.userError e)
@@ -326,7 +327,8 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
   IO.eprintln s!"Wrote {rows.length} zopfli rows → {outPath}"
 
 /-- Decode `ref`, optionally pre-sizing the output to `hint` (`0` = no hint).
-    `@[noinline]` keeps the pure `inflate` call from being hoisted out of the
+    `Inflate.inflate` is the shipped production decode path (tree-free).
+    `@[noinline]` keeps the pure decode call from being hoisted out of the
     timed loop (it is otherwise loop-invariant), so each timed call really decodes. -/
 @[noinline] def decodeForAB (ref : ByteArray) (hint : Nat) : IO Nat := do
   match Zip.Native.Inflate.inflate ref (sizeHint := hint) with

--- a/ZipTreeFreeDecodeBench.lean
+++ b/ZipTreeFreeDecodeBench.lean
@@ -5,8 +5,8 @@ import Zip
 # End-to-end tree-free decode: conformance + benchmark
 
 Compresses each corpus file with the zlib FFI (a format-correct raw-deflate
-stream), then decodes it two ways — the verified `Inflate.inflate` (tree + table)
-and the prototype `Inflate.inflateTreeFree` (no Huffman tree) — asserts the two
+stream), then decodes it two ways — the verified reference `Inflate.inflateReference`
+(tree + table) and the production `Inflate.inflate` (tree-free) — asserts the two
 outputs are byte-identical to the original (conformance), and times both with a
 paired interleaved measurement (per-file geomean of after/before ratios), so
 common-mode machine noise cancels.
@@ -41,11 +41,11 @@ def timeDecode (decode : ByteArray → IO ByteArray) (input : ByteArray) : IO (N
   return (t1 - t0, out.size)
 
 def baselineDecode (input : ByteArray) (origSize : Nat) : IO ByteArray :=
-  match Inflate.inflate input (sizeHint := origSize) with
+  match Inflate.inflateReference input (sizeHint := origSize) with
   | .ok b => pure b | .error e => throw (IO.userError s!"baseline: {e}")
 
 def treeFreeDecode (input : ByteArray) : IO ByteArray :=
-  match Inflate.inflateTreeFree input with
+  match Inflate.inflate input with
   | .ok b => pure b | .error e => throw (IO.userError s!"treefree: {e}")
 
 /-- Geometric mean of a list of ratios (×1000 fixed-point for printing). -/

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe16209b2d1)">
+   <g clip-path="url(#paa307c7229)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YT4pl5R3H4brVtxtpiiYK/mtCkEBCBpmHkDVk4kJcgbtwBYLgyKmIGWaWJcREQsBWTNmdbsrqsvr2Pc4yFz4vv3h5nhV8Dwfe8znv7vj04+2Mn5ebq+kF69w8m16wxPbidnrCMrsHb0xPWOPuK9ML1jk/n16wxoub6QXr7E7znW1PHk1PWOY03xgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2//r7HJ6wxIvjjfTE5Z5+xe/np6wzMX21vSEJXbfP56esMxfn/99esISv7z3xvSEZQ7H2+kJS1y9PN1z//Z4mJ6wxB8e/Gp6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2e/bDJ9v0iBWeH66mJyzz+vH+9IR1DrfTC9a4upxesM6bv51esMTVdj09YZlTPR9f3y6mJyzz6Ozx9IQlHl7+d3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/eHI5vWGJi/296Qnr3HwzvWCZ7erp9IQ1jsfpBcvs7n87PWGJUz5DLvYPpiesce+V6QXLPHx+Oz1hie366+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7bfLb6Y38FMdj9ML4H+2r76cnrDGuf/Pnx1nI/9HnCAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ27/3n39Pb1jiyc3L6QnL/O3Rs+kJy3z67p+mJyzx1v13pics8/sPP5qesMSff/Pa9IRl/vnkZnoCP9Fnn/9jesIS1x+8Pz1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENsdjn/Zpkes8PJ4mJ6wzPnudLv4zs319IQ17uynF6zz/ePpBUscX304PWGZbTtOT1jizgnfGbzYTvObdvdwms91duYGCwAgJ7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL78216wiLn++kFy5x/++X0hGW2Z99NT1jjcJhesMz2uz9OT1ji/IT/P4+76QWL/HA9vWCZu7en+WzbV19MT1jmdE8QAIAhAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYjq2KMAzI9Ph4AAAAASUVORK5CYII=" id="imaged071bd05d6" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz6rcdx3H4TMnk1DCIdhC/xhEpKC4cF9Kr6EbL8Qr6F30CgqCK7ciunTnJWgtIjQt7WnShNNkejKZnzv3hdeXjx2e5wrew8BnXvPdnZ7+Ybvgx+VwM71gncOz6QVLbC9vpycss3vw1vSENe6+Nr1gncvL6QVrvDxML1hnd57f2fbk0fSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+39fXE9vWOLl6TA9YZmf/uTd6QnLXG3vTE9YYvfd4+kJy/ztxT+mJyzxs3tvTU9Y5ni6nZ6wxM2r8737t6fj9IQl3nvw8+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNju2fd/3KZHrPDieDM9YZk3T/enJ6xzvJ1esMbN9fSCdd7+1fSCJW6259MTljnX+/jmdjU9YZlHF4+nJyzx8Prb6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7qyfX0hiWu9vemJ6xz+HJ6wTLbzdPpCWucTtMLltnd/2p6whLnfEOu9g+mJ6xx77XpBcs8fHE7PWGJ7fkX0xOW8YIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbb9dfTm/ghzqdphfA/2yffzY9YY1L/z9/dNxG/o+4IAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb/+7r/0xvWOLJ4dX0hGX+/ujZ9IRl/vTbD6YnLPHO/V9MT1jmN5/8fnrCEh/+8o3pCcv868lhegI/0J//8un0hCWef/zR9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbHc8/XWbHrHCq9NxesIyl7vz7eI7h+fTE9a4s59esM53j6cXLHF6/eH0hGW27TQ9YYk7Z/xm8HI7z9+0u8fz/FwXF16wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/PNfGutxPL1jm8qvPpicssz37ZnrCGsfj9IJltl+/Pz1hibO9jRcXF6fd9IJFbg/TC5a5+/3N9IQlts//OT1hmfO9IAAAQwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDsv2cHiwZH5S3pAAAAAElFTkSuQmCC" id="imagee68bed97e5" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m79cfb91616" d="M 0 0 
+       <path id="mf956c79e97" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m79cfb91616" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m79cfb91616" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m79cfb91616" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m79cfb91616" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m79cfb91616" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m79cfb91616" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m79cfb91616" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m79cfb91616" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m79cfb91616" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m79cfb91616" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m79cfb91616" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf956c79e97" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m30e8105fa0" d="M 0 0 
+       <path id="m8492e361eb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8492e361eb" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,48 +1303,14 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +4 -->
+    <!-- +5 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1362,28 +1328,9 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1478,6 +1425,27 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
@@ -1486,15 +1454,49 @@ z
    <g id="text_25">
     <!-- +3 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -2 -->
+    <!-- -1 -->
     <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1505,11 +1507,11 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -19 -->
+    <!-- -18 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -2178,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image5105204d9b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagebcc872d18c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m5c84dbce03" d="M 0 0 
+       <path id="m58214364c6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58214364c6" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(20.601719 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,16 +3010,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe16209b2d1">
+  <clipPath id="paa307c7229">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m017ae46f6a" d="M 0 0 
+       <path id="mb952035da3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m017ae46f6a" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m017ae46f6a" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m017ae46f6a" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m017ae46f6a" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m017ae46f6a" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m017ae46f6a" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m017ae46f6a" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb952035da3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="me7c02f062d" d="M 0 0 
+       <path id="m4f1d12cecb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f1d12cecb" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f1d12cecb" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f1d12cecb" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m8b8a645fd4" d="M 0 0 
+       <path id="m689cf2f740" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m689cf2f740" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 177.010476) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 176.929412) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.711397) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.484087) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma438fab564" d="M -2.5 2.5 
+     <path id="m7ade56cd58" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#ma438fab564" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m7ade56cd58" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ade56cd58" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1189e8c40f" d="M 0 -2.5 
+     <path id="m201a72eebf" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m1189e8c40f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m201a72eebf" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m201a72eebf" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf60f1c6ca7" d="M -0 3.535534 
+     <path id="me3b7657ed0" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#mf60f1c6ca7" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#me3b7657ed0" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b7657ed0" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5d6f889b6c" d="M -0 2.5 
+     <path id="m0f19908ff5" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m5d6f889b6c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m0f19908ff5" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="meac0638faf" d="M -0.833333 2.5 
+     <path id="m3d7fcd1234" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#meac0638faf" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m3d7fcd1234" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d7fcd1234" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7380496e1d" d="M -1.25 2.5 
+     <path id="md730be5a54" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m7380496e1d" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#md730be5a54" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md730be5a54" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6286642f26" d="M 0 -2.5 
+     <path id="m143f54e1de" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m143f54e1de" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m143f54e1de" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbf5e0f79bd" d="M 0 -2.5 
+     <path id="m16c8470b4b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#mbf5e0f79bd" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m16c8470b4b" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16c8470b4b" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m486e54e1b3" d="M 0 3.5 
+      <path id="m58c03a45bf" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m486e54e1b3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m58c03a45bf" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma438fab564" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7ade56cd58" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1189e8c40f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m201a72eebf" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf60f1c6ca7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me3b7657ed0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5d6f889b6c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0f19908ff5" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#meac0638faf" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3d7fcd1234" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7380496e1d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md730be5a54" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6286642f26" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m143f54e1de" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbf5e0f79bd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m16c8470b4b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 182.010476 
-L 214.084819 184.35903 
-L 206.266533 187.050863 
-L 187.75787 193.186538 
-L 186.58897 193.984995 
-L 184.505355 196.319133 
-L 152.30308 249.650734 
-L 150.950891 251.698077 
-L 98.348822 336.711397 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m486e54e1b3" x="226.647908" y="182.010476" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="214.084819" y="184.35903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="206.266533" y="187.050863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="187.75787" y="193.186538" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="186.58897" y="193.984995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="184.505355" y="196.319133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="152.30308" y="249.650734" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="150.950891" y="251.698077" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="98.348822" y="336.711397" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 181.929412 
+L 214.084819 184.558703 
+L 206.266533 187.021542 
+L 187.75787 192.983532 
+L 186.58897 193.923636 
+L 184.505355 196.021813 
+L 152.30308 249.703116 
+L 150.950891 251.545376 
+L 98.348822 336.484087 
+" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pa671bb694f)">
+     <use xlink:href="#m58c03a45bf" x="226.647908" y="181.929412" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="214.084819" y="184.558703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="206.266533" y="187.021542" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="187.75787" y="192.983532" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="186.58897" y="193.923636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="184.505355" y="196.021813" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="152.30308" y="249.703116" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="150.950891" y="251.545376" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58c03a45bf" x="98.348822" y="336.484087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.601719 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2941,6 +2941,16 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3000,46 +3010,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3078,16 +3048,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3126,109 +3096,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1485ea9e7f">
+  <clipPath id="pa671bb694f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p2f36b9bb58)">
+   <g clip-path="url(#pd76c148a36)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image24da510372" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imaged74e7115d2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m47ec8d25a7" d="M 0 0 
+       <path id="m6b53413a1a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m47ec8d25a7" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b53413a1a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m09f057a626" d="M 0 0 
+       <path id="m181a40dec8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m181a40dec8" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8a35ff46db" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image185f8a1001" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m8b2eefb923" d="M 0 0 
+       <path id="m905d4e044e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m905d4e044e" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(20.601719 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2951,16 +2951,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2f36b9bb58">
+  <clipPath id="pd76c148a36">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.196563pt" height="386.202469pt" viewBox="0 0 567.196563 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 567.196563 386.202469 
+L 567.196563 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 185.723281 104.1264 
+L 290.348281 104.1264 
+L 290.348281 74.7432 
+L 185.723281 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 290.348281 104.1264 
+L 394.973281 104.1264 
+L 394.973281 74.7432 
+L 290.348281 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 394.973281 104.1264 
+L 499.598281 104.1264 
+L 499.598281 74.7432 
+L 394.973281 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 185.723281 133.5096 
+L 290.348281 133.5096 
+L 290.348281 104.1264 
+L 185.723281 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 290.348281 133.5096 
+L 394.973281 133.5096 
+L 394.973281 104.1264 
+L 290.348281 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 394.973281 133.5096 
+L 499.598281 133.5096 
+L 499.598281 104.1264 
+L 394.973281 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 185.723281 162.8928 
+L 290.348281 162.8928 
+L 290.348281 133.5096 
+L 185.723281 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 290.348281 162.8928 
+L 394.973281 162.8928 
+L 394.973281 133.5096 
+L 290.348281 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 394.973281 162.8928 
+L 499.598281 162.8928 
+L 499.598281 133.5096 
+L 394.973281 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 185.723281 192.276 
+L 290.348281 192.276 
+L 290.348281 162.8928 
+L 185.723281 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 290.348281 192.276 
+L 394.973281 192.276 
+L 394.973281 162.8928 
+L 290.348281 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 394.973281 192.276 
+L 499.598281 192.276 
+L 499.598281 162.8928 
+L 394.973281 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 185.723281 221.6592 
+L 290.348281 221.6592 
+L 290.348281 192.276 
+L 185.723281 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 290.348281 221.6592 
+L 394.973281 221.6592 
+L 394.973281 192.276 
+L 290.348281 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 394.973281 221.6592 
+L 499.598281 221.6592 
+L 499.598281 192.276 
+L 394.973281 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 185.723281 251.0424 
+L 290.348281 251.0424 
+L 290.348281 221.6592 
+L 185.723281 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 290.348281 251.0424 
+L 394.973281 251.0424 
+L 394.973281 221.6592 
+L 290.348281 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 394.973281 251.0424 
+L 499.598281 251.0424 
+L 499.598281 221.6592 
+L 394.973281 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f46d43; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 185.723281 280.4256 
+L 290.348281 280.4256 
+L 290.348281 251.0424 
+L 185.723281 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 290.348281 280.4256 
+L 394.973281 280.4256 
+L 394.973281 251.0424 
+L 290.348281 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 394.973281 280.4256 
+L 499.598281 280.4256 
+L 499.598281 251.0424 
+L 394.973281 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 185.723281 309.8088 
+L 290.348281 309.8088 
+L 290.348281 280.4256 
+L 185.723281 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 290.348281 309.8088 
+L 394.973281 309.8088 
+L 394.973281 280.4256 
+L 290.348281 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 394.973281 309.8088 
+L 499.598281 309.8088 
+L 499.598281 280.4256 
+L 394.973281 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 185.723281 339.192 
+L 290.348281 339.192 
+L 290.348281 309.8088 
+L 185.723281 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 290.348281 339.192 
+L 394.973281 339.192 
+L 394.973281 309.8088 
+L 290.348281 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 394.973281 339.192 
+L 499.598281 339.192 
+L 499.598281 309.8088 
+L 394.973281 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pdc820f49d7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(118.710547 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(225.994766 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(304.566875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(402.918594 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(114.648281 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.025781 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.286406 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.462266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(126.549531 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(109.855781 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.012031 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.357656 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.296641 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(225.383906 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 24 -->
-    <g transform="translate(338.007266 238.5583) scale(0.08 -0.08)">
+    <!-- 25 -->
+    <g transform="translate(337.094531 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,14 +1724,39 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 137 -->
-    <g transform="translate(439.849141 238.5583) scale(0.08 -0.08)">
+    <!-- 150 -->
+    <g transform="translate(438.936406 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1747,25 +1772,15 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(94.472656 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1894,7 +1909,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.497266 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1904,14 +1919,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.483516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.563516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1919,7 +1934,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.979531 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1975,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1985,21 +2000,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.195781 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(122.693906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2010,7 +2025,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2020,13 +2035,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.115781 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.285781 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2042,7 +2057,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.019766 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.107031 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2255,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2394,16 +2409,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2442,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p71790097ce">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pdc820f49d7">
+   <rect x="81.098281" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p32e61e563f)">
+   <g clip-path="url(#pf4c8c6eb13)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3Yv46ldR3H8T0zh1nYhbjKugRNNjZohQmRisY7oOAyKGntKa1t7b0BKo2ViTHaYQdBClgicWXZ7MyZOeMVWG1+7+/sk9frCj4nz5/f+zm7479/f31ryw7PphfwPI6X0wvW2p1ML1jr8mJ6wVp37k0vWOv8yfSCtU7PphfwPLZ+f57dmV6w1MZPPwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav+3w+fTG5ban5xOT1jqeH09PWGpB689mJ6w1Of//df0hLU2/on785fvTU9Y6nD7bHrCUn9/9On0hKV+ef+t6QlLnZ8dpycstds9nZ6w1MaPBwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaP3ztZ9Mblrp3+8H0hKW+efbl9ISlfvJ0299Ir77+9vSEpU53++kJSx1vHacnLPXjW/enJyx1ef9iesJSb9x5OD1hqcNx29fv7sW23y/bPt0BALhxBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9brftBv3u8O30hKVeOX11esJSV6//aHrCUl89/sf0hKWeXDybnrDUr3747vSEpS5Opxes9f3hu+kJPIf/nD+anrDW7QfTC5badn0CAHDjCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7qz9/dD09YqnjcXoB/H8nvgFfaN4vL7atP39bvz9dvxfaxq8eAAA3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f+Ov/5zesNTJftuN/ejTb6YnLPW7D9+ZnrDUx3/5enrCUr9++IPpCUv94U+fTU9Y6jcf/GJ6wlK//eMX0xOWev+dN6cnLPXF4/PpCUu999O70xOW2nadAQBw4whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTucPXJ9fSIlU4vL6cnrHWyn16w1uWz6QVrnd2ZXrDWbuPfuNfH6QVrHTx/L7SrbZ9/h922n7+XNt4vGz8dAAC4aQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fH6OL1hqdP92fSEpY676QVrnTz+dnrCUldnL09PWOr0cDE9gedx8XR6wVLfn1xOT1jq7tW2/2N6abft33fr/Mn0gqU2fvUAALhpBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AYWSfZp0uJWIAAAAAElFTkSuQmCC" id="image913226b9bf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ50lEQVR4nO3Yu46VVQCG4dkzmwE5RBSEqAmxUStNiFY23oGFl2Fpa29pbWvvDVhprEyM0Q47CVooRCJyCDN7Zo9XYEXWu4Y/z3MF385/WO+/V9u/vzrZWbLN09kLeBbbo9kLxlrtzl4w1tHh7AVjnb88e8FYB49mLxhrb3/2Ap7F0u/P/fOzFwy18NMPAIDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBa/7S5PXvDUOvdvdkThtqenMyeMNS1S9dmTxjq9r+/z54w1sI/cd86d3n2hKE2Z/dnTxjq57u3Zk8Y6t2rb86eMNTB/nb2hKFWqyezJwy18OMBAIDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNY3Lr0xe8NQl89emz1hqHtP/5g9YajXniz7G+nilXdmTxhqb7WePWGo7c529oShXtm5OnvCUEdXD2dPGOr6+RuzJwy12S77+l04XPb7ZdmnOwAAp44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtV6tlt2gDzf3Z08Y6oW9i7MnDHV85eXZE4b688EvsycM9ejw6ewJQ7330vuzJwx1uDd7wViPNw9nT+AZ/HNwd/aEsc5em71gqGXXJwAAp44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtTr+/tOT2SOG2m5nL4D/t+sb8Lnm/fJ8W/rzt/T70/V7ri386gEAcNoIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUuvrP/46e8NQu+tlN/bdW/dmTxjqy09uzp4w1Oc//DV7wlAf3nhx9oShvv7ut9kThvrs47dnTxjqi2/vzJ4w1Ec3X509Yag7Dw5mTxjqg9cvzJ4w1LLrDACAU0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKRWm+NvTmaPGGnv6Gj2hLF217MXjHX0dPaCsfbPz14w1mrh37gn29kLxtp4/p5rx8s+/zarZT9/ZxbeLws/HQAAOG0EKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqfX2ZDt7w1B7Z87NnsCzeHB/9oKhjveXfX/uHR3NnjDWwt+fO4dPZi8Y6vHusu/PC8fL/o/pzGrZv2/n4NHsBUMt/OoBAHDaCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/AcaPfpyr8V7bAAAAAElFTkSuQmCC" id="imagecfbbd1ec65" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mec6c2f9281" d="M 0 0 
+       <path id="mfe89294e75" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mec6c2f9281" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mec6c2f9281" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mec6c2f9281" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mec6c2f9281" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mec6c2f9281" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mec6c2f9281" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mec6c2f9281" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mec6c2f9281" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mec6c2f9281" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mec6c2f9281" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mec6c2f9281" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mec6c2f9281" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfe89294e75" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc0e916c336" d="M 0 0 
+       <path id="mae5849834e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae5849834e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,53 +1156,100 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
 z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +1 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -37 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1236,22 +1283,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +3 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -37 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1308,23 +1339,16 @@ z
     </g>
    </g>
    <g id="text_26">
+    <!-- -9 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
     <!-- -10 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
 Q 1056 3291 1056 2328 
@@ -1352,59 +1376,9 @@ z
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_28">
-    <!-- -26 -->
+    <!-- -25 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +17 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -15 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1433,13 +1407,62 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
+   <g id="text_29">
+    <!-- +18 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- -14 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1466,12 +1489,20 @@ z
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_31">
+    <!-- -12 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_32">
-    <!-- -27 -->
+    <!-- -26 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1550,38 +1581,6 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -2193,18 +2192,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image72534f1d25" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image87e4afff01" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma2a229a83e" d="M 0 0 
+       <path id="mbe0b488c0f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2226,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2240,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2254,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2267,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2280,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2293,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbe0b488c0f" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2909,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.601719 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,16 +2999,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p32e61e563f">
+  <clipPath id="pf4c8c6eb13">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf932cfc11c" d="M 0 0 
+       <path id="m84f3ae95db" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf932cfc11c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf932cfc11c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf932cfc11c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf932cfc11c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf932cfc11c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf932cfc11c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf932cfc11c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84f3ae95db" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mee54c87ccf" d="M 0 0 
+       <path id="mf253587df3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf253587df3" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf253587df3" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf253587df3" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mddeb160c53" d="M 0 0 
+       <path id="mf73763f27e" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf73763f27e" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 150.637342) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 150.000152) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 352.56427) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.288525) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m50c0fa6663" d="M -2.5 2.5 
+     <path id="m0ea55cb809" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m50c0fa6663" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m0ea55cb809" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0ea55cb809" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9242dac054" d="M 0 -2.5 
+     <path id="m1a61b817df" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m9242dac054" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m1a61b817df" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a61b817df" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2af8fc868a" d="M -0 3.535534 
+     <path id="m7e7e4e11ca" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m2af8fc868a" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m7e7e4e11ca" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7e4e11ca" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7e6694d5b1" d="M -0 2.5 
+     <path id="ma332f02c1d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m7e6694d5b1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#ma332f02c1d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mcbe58fd8a6" d="M -0.833333 2.5 
+     <path id="m6f75adcb96" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#mcbe58fd8a6" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m6f75adcb96" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6f75adcb96" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5b66e67a84" d="M -1.25 2.5 
+     <path id="m3aa3193e25" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m5b66e67a84" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m3aa3193e25" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aa3193e25" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="macb9df86c3" d="M 0 -2.5 
+     <path id="mc4a4797e20" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4a4797e20" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdac33ce478" d="M 0 -2.5 
+     <path id="mbf96da430d" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#mdac33ce478" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#mbf96da430d" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf96da430d" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m1859526068" d="M 0 3.5 
+      <path id="m1d9c428c10" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1859526068" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1d9c428c10" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m50c0fa6663" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0ea55cb809" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9242dac054" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1a61b817df" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2af8fc868a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7e7e4e11ca" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7e6694d5b1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma332f02c1d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcbe58fd8a6" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6f75adcb96" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5b66e67a84" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3aa3193e25" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#macb9df86c3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc4a4797e20" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdac33ce478" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbf96da430d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 155.637342 
-L 236.23654 159.215188 
-L 222.073314 163.095774 
-L 202.315941 172.716799 
-L 199.905291 174.333319 
-L 195.893147 178.106216 
-L 157.982343 243.551047 
-L 157.246106 245.651483 
-L 95.319203 357.56427 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m1859526068" x="257.531237" y="155.637342" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="236.23654" y="159.215188" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="222.073314" y="163.095774" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="202.315941" y="172.716799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="199.905291" y="174.333319" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="195.893147" y="178.106216" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="157.982343" y="243.551047" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="157.246106" y="245.651483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="95.319203" y="357.56427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 155.000152 
+L 236.23654 158.851774 
+L 222.073314 162.685682 
+L 202.315941 172.243788 
+L 199.905291 173.879715 
+L 195.893147 177.697078 
+L 157.982343 243.559043 
+L 157.246106 245.645559 
+L 95.319203 357.288525 
+" clip-path="url(#p28786db23d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p28786db23d)">
+     <use xlink:href="#m1d9c428c10" x="257.531237" y="155.000152" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="236.23654" y="158.851774" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="222.073314" y="162.685682" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="202.315941" y="172.243788" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="199.905291" y="173.879715" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="195.893147" y="177.697078" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="157.982343" y="243.559043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="157.246106" y="245.645559" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1d9c428c10" x="95.319203" y="357.288525" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.601719 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2853,6 +2853,16 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2912,46 +2922,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2990,16 +2960,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3038,109 +3008,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p82ad7000b3">
+  <clipPath id="p28786db23d">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pdf9118cc88)">
+   <g clip-path="url(#p4fa9c48c34)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image193907e3da" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image6869720b13" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m437818802e" d="M 0 0 
+       <path id="ma4ef9b7f6a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m437818802e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m437818802e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m437818802e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m437818802e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m437818802e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m437818802e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m437818802e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m437818802e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m437818802e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m437818802e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m437818802e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m437818802e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4ef9b7f6a" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m00a7a1f506" d="M 0 0 
+       <path id="me67669bc4c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me67669bc4c" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagece0c6a463b" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageeb9d9fa5a4" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m634ef6ffb6" d="M 0 0 
+       <path id="mfb5caf164b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb5caf164b" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb5caf164b" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb5caf164b" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb5caf164b" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb5caf164b" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.601719 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,16 +2870,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdf9118cc88">
+  <clipPath id="p4fa9c48c34">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.196563pt" height="386.202469pt" viewBox="0 0 567.196563 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 567.196563 386.202469 
+L 567.196563 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 185.723281 104.1264 
+L 290.348281 104.1264 
+L 290.348281 74.7432 
+L 185.723281 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 290.348281 104.1264 
+L 394.973281 104.1264 
+L 394.973281 74.7432 
+L 290.348281 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 394.973281 104.1264 
+L 499.598281 104.1264 
+L 499.598281 74.7432 
+L 394.973281 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 185.723281 133.5096 
+L 290.348281 133.5096 
+L 290.348281 104.1264 
+L 185.723281 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 290.348281 133.5096 
+L 394.973281 133.5096 
+L 394.973281 104.1264 
+L 290.348281 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 394.973281 133.5096 
+L 499.598281 133.5096 
+L 499.598281 104.1264 
+L 394.973281 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 185.723281 162.8928 
+L 290.348281 162.8928 
+L 290.348281 133.5096 
+L 185.723281 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 290.348281 162.8928 
+L 394.973281 162.8928 
+L 394.973281 133.5096 
+L 290.348281 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 394.973281 162.8928 
+L 499.598281 162.8928 
+L 499.598281 133.5096 
+L 394.973281 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 185.723281 192.276 
+L 290.348281 192.276 
+L 290.348281 162.8928 
+L 185.723281 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 290.348281 192.276 
+L 394.973281 192.276 
+L 394.973281 162.8928 
+L 290.348281 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 394.973281 192.276 
+L 499.598281 192.276 
+L 499.598281 162.8928 
+L 394.973281 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 185.723281 221.6592 
+L 290.348281 221.6592 
+L 290.348281 192.276 
+L 185.723281 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 290.348281 221.6592 
+L 394.973281 221.6592 
+L 394.973281 192.276 
+L 290.348281 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 394.973281 221.6592 
+L 499.598281 221.6592 
+L 499.598281 192.276 
+L 394.973281 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 185.723281 251.0424 
+L 290.348281 251.0424 
+L 290.348281 221.6592 
+L 185.723281 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 290.348281 251.0424 
+L 394.973281 251.0424 
+L 394.973281 221.6592 
+L 290.348281 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 394.973281 251.0424 
+L 499.598281 251.0424 
+L 499.598281 221.6592 
+L 394.973281 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 185.723281 280.4256 
+L 290.348281 280.4256 
+L 290.348281 251.0424 
+L 185.723281 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 290.348281 280.4256 
+L 394.973281 280.4256 
+L 394.973281 251.0424 
+L 290.348281 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 394.973281 280.4256 
+L 499.598281 280.4256 
+L 499.598281 251.0424 
+L 394.973281 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 185.723281 309.8088 
+L 290.348281 309.8088 
+L 290.348281 280.4256 
+L 185.723281 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 290.348281 309.8088 
+L 394.973281 309.8088 
+L 394.973281 280.4256 
+L 290.348281 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 394.973281 309.8088 
+L 499.598281 309.8088 
+L 499.598281 280.4256 
+L 394.973281 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 185.723281 339.192 
+L 290.348281 339.192 
+L 290.348281 309.8088 
+L 185.723281 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 290.348281 339.192 
+L 394.973281 339.192 
+L 394.973281 309.8088 
+L 290.348281 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 394.973281 339.192 
+L 499.598281 339.192 
+L 499.598281 309.8088 
+L 394.973281 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p68884c66fc)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(118.710547 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(225.994766 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(304.566875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(402.918594 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(114.648281 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.025781 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.286406 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(96.979531 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.012031 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.462266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(126.549531 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(109.855781 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(439.650781 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.357656 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(225.383906 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1853,15 +1853,36 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 33 -->
-    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
+    <!-- 34 -->
+    <g transform="translate(337.094531 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 168 -->
-    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
+    <!-- 182 -->
+    <g transform="translate(438.936406 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1875,36 +1896,6 @@ L 4013 831
 L 4013 0 
 L 750 0 
 L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
@@ -1948,13 +1939,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(94.472656 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2019,7 +2010,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2029,21 +2020,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(337.570781 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.195781 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(122.693906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2054,7 +2045,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(226.584531 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2064,13 +2055,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.115781 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.285781 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2086,7 +2077,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.112734 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.2 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2159,6 +2150,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2200,7 +2221,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2339,16 +2360,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2387,110 +2408,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1f9872afb5">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p68884c66fc">
+   <rect x="81.098281" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-20T12:25:48Z",
+  "date": "2026-06-23T00:54:17Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "a19271bf",
+  "git_commit": "df20821f",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 39.68,
-   "decompress_mbps": 126.92
+   "compress_mbps": 40.16,
+   "decompress_mbps": 133.39
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.47,
-   "decompress_mbps": 139.53
+   "compress_mbps": 36.27,
+   "decompress_mbps": 147.64
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.06,
-   "decompress_mbps": 155.07
+   "compress_mbps": 33.55,
+   "decompress_mbps": 163.66
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.6,
-   "decompress_mbps": 160.98
+   "compress_mbps": 27.65,
+   "decompress_mbps": 167.64
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.81,
-   "decompress_mbps": 165.43
+   "compress_mbps": 26.84,
+   "decompress_mbps": 172.99
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.71,
-   "decompress_mbps": 172.51
+   "compress_mbps": 25.02,
+   "decompress_mbps": 179.13
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.38,
-   "decompress_mbps": 171.27
+   "compress_mbps": 9.4,
+   "decompress_mbps": 178.63
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.1,
-   "decompress_mbps": 172.33
+   "compress_mbps": 9.25,
+   "decompress_mbps": 180.32
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 172.52
+   "compress_mbps": 1.29,
+   "decompress_mbps": 179.96
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.1,
-   "decompress_mbps": 122.99
+   "compress_mbps": 37.24,
+   "decompress_mbps": 128.71
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.3,
-   "decompress_mbps": 128.57
+   "compress_mbps": 34.57,
+   "decompress_mbps": 135.66
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.32,
-   "decompress_mbps": 136.82
+   "compress_mbps": 31.94,
+   "decompress_mbps": 145.95
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.49,
-   "decompress_mbps": 144.86
+   "compress_mbps": 25.72,
+   "decompress_mbps": 152.68
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.84,
-   "decompress_mbps": 153.18
+   "compress_mbps": 24.96,
+   "decompress_mbps": 159.2
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.69,
-   "decompress_mbps": 154.5
+   "compress_mbps": 23.87,
+   "decompress_mbps": 161.62
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.9,
-   "decompress_mbps": 155.69
+   "compress_mbps": 9.0,
+   "decompress_mbps": 162.09
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.89,
-   "decompress_mbps": 156.26
+   "compress_mbps": 8.99,
+   "decompress_mbps": 163.39
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.37,
-   "decompress_mbps": 155.37
+   "compress_mbps": 1.41,
+   "decompress_mbps": 162.1
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.7,
-   "decompress_mbps": 132.6
+   "compress_mbps": 33.68,
+   "decompress_mbps": 142.97
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.75,
-   "decompress_mbps": 139.43
+   "compress_mbps": 32.82,
+   "decompress_mbps": 147.62
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 141.97
+   "compress_mbps": 31.98,
+   "decompress_mbps": 150.44
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.24,
-   "decompress_mbps": 142.66
+   "compress_mbps": 30.28,
+   "decompress_mbps": 155.05
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.8,
-   "decompress_mbps": 148.83
+   "compress_mbps": 29.87,
+   "decompress_mbps": 158.93
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.94,
-   "decompress_mbps": 148.54
+   "compress_mbps": 29.07,
+   "decompress_mbps": 160.31
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.67,
-   "decompress_mbps": 150.21
+   "compress_mbps": 9.66,
+   "decompress_mbps": 162.62
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 150.65
+   "compress_mbps": 9.69,
+   "decompress_mbps": 160.7
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 150.71
+   "compress_mbps": 1.62,
+   "decompress_mbps": 159.43
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 103.02
+   "compress_mbps": 23.08,
+   "decompress_mbps": 110.7
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.1,
-   "decompress_mbps": 106.47
+   "compress_mbps": 22.5,
+   "decompress_mbps": 114.03
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.09,
-   "decompress_mbps": 108.64
+   "compress_mbps": 22.2,
+   "decompress_mbps": 116.73
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.22,
-   "decompress_mbps": 111.5
+   "compress_mbps": 21.5,
+   "decompress_mbps": 119.57
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.27,
-   "decompress_mbps": 112.95
+   "compress_mbps": 21.28,
+   "decompress_mbps": 122.32
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.19,
-   "decompress_mbps": 113.72
+   "compress_mbps": 21.07,
+   "decompress_mbps": 122.03
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.06,
-   "decompress_mbps": 113.99
+   "compress_mbps": 7.03,
+   "decompress_mbps": 123.09
   },
   {
    "compressor": "native",
@@ -355,7 +355,7 @@
    "out_size": 3128,
    "ratio": 0.2805,
    "compress_mbps": 7.03,
-   "decompress_mbps": 113.43
+   "decompress_mbps": 123.08
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.54,
-   "decompress_mbps": 113.45
+   "compress_mbps": 1.53,
+   "decompress_mbps": 123.24
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.3,
-   "decompress_mbps": 52.0
+   "compress_mbps": 11.66,
+   "decompress_mbps": 60.23
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.13,
-   "decompress_mbps": 52.14
+   "compress_mbps": 11.48,
+   "decompress_mbps": 61.47
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.02,
-   "decompress_mbps": 52.43
+   "compress_mbps": 11.46,
+   "decompress_mbps": 61.35
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.0,
-   "decompress_mbps": 53.06
+   "compress_mbps": 11.26,
+   "decompress_mbps": 62.04
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.04,
-   "decompress_mbps": 53.83
+   "compress_mbps": 11.33,
+   "decompress_mbps": 62.72
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 10.94,
-   "decompress_mbps": 53.73
+   "compress_mbps": 11.32,
+   "decompress_mbps": 62.7
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.77,
-   "decompress_mbps": 53.74
+   "compress_mbps": 3.79,
+   "decompress_mbps": 62.59
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.78,
-   "decompress_mbps": 53.56
+   "compress_mbps": 3.8,
+   "decompress_mbps": 62.66
   },
   {
    "compressor": "native",
@@ -455,7 +455,7 @@
    "out_size": 1190,
    "ratio": 0.3198,
    "compress_mbps": 1.23,
-   "decompress_mbps": 53.79
+   "decompress_mbps": 61.95
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 62.65,
-   "decompress_mbps": 197.93
+   "compress_mbps": 62.86,
+   "decompress_mbps": 221.11
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 59.78,
-   "decompress_mbps": 234.54
+   "compress_mbps": 59.81,
+   "decompress_mbps": 268.21
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 57.82,
-   "decompress_mbps": 253.1
+   "compress_mbps": 59.03,
+   "decompress_mbps": 282.63
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 55.52,
-   "decompress_mbps": 268.46
+   "compress_mbps": 55.44,
+   "decompress_mbps": 294.04
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.58,
-   "decompress_mbps": 189.62
+   "compress_mbps": 54.47,
+   "decompress_mbps": 224.5
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.64,
-   "decompress_mbps": 190.1
+   "compress_mbps": 51.62,
+   "decompress_mbps": 224.57
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.63,
-   "decompress_mbps": 168.16
+   "compress_mbps": 9.55,
+   "decompress_mbps": 207.6
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.59,
-   "decompress_mbps": 167.37
+   "compress_mbps": 7.65,
+   "decompress_mbps": 202.91
   },
   {
    "compressor": "native",
@@ -545,7 +545,7 @@
    "out_size": 178311,
    "ratio": 0.1732,
    "compress_mbps": 0.95,
-   "decompress_mbps": 165.3
+   "decompress_mbps": 202.51
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 43.13,
-   "decompress_mbps": 133.92
+   "compress_mbps": 43.42,
+   "decompress_mbps": 141.66
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 39.41,
-   "decompress_mbps": 142.51
+   "compress_mbps": 39.67,
+   "decompress_mbps": 151.1
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.51,
-   "decompress_mbps": 159.43
+   "compress_mbps": 36.1,
+   "decompress_mbps": 167.99
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 28.83,
-   "decompress_mbps": 165.58
+   "compress_mbps": 29.16,
+   "decompress_mbps": 172.85
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 173.65
+   "compress_mbps": 28.41,
+   "decompress_mbps": 180.23
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.07,
-   "decompress_mbps": 174.78
+   "compress_mbps": 26.32,
+   "decompress_mbps": 184.09
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 9.93,
-   "decompress_mbps": 175.25
+   "compress_mbps": 10.03,
+   "decompress_mbps": 184.72
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.9,
-   "decompress_mbps": 175.78
+   "compress_mbps": 9.94,
+   "decompress_mbps": 185.04
   },
   {
    "compressor": "native",
@@ -635,7 +635,7 @@
    "out_size": 138661,
    "ratio": 0.3249,
    "compress_mbps": 1.3,
-   "decompress_mbps": 175.77
+   "decompress_mbps": 185.0
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 37.66,
-   "decompress_mbps": 117.9
+   "compress_mbps": 36.88,
+   "decompress_mbps": 123.2
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 34.29,
-   "decompress_mbps": 128.42
+   "compress_mbps": 33.9,
+   "decompress_mbps": 133.96
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.08,
-   "decompress_mbps": 134.83
+   "compress_mbps": 31.2,
+   "decompress_mbps": 143.41
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.02,
-   "decompress_mbps": 141.65
+   "compress_mbps": 23.09,
+   "decompress_mbps": 148.82
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.28,
-   "decompress_mbps": 150.1
+   "compress_mbps": 22.26,
+   "decompress_mbps": 156.19
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 153.22
+   "compress_mbps": 20.69,
+   "decompress_mbps": 159.82
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.44,
-   "decompress_mbps": 153.78
+   "compress_mbps": 8.43,
+   "decompress_mbps": 159.87
   },
   {
    "compressor": "native",
@@ -715,7 +715,7 @@
    "out_size": 194380,
    "ratio": 0.4034,
    "compress_mbps": 8.41,
-   "decompress_mbps": 153.79
+   "decompress_mbps": 160.56
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 153.71
+   "compress_mbps": 1.26,
+   "decompress_mbps": 160.87
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 116.22,
-   "decompress_mbps": 368.05
+   "compress_mbps": 117.53,
+   "decompress_mbps": 383.91
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 103.34,
-   "decompress_mbps": 384.27
+   "compress_mbps": 103.95,
+   "decompress_mbps": 405.95
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 89.43,
-   "decompress_mbps": 403.92
+   "compress_mbps": 89.99,
+   "decompress_mbps": 428.5
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 71.92,
-   "decompress_mbps": 369.09
+   "compress_mbps": 72.9,
+   "decompress_mbps": 388.76
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 69.43,
-   "decompress_mbps": 393.57
+   "compress_mbps": 69.99,
+   "decompress_mbps": 415.12
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 62.69,
-   "decompress_mbps": 415.82
+   "compress_mbps": 63.55,
+   "decompress_mbps": 444.26
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 18.56,
-   "decompress_mbps": 437.7
+   "compress_mbps": 18.72,
+   "decompress_mbps": 464.07
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 465.78
+   "compress_mbps": 16.52,
+   "decompress_mbps": 496.05
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.95,
-   "decompress_mbps": 474.79
+   "compress_mbps": 0.96,
+   "decompress_mbps": 512.72
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.27,
-   "decompress_mbps": 95.25
+   "compress_mbps": 26.41,
+   "decompress_mbps": 107.26
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 99.26
+   "compress_mbps": 25.99,
+   "decompress_mbps": 111.68
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.22,
-   "decompress_mbps": 103.64
+   "compress_mbps": 25.06,
+   "decompress_mbps": 115.56
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.35,
-   "decompress_mbps": 100.8
+   "compress_mbps": 23.3,
+   "decompress_mbps": 114.02
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.89,
-   "decompress_mbps": 107.67
+   "compress_mbps": 22.92,
+   "decompress_mbps": 121.67
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.64,
-   "decompress_mbps": 108.85
+   "compress_mbps": 21.7,
+   "decompress_mbps": 122.81
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 5.81,
-   "decompress_mbps": 110.66
+   "compress_mbps": 5.75,
+   "decompress_mbps": 123.85
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.46,
-   "decompress_mbps": 114.32
+   "compress_mbps": 5.4,
+   "decompress_mbps": 126.94
   },
   {
    "compressor": "native",
@@ -905,7 +905,7 @@
    "out_size": 12278,
    "ratio": 0.3211,
    "compress_mbps": 1.2,
-   "decompress_mbps": 111.97
+   "decompress_mbps": 125.85
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.92,
-   "decompress_mbps": 55.42
+   "compress_mbps": 12.42,
+   "decompress_mbps": 64.0
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.82,
-   "decompress_mbps": 56.32
+   "compress_mbps": 12.37,
+   "decompress_mbps": 64.08
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.79,
-   "decompress_mbps": 56.07
+   "compress_mbps": 12.34,
+   "decompress_mbps": 64.03
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.55,
-   "decompress_mbps": 56.78
+   "compress_mbps": 12.23,
+   "decompress_mbps": 65.37
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.76,
-   "decompress_mbps": 57.62
+   "compress_mbps": 12.19,
+   "decompress_mbps": 65.58
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 57.47
+   "compress_mbps": 12.44,
+   "decompress_mbps": 65.6
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 57.5
+   "compress_mbps": 4.09,
+   "decompress_mbps": 65.45
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 56.88
+   "compress_mbps": 4.11,
+   "decompress_mbps": 65.49
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 1.4,
-   "decompress_mbps": 57.42
+   "compress_mbps": 1.39,
+   "decompress_mbps": 65.6
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 36.8,
-   "decompress_mbps": 119.48
+   "compress_mbps": 36.67,
+   "decompress_mbps": 126.39
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 33.51,
-   "decompress_mbps": 128.19
+   "compress_mbps": 33.73,
+   "decompress_mbps": 136.53
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 141.83
+   "compress_mbps": 33.6,
+   "decompress_mbps": 151.16
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 144.09
+   "compress_mbps": 25.73,
+   "decompress_mbps": 153.72
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 149.81
+   "compress_mbps": 24.88,
+   "decompress_mbps": 159.14
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 155.13
+   "compress_mbps": 23.12,
+   "decompress_mbps": 162.63
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.84,
-   "decompress_mbps": 159.53
+   "compress_mbps": 8.93,
+   "decompress_mbps": 167.21
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.94,
-   "decompress_mbps": 151.79
+   "compress_mbps": 8.9,
+   "decompress_mbps": 165.4
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 160.89
+   "compress_mbps": 1.24,
+   "decompress_mbps": 168.65
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 50.11,
-   "decompress_mbps": 109.48
+   "compress_mbps": 50.0,
+   "decompress_mbps": 122.03
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 47.49,
-   "decompress_mbps": 113.81
+   "compress_mbps": 47.47,
+   "decompress_mbps": 127.42
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 44.6,
-   "decompress_mbps": 118.57
+   "compress_mbps": 44.67,
+   "decompress_mbps": 133.83
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.29,
-   "decompress_mbps": 121.51
+   "compress_mbps": 38.18,
+   "decompress_mbps": 139.49
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.59,
-   "decompress_mbps": 129.68
+   "compress_mbps": 36.76,
+   "decompress_mbps": 147.86
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.58,
-   "decompress_mbps": 133.53
+   "compress_mbps": 32.9,
+   "decompress_mbps": 148.81
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177172,
    "ratio": 0.3744,
-   "compress_mbps": 7.55,
-   "decompress_mbps": 132.09
+   "compress_mbps": 7.5,
+   "decompress_mbps": 150.19
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.98,
-   "decompress_mbps": 133.69
+   "compress_mbps": 6.93,
+   "decompress_mbps": 151.23
   },
   {
    "compressor": "native",
@@ -4145,7 +4145,7 @@
    "out_size": 18518350,
    "ratio": 0.3615,
    "compress_mbps": 1.17,
-   "decompress_mbps": 133.1
+   "decompress_mbps": 150.32
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 51.18,
-   "decompress_mbps": 104.37
+   "compress_mbps": 49.98,
+   "decompress_mbps": 120.27
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.03,
-   "decompress_mbps": 107.27
+   "compress_mbps": 47.02,
+   "decompress_mbps": 123.03
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 42.09,
-   "decompress_mbps": 108.91
+   "compress_mbps": 41.65,
+   "decompress_mbps": 127.73
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.14,
-   "decompress_mbps": 100.95
+   "compress_mbps": 31.1,
+   "decompress_mbps": 119.56
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.4,
-   "decompress_mbps": 107.95
+   "compress_mbps": 29.63,
+   "decompress_mbps": 124.89
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.19,
-   "decompress_mbps": 110.06
+   "compress_mbps": 26.78,
+   "decompress_mbps": 129.06
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.43,
-   "decompress_mbps": 109.54
+   "compress_mbps": 8.3,
+   "decompress_mbps": 131.12
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.04,
-   "decompress_mbps": 111.83
+   "compress_mbps": 8.09,
+   "decompress_mbps": 134.82
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 0.98,
-   "decompress_mbps": 115.32
+   "compress_mbps": 0.99,
+   "decompress_mbps": 134.77
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 115.44,
-   "decompress_mbps": 420.5
+   "compress_mbps": 116.52,
+   "decompress_mbps": 437.22
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 102.54,
-   "decompress_mbps": 469.25
+   "compress_mbps": 104.56,
+   "decompress_mbps": 489.87
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 87.59,
-   "decompress_mbps": 525.66
+   "compress_mbps": 89.26,
+   "decompress_mbps": 540.78
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 78.22,
-   "decompress_mbps": 538.47
+   "compress_mbps": 79.46,
+   "decompress_mbps": 559.59
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 76.54,
-   "decompress_mbps": 606.23
+   "compress_mbps": 77.15,
+   "decompress_mbps": 628.82
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 70.87,
-   "decompress_mbps": 653.11
+   "compress_mbps": 71.39,
+   "decompress_mbps": 672.12
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 25.82,
-   "decompress_mbps": 651.66
+   "compress_mbps": 25.88,
+   "decompress_mbps": 667.9
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 654.54
+   "compress_mbps": 22.81,
+   "decompress_mbps": 690.12
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 2868751,
    "ratio": 0.0855,
    "compress_mbps": 0.77,
-   "decompress_mbps": 635.2
+   "decompress_mbps": 633.79
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 35.88,
-   "decompress_mbps": 72.27
+   "compress_mbps": 37.27,
+   "decompress_mbps": 82.63
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 35.63,
-   "decompress_mbps": 74.7
+   "compress_mbps": 35.75,
+   "decompress_mbps": 84.68
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 80.56
+   "compress_mbps": 34.65,
+   "decompress_mbps": 90.13
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.33,
-   "decompress_mbps": 81.54
+   "compress_mbps": 29.42,
+   "decompress_mbps": 92.44
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 28.95,
-   "decompress_mbps": 84.67
+   "compress_mbps": 28.97,
+   "decompress_mbps": 93.74
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 27.74,
-   "decompress_mbps": 85.95
+   "compress_mbps": 27.97,
+   "decompress_mbps": 97.84
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 6.91,
-   "decompress_mbps": 87.79
+   "compress_mbps": 7.0,
+   "decompress_mbps": 99.27
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.8,
-   "decompress_mbps": 88.77
+   "compress_mbps": 6.85,
+   "decompress_mbps": 100.94
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.45,
-   "decompress_mbps": 88.41
+   "compress_mbps": 1.47,
+   "decompress_mbps": 100.77
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 52.37,
-   "decompress_mbps": 100.23
+   "compress_mbps": 52.58,
+   "decompress_mbps": 124.14
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.3,
-   "decompress_mbps": 103.88
+   "compress_mbps": 49.63,
+   "decompress_mbps": 128.14
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 48.31,
-   "decompress_mbps": 106.54
+   "compress_mbps": 48.63,
+   "decompress_mbps": 131.49
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 44.95,
-   "decompress_mbps": 107.56
+   "compress_mbps": 44.98,
+   "decompress_mbps": 133.57
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 45.03,
-   "decompress_mbps": 104.38
+   "compress_mbps": 44.78,
+   "decompress_mbps": 130.66
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 44.51,
-   "decompress_mbps": 104.38
+   "compress_mbps": 44.77,
+   "decompress_mbps": 132.19
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.02,
-   "decompress_mbps": 107.11
+   "compress_mbps": 12.01,
+   "decompress_mbps": 136.37
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.03,
-   "decompress_mbps": 105.89
+   "compress_mbps": 12.07,
+   "decompress_mbps": 135.82
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.76,
-   "decompress_mbps": 106.4
+   "compress_mbps": 1.78,
+   "decompress_mbps": 135.94
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 45.3,
-   "decompress_mbps": 145.81
+   "compress_mbps": 47.27,
+   "decompress_mbps": 154.55
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 41.76,
-   "decompress_mbps": 161.19
+   "compress_mbps": 41.82,
+   "decompress_mbps": 175.6
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 36.17,
-   "decompress_mbps": 177.56
+   "compress_mbps": 35.54,
+   "decompress_mbps": 190.12
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 181.87
+   "compress_mbps": 26.62,
+   "decompress_mbps": 191.89
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.14,
-   "decompress_mbps": 190.93
+   "compress_mbps": 24.54,
+   "decompress_mbps": 202.44
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.31,
-   "decompress_mbps": 199.65
+   "compress_mbps": 20.46,
+   "decompress_mbps": 212.31
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.35,
-   "decompress_mbps": 199.68
+   "compress_mbps": 8.37,
+   "decompress_mbps": 230.03
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.73,
-   "decompress_mbps": 215.64
+   "compress_mbps": 7.77,
+   "decompress_mbps": 224.87
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 0.91,
-   "decompress_mbps": 211.06
+   "compress_mbps": 0.93,
+   "decompress_mbps": 219.48
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 65.82,
-   "decompress_mbps": 216.33
+   "compress_mbps": 66.0,
+   "decompress_mbps": 226.5
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 59.68,
-   "decompress_mbps": 227.91
+   "compress_mbps": 60.29,
+   "decompress_mbps": 238.62
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 53.72,
-   "decompress_mbps": 238.38
+   "compress_mbps": 55.57,
+   "decompress_mbps": 249.99
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.19,
-   "decompress_mbps": 249.5
+   "compress_mbps": 46.73,
+   "decompress_mbps": 259.52
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.2,
-   "decompress_mbps": 259.7
+   "compress_mbps": 45.33,
+   "decompress_mbps": 269.75
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.02,
-   "decompress_mbps": 264.49
+   "compress_mbps": 42.42,
+   "decompress_mbps": 276.8
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.27,
-   "decompress_mbps": 247.44
+   "compress_mbps": 13.26,
+   "decompress_mbps": 262.53
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.81,
-   "decompress_mbps": 253.69
+   "compress_mbps": 12.76,
+   "decompress_mbps": 262.3
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.3,
-   "decompress_mbps": 259.35
+   "decompress_mbps": 272.5
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 31.32,
-   "decompress_mbps": 104.75
+   "compress_mbps": 32.27,
+   "decompress_mbps": 103.73
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 107.75
+   "compress_mbps": 31.0,
+   "decompress_mbps": 106.56
   },
   {
    "compressor": "native",
@@ -4715,7 +4715,7 @@
    "out_size": 5522436,
    "ratio": 0.7615,
    "compress_mbps": 29.6,
-   "decompress_mbps": 112.27
+   "decompress_mbps": 109.82
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.0,
-   "decompress_mbps": 114.03
+   "compress_mbps": 25.35,
+   "decompress_mbps": 113.5
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.39,
-   "decompress_mbps": 117.25
+   "compress_mbps": 24.91,
+   "decompress_mbps": 114.65
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 118.88
+   "compress_mbps": 24.31,
+   "decompress_mbps": 116.63
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.15,
-   "decompress_mbps": 119.72
+   "compress_mbps": 6.17,
+   "decompress_mbps": 117.74
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.14,
-   "decompress_mbps": 118.62
+   "compress_mbps": 6.18,
+   "decompress_mbps": 118.64
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.57,
-   "decompress_mbps": 119.29
+   "compress_mbps": 1.58,
+   "decompress_mbps": 118.66
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 156.46
+   "compress_mbps": 49.56,
+   "decompress_mbps": 163.2
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 46.05,
-   "decompress_mbps": 166.15
+   "compress_mbps": 45.83,
+   "decompress_mbps": 176.19
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 42.93,
-   "decompress_mbps": 178.98
+   "compress_mbps": 43.31,
+   "decompress_mbps": 188.83
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.34,
-   "decompress_mbps": 188.16
+   "compress_mbps": 35.72,
+   "decompress_mbps": 197.7
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.06,
-   "decompress_mbps": 194.94
+   "compress_mbps": 34.48,
+   "decompress_mbps": 204.93
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 30.99,
-   "decompress_mbps": 199.28
+   "compress_mbps": 31.31,
+   "decompress_mbps": 210.43
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.59,
-   "decompress_mbps": 198.89
+   "compress_mbps": 11.65,
+   "decompress_mbps": 210.0
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.35,
-   "decompress_mbps": 200.22
+   "compress_mbps": 11.44,
+   "decompress_mbps": 210.6
   },
   {
    "compressor": "native",
@@ -4865,7 +4865,7 @@
    "out_size": 11638957,
    "ratio": 0.2807,
    "compress_mbps": 1.21,
-   "decompress_mbps": 198.22
+   "decompress_mbps": 211.67
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 58.24
+   "compress_mbps": 32.78,
+   "decompress_mbps": 67.21
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.0,
-   "decompress_mbps": 64.12
+   "compress_mbps": 32.43,
+   "decompress_mbps": 71.75
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 31.99,
-   "decompress_mbps": 68.69
+   "compress_mbps": 32.62,
+   "decompress_mbps": 75.68
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.55,
-   "decompress_mbps": 67.6
+   "compress_mbps": 30.89,
+   "decompress_mbps": 74.28
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.52,
-   "decompress_mbps": 69.27
+   "compress_mbps": 30.88,
+   "decompress_mbps": 76.12
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.19,
-   "decompress_mbps": 70.52
+   "compress_mbps": 30.72,
+   "decompress_mbps": 77.38
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.76,
-   "decompress_mbps": 71.46
+   "compress_mbps": 4.73,
+   "decompress_mbps": 78.1
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.75,
-   "decompress_mbps": 71.59
+   "compress_mbps": 4.69,
+   "decompress_mbps": 77.08
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.68,
-   "decompress_mbps": 70.35
+   "compress_mbps": 1.69,
+   "decompress_mbps": 77.5
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 95.1,
-   "decompress_mbps": 291.35
+   "compress_mbps": 96.77,
+   "decompress_mbps": 312.8
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 85.52,
-   "decompress_mbps": 325.65
+   "compress_mbps": 86.89,
+   "decompress_mbps": 366.86
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 76.89,
-   "decompress_mbps": 360.99
+   "compress_mbps": 77.59,
+   "decompress_mbps": 393.73
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 63.34,
-   "decompress_mbps": 363.56
+   "compress_mbps": 64.74,
+   "decompress_mbps": 378.86
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.13,
-   "decompress_mbps": 398.31
+   "compress_mbps": 62.92,
+   "decompress_mbps": 406.24
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 57.81,
-   "decompress_mbps": 427.19
+   "compress_mbps": 58.44,
+   "decompress_mbps": 450.19
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.68,
-   "decompress_mbps": 444.63
+   "compress_mbps": 21.51,
+   "decompress_mbps": 470.1
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.33,
-   "decompress_mbps": 451.62
+   "compress_mbps": 19.98,
+   "decompress_mbps": 475.29
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 0.97,
-   "decompress_mbps": 473.88
+   "decompress_mbps": 513.93
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR makes `Inflate.inflate` / `Inflate.inflateRaw` themselves the verified tree-free canonical Huffman decoder from #2681 — no Huffman tree is built anywhere on the decode path (fast ≤9-bit codes go through the canonical 9-bit table, long codes through a canonical `walkCanonical` bit-by-bit decode) — so the decode win ships on every production path (gzip/zlib/raw-deflate/ZIP, benchmarks, tests). Closes #2682. Part of #2668. Supersedes #2683 and #2684 (consolidated into this single PR against master).

The blocker that made this more than a name swap was a correctness/security gap: the tree-free path previously skipped the `maxBits`/Kraft validation `HuffTree.fromLengths` performs, so its accept-set was a superset of the verified decoder's — it accepted some malformed dynamic-code-length streams the tree path rejects, which would widen the native accept-set versus the zlib FFI (the `native ⊆ FFI` property the fuzz census enforces). `HuffTree.validateLengths` factors that exact check (same `"Inflate: code length exceeds maximum"` / `"Inflate: oversubscribed Huffman code"` messages, computed from the lengths alone — no tree), and `decodeDynamicLengthsOnly` runs it, rejecting exactly what `decodeDynamicTrees` rejects.

The old tree-building implementation is preserved as the verified reference `Inflate.inflateReference` / `inflateRawReference` (`inflateLoop` unchanged). The whole verified spec tree is restated about the reference, and `Zip.Spec.InflateTreeFreeCorrect` proves the standalone equivalence bridge `inflate_ok_iff_reference` (`inflate data = .ok out ↔ inflateReference data = .ok out`) and `inflateRaw_ok_iff_reference`, via the new backward loop lemma `inflateLoop_of_inflateLoopTreeFree` (mirroring the forward one) over the `decodeDynamicTrees_of_lengthsOnly` correspondence the closed gap enables. So every decode-correctness / completeness / roundtrip theorem about the reference transfers to the production decoder, with no `@[implemented_by]` and no trust gap.

`nix-shell --run "lake build && lake exe test"` green (all 8 executable targets build); no `sorry`; the FuzzInflate native⊆FFI census (now exercising the tree-free `Inflate.inflate` directly) is unchanged — native-accept/FFI-reject 1, zero silent corruption. Decode throughput measured ~1.07x across all levels on Canterbury and Silesia, output-neutral (`max |Δratio| = 0.000000`); the dashboard is refreshed for the shipped decoder. Before/after graphs: https://github.com/kim-em/lean-zip/pull/2683#issuecomment-4774479797

🤖 Prepared with Claude Code