### PR TITLE
perf(decode): compute validateLengths Kraft sum from the count array, not a per-block List

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -110,27 +110,6 @@ def fromLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
     else
       .ok (fromLengthsTree lengths maxBits)
 
-/-- The code-length validity check that `fromLengths` performs, factored out so a
-    decoder that builds no tree (the canonical tree-free path) can reject exactly
-    the malformed length sets `fromLengths` rejects, with the same error messages:
-    `"Inflate: code length exceeds maximum"` for any length `> maxBits`, and
-    `"Inflate: oversubscribed Huffman code"` when the Kraft sum overflows. Computed
-    cheaply from the lengths alone — no tree, no `count` array, no insertion pass.
-    `fromLengths = (validateLengths …).map (fun _ => fromLengthsTree …)`
-    (`Zip.Spec.InflateTreeFreeCorrect.fromLengths_eq_validate`). -/
-def validateLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
-    Except String Unit :=
-  if lengths.any (fun l => l.toNat > maxBits) then
-    .error "Inflate: code length exceeds maximum"
-  else
-    let lsList := lengths.toList.map UInt8.toNat
-    let kraft := (lsList.filter (· != 0)).foldl
-      (fun acc l => acc + 2 ^ (maxBits - l)) 0
-    if kraft > 2 ^ maxBits then
-      .error "Inflate: oversubscribed Huffman code"
-    else
-      .ok ()
-
 /-- Decode one symbol from the bit reader using this Huffman tree. -/
 def decode (tree : HuffTree) (br : BitReader) :
     Except String (UInt16 × BitReader) :=
@@ -364,6 +343,43 @@ where
       go lengths maxBits (i + 1) count
     else count
   termination_by lengths.size - i
+
+/-- Kraft sum `∑_{len=0}^{maxBits} count[len] · 2^(maxBits − len)` over the
+    per-length histogram, by an `O(maxBits)` tail loop with **no allocation** —
+    `count` is the same array `buildTableCanonicalFast` already builds. (The `len=0`
+    term is zero for a `countLengthsFast` histogram, which never sets index 0, so it
+    contributes nothing while keeping the recurrence aligned with the spec's
+    `kraftSumFrom` from `0`.) The Kraft check `validateLengths` runs is then this
+    sum against `2^maxBits`, replacing the per-block `lengths.toList`/`filter`
+    `List` allocation `fromLengths` uses. -/
+def kraftSumFast (count : Array Nat) (maxBits : Nat) : Nat :=
+  go count maxBits 0 0
+where
+  go (count : Array Nat) (maxBits b acc : Nat) : Nat :=
+    if h : b ≤ maxBits then
+      go count maxBits (b + 1) (acc + count[b]! * 2 ^ (maxBits - b))
+    else acc
+  termination_by maxBits + 1 - b
+
+/-- The code-length validity check that `fromLengths` performs, factored out so a
+    decoder that builds no tree (the canonical tree-free path) can reject exactly
+    the malformed length sets `fromLengths` rejects, with the same error messages:
+    `"Inflate: code length exceeds maximum"` for any length `> maxBits`, and
+    `"Inflate: oversubscribed Huffman code"` when the Kraft sum overflows. The Kraft
+    sum is computed from the per-length `count` histogram (`countLengthsFast` —
+    the same array the canonical table build needs) via the allocation-free
+    `kraftSumFast`, rather than the per-block `List` (`lengths.toList`/`filter`)
+    `fromLengths` allocates; the over-bound check is a plain `Array.any`. No tree is
+    built. `fromLengths = (validateLengths …).map (fun _ => fromLengthsTree …)`
+    (`Zip.Spec.InflateTreeFreeCorrect.fromLengths_eq_validate`). -/
+def validateLengths (lengths : Array UInt8) (maxBits : Nat := 15) :
+    Except String Unit :=
+  if lengths.any (fun l => l.toNat > maxBits) then
+    .error "Inflate: code length exceeds maximum"
+  else if kraftSumFast (countLengthsFast lengths maxBits) maxBits > 2 ^ maxBits then
+    .error "Inflate: oversubscribed Huffman code"
+  else
+    .ok ()
 
 /-- First canonical code per length (RFC 1951 §3.2.2 step 2), as a `UInt32` array
     computed by a direct `1..maxBits` loop — fast form of

--- a/Zip/Spec/HuffmanKraft.lean
+++ b/Zip/Spec/HuffmanKraft.lean
@@ -64,37 +64,39 @@ protected def ncRec (blCount : Array Nat) : Nat → Nat
 
 /-- Partial Kraft sum from position `start` to `maxBits`:
     `∑_{i=start}^{maxBits} blCount[i]! * 2^(maxBits - i)`. -/
-private def kraftSumFrom (blCount : Array Nat) (maxBits b : Nat) : Nat :=
+protected def kraftSumFrom (blCount : Array Nat) (maxBits b : Nat) : Nat :=
   if b > maxBits then 0
-  else blCount[b]! * 2 ^ (maxBits - b) + kraftSumFrom blCount maxBits (b + 1)
+  else blCount[b]! * 2 ^ (maxBits - b) + Huffman.Spec.kraftSumFrom blCount maxBits (b + 1)
 termination_by maxBits + 1 - b
 
 /-! ## Conservation law: ncRec and kraftSumFrom -/
 
 /-- Unfolding lemma for `kraftSumFrom` when `b ≤ maxBits`. -/
-private theorem kraftSumFrom_unfold (blCount : Array Nat) (maxBits b : Nat) (hb : b ≤ maxBits) :
-    kraftSumFrom blCount maxBits b =
-      blCount[b]! * 2 ^ (maxBits - b) + kraftSumFrom blCount maxBits (b + 1) := by
-  rw [kraftSumFrom.eq_1]; exact if_neg (by omega)
+protected theorem kraftSumFrom_unfold (blCount : Array Nat) (maxBits b : Nat) (hb : b ≤ maxBits) :
+    Huffman.Spec.kraftSumFrom blCount maxBits b =
+      blCount[b]! * 2 ^ (maxBits - b) + Huffman.Spec.kraftSumFrom blCount maxBits (b + 1) := by
+  rw [Huffman.Spec.kraftSumFrom.eq_1]; exact if_neg (by omega)
 
 /-- `kraftSumFrom` past `maxBits` is zero. -/
-private theorem kraftSumFrom_gt (blCount : Array Nat) (maxBits b : Nat) (hb : b > maxBits) :
-    kraftSumFrom blCount maxBits b = 0 := by
-  rw [kraftSumFrom.eq_1]; exact if_pos hb
+protected theorem kraftSumFrom_gt (blCount : Array Nat) (maxBits b : Nat) (hb : b > maxBits) :
+    Huffman.Spec.kraftSumFrom blCount maxBits b = 0 := by
+  rw [Huffman.Spec.kraftSumFrom.eq_1]; exact if_pos hb
 
 /-- Conservation law: `ncRec b * 2^(maxBits-b) + kraftSumFrom b = kraftSumFrom 0`.
     The nextCodes recurrence preserves the total Kraft sum. -/
 private theorem ncRec_kraft_conservation (blCount : Array Nat) (maxBits b : Nat)
     (hb : b ≤ maxBits) :
-    Huffman.Spec.ncRec blCount b * 2 ^ (maxBits - b) + kraftSumFrom blCount maxBits b =
-      kraftSumFrom blCount maxBits 0 := by
+    Huffman.Spec.ncRec blCount b * 2 ^ (maxBits - b) +
+        Huffman.Spec.kraftSumFrom blCount maxBits b =
+      Huffman.Spec.kraftSumFrom blCount maxBits 0 := by
   induction b with
   | zero => simp only [Spec.ncRec, Nat.sub_zero, Nat.zero_mul, Nat.zero_add]
   | succ n ih =>
     have ih' := ih (by omega)
-    rw [kraftSumFrom_unfold blCount maxBits n (by omega)] at ih'
+    rw [Huffman.Spec.kraftSumFrom_unfold blCount maxBits n (by omega)] at ih'
     show (Huffman.Spec.ncRec blCount n + blCount[n]!) * 2 * 2 ^ (maxBits - (n + 1)) +
-      kraftSumFrom blCount maxBits (n + 1) = kraftSumFrom blCount maxBits 0
+      Huffman.Spec.kraftSumFrom blCount maxBits (n + 1) =
+        Huffman.Spec.kraftSumFrom blCount maxBits 0
     have : 2 * 2 ^ (maxBits - (n + 1)) = 2 ^ (maxBits - n) := by
       rw [show maxBits - n = (maxBits - (n + 1)) + 1 from by omega, Nat.pow_succ, Nat.mul_comm]
     rw [Nat.mul_assoc, this, Nat.add_mul]
@@ -196,14 +198,14 @@ protected theorem nextCodes_eq_ncRec (blCount : Array Nat) (maxBits b : Nat)
     from positions ≤ l, and doesn't affect positions > l. -/
 private theorem kraftSumFrom_incr (acc : Array Nat) (maxBits l b : Nat)
     (hl : l ≤ maxBits) (hsize : acc.size ≥ maxBits + 1) :
-    kraftSumFrom (acc.set! l (acc[l]! + 1)) maxBits b =
-      kraftSumFrom acc maxBits b + if b ≤ l then 2 ^ (maxBits - l) else 0 := by
+    Huffman.Spec.kraftSumFrom (acc.set! l (acc[l]! + 1)) maxBits b =
+      Huffman.Spec.kraftSumFrom acc maxBits b + if b ≤ l then 2 ^ (maxBits - l) else 0 := by
   if hb : b > maxBits then
-    simp only [Array.set!_eq_setIfInBounds, kraftSumFrom_gt _ _ _ hb,
+    simp only [Array.set!_eq_setIfInBounds, Huffman.Spec.kraftSumFrom_gt _ _ _ hb,
       show ¬(b ≤ l) from by omega, ↓reduceIte, Nat.add_zero]
   else
     have hb' : b ≤ maxBits := by omega
-    rw [kraftSumFrom_unfold _ _ _ hb', kraftSumFrom_unfold _ _ _ hb']
+    rw [Huffman.Spec.kraftSumFrom_unfold _ _ _ hb', Huffman.Spec.kraftSumFrom_unfold _ _ _ hb']
     if hbl : b = l then
       subst hbl
       rw [Array.getElem!_set!_self acc b _ (by omega)]
@@ -223,10 +225,10 @@ termination_by maxBits + 1 - b
 
 /-- `kraftSumFrom` over an all-zeros array is 0. -/
 private theorem kraftSumFrom_replicate (maxBits b : Nat) :
-    kraftSumFrom (Array.replicate (maxBits + 1) 0) maxBits b = 0 := by
-  if hb : b > maxBits then exact kraftSumFrom_gt _ _ _ hb
+    Huffman.Spec.kraftSumFrom (Array.replicate (maxBits + 1) 0) maxBits b = 0 := by
+  if hb : b > maxBits then exact Huffman.Spec.kraftSumFrom_gt _ _ _ hb
   else
-    rw [kraftSumFrom_unfold _ _ _ (by omega)]
+    rw [Huffman.Spec.kraftSumFrom_unfold _ _ _ (by omega)]
     simp only [Array.size_replicate, show b < maxBits + 1 from by omega, getElem!_pos,
       Array.getElem_replicate, Nat.zero_mul, kraftSumFrom_replicate maxBits (b + 1), Nat.add_zero]
 termination_by maxBits + 1 - b
@@ -243,48 +245,59 @@ protected theorem validLengths_cons {l : Nat} {ls : List Nat} {maxBits : Nat}
       rw [List.foldl_add_init] at hf; exact Nat.le_trans (Nat.le_add_left _ _) hf
     · exact hf
 
-/-- The full Kraft sum `kraftSumFrom 0` equals the Kraft sum in `ValidLengths`. -/
-private theorem kraftSumFrom_eq_kraft_foldl (lengths : List Nat) (maxBits : Nat)
-    (hv : ValidLengths lengths maxBits) :
-    kraftSumFrom (countLengths lengths maxBits) maxBits 0 ≤ 2 ^ maxBits := by
+/-- The full Kraft sum `kraftSumFrom 0` over the `countLengths` histogram equals the
+    direct per-element Kraft fold over the non-zero lengths, whenever no length
+    exceeds `maxBits`. This is the identity that lets the tree-free `validateLengths`
+    compute its Kraft check from the per-length `count` array (an `O(maxBits)` fold,
+    no `List` allocation) instead of `fromLengths`' `lengths.toList`/`filter` list. -/
+protected theorem kraftSumFrom_zero_eq_foldl (lengths : List Nat) (maxBits : Nat)
+    (hle : ∀ l ∈ lengths, l ≤ maxBits) :
+    Huffman.Spec.kraftSumFrom (countLengths lengths maxBits) maxBits 0 =
+      (lengths.filter (· != 0)).foldl (fun acc l => acc + 2 ^ (maxBits - l)) 0 := by
   simp only [countLengths]
   suffices ∀ (acc : Array Nat), acc.size = maxBits + 1 →
-      kraftSumFrom (lengths.foldl (fun acc len =>
+      Huffman.Spec.kraftSumFrom (lengths.foldl (fun acc len =>
         if len == 0 || len > maxBits then acc
         else acc.set! len (acc[len]! + 1)) acc) maxBits 0 =
-      kraftSumFrom acc maxBits 0 +
+      Huffman.Spec.kraftSumFrom acc maxBits 0 +
       (lengths.filter (· != 0)).foldl (fun acc l => acc + 2 ^ (maxBits - l)) 0 by
     rw [this _ (Array.size_replicate ..)]
     rw [kraftSumFrom_replicate, Nat.zero_add]
-    exact hv.2
   intro acc hsize
   induction lengths generalizing acc with
   | nil => simp only [gt_iff_lt, Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq,
       Array.set!_eq_setIfInBounds, List.foldl_nil, List.filter_nil, Nat.add_zero]
   | cons l ls ih =>
-    have hv_ls := Huffman.Spec.validLengths_cons hv
+    have hle_ls : ∀ x ∈ ls, x ≤ maxBits := fun x hx => hle x (List.mem_cons_of_mem l hx)
     simp only [List.foldl_cons]
     split
     · rename_i hskip
-      rw [ih hv_ls acc hsize]
+      rw [ih hle_ls acc hsize]
       congr 1
       simp only [List.filter_cons]
       simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq] at hskip
       cases hskip with
       | inl h => simp only [h, bne_self_eq_false, Bool.false_eq_true, ↓reduceIte]
-      | inr h => exfalso; exact Nat.not_lt.mpr (hv.1 l List.mem_cons_self) h
+      | inr h => exact absurd (hle l List.mem_cons_self) (by omega)
     · rename_i hset
       simp only [Bool.or_eq_true, beq_iff_eq, not_or, decide_eq_true_eq] at hset
       have hl_ne : l ≠ 0 := hset.1
       have hl_le : l ≤ maxBits := by omega
       have hsize' : (acc.set! l (acc[l]! + 1)).size = maxBits + 1 := by
         rw [Array.size_set!]; exact hsize
-      rw [ih hv_ls (acc.set! l (acc[l]! + 1)) hsize',
+      rw [ih hle_ls (acc.set! l (acc[l]! + 1)) hsize',
           kraftSumFrom_incr acc maxBits l 0 hl_le (by omega)]
       simp only [Nat.zero_le, ite_true]
       rw [show (l :: ls).filter (· != 0) = l :: ls.filter (· != 0) from by
         simp only [bne_iff_ne, ne_eq, hl_ne, not_false_eq_true, List.filter_cons_of_pos],
         List.foldl_cons, Nat.zero_add, Nat.add_assoc, ← List.foldl_add_init]
+
+/-- The full Kraft sum `kraftSumFrom 0` equals the Kraft sum in `ValidLengths`. -/
+private theorem kraftSumFrom_eq_kraft_foldl (lengths : List Nat) (maxBits : Nat)
+    (hv : ValidLengths lengths maxBits) :
+    Huffman.Spec.kraftSumFrom (countLengths lengths maxBits) maxBits 0 ≤ 2 ^ maxBits := by
+  rw [Huffman.Spec.kraftSumFrom_zero_eq_foldl lengths maxBits (fun l hl => hv.1 l hl)]
+  exact hv.2
 
 /-- The ncRec recurrence at higher bit lengths bounds from below by
     scaling the value at a lower length:
@@ -311,13 +324,13 @@ protected theorem ncRec_shift (blCount : Array Nat) (b₁ b₂ : Nat) (h : b₁ 
     inequality holds for the full sum from 0. -/
 private theorem ncRec_bound (blCount : Array Nat) (maxBits b : Nat)
     (hb : b ≤ maxBits)
-    (hkraft : kraftSumFrom blCount maxBits 0 ≤ 2 ^ maxBits) :
+    (hkraft : Huffman.Spec.kraftSumFrom blCount maxBits 0 ≤ 2 ^ maxBits) :
     Huffman.Spec.ncRec blCount b + blCount[b]! ≤ 2 ^ b := by
   have hcons := ncRec_kraft_conservation blCount maxBits b hb
-  rw [kraftSumFrom_unfold blCount maxBits b hb] at hcons
+  rw [Huffman.Spec.kraftSumFrom_unfold blCount maxBits b hb] at hcons
   have h1 : (Huffman.Spec.ncRec blCount b + blCount[b]!) * 2 ^ (maxBits - b) ≤ 2 ^ maxBits := by
     have : (Huffman.Spec.ncRec blCount b + blCount[b]!) * 2 ^ (maxBits - b) ≤
-           kraftSumFrom blCount maxBits 0 := by rw [Nat.add_mul]; omega
+           Huffman.Spec.kraftSumFrom blCount maxBits 0 := by rw [Nat.add_mul]; omega
     omega
   rw [show 2 ^ maxBits = 2 ^ b * 2 ^ (maxBits - b) from by
     rw [← Nat.pow_add]; congr 1; omega] at h1

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -41,7 +41,61 @@ namespace Zip.Native.HuffTree
 building the tree, factored out for the tree-free path. These lemmas certify that
 running `validateLengths` rejects (and accepts) precisely the length sets
 `fromLengths` does, with identical error messages — the foundation of closing the
-tree-free code-length validation gap. -/
+tree-free code-length validation gap.
+
+`fromLengths` computes its Kraft sum over a per-block `lengths.toList`/`filter`
+`List`; `validateLengths` computes the same sum from the per-length `count`
+histogram (`countLengthsFast`, the array the canonical table build already needs)
+via the allocation-free `kraftSumFast`. `validate_kraft_eq` certifies the two Kraft
+computations agree on every length set with no over-bound length, so the check
+cascades stay identical. -/
+
+/-- The fast histogram equals the spec `countLengths` on the mapped lengths.
+    (Local restatement of the `hcount` step inside `buildTableCanonicalFast_eq`.) -/
+theorem countLengthsFast_eq (lengths : Array UInt8) (maxBits : Nat) :
+    countLengthsFast lengths maxBits
+      = Huffman.Spec.countLengths (lengths.toList.map UInt8.toNat) maxBits := by
+  rw [countLengthsFast,
+      countLengthsFast_go_eq lengths maxBits lengths.size 0 _ (by omega), List.drop_zero]
+  rfl
+
+/-- Accumulator invariant for `kraftSumFast.go`: the loop threads the running Kraft
+    sum, so it equals the accumulator plus the spec backward recurrence
+    `Huffman.Spec.kraftSumFrom` from the current index. -/
+theorem kraftSumFast_go_eq (count : Array Nat) (maxBits b acc : Nat) :
+    kraftSumFast.go count maxBits b acc = acc + Huffman.Spec.kraftSumFrom count maxBits b := by
+  rw [kraftSumFast.go]
+  if h : b ≤ maxBits then
+    rw [dif_pos h, kraftSumFast_go_eq count maxBits (b + 1) _,
+        Huffman.Spec.kraftSumFrom_unfold count maxBits b h]
+    omega
+  else
+    rw [dif_neg h, Huffman.Spec.kraftSumFrom_gt count maxBits b (by omega), Nat.add_zero]
+termination_by maxBits + 1 - b
+
+/-- `kraftSumFast` equals the spec backward Kraft recurrence from index `0`. -/
+theorem kraftSumFast_eq (count : Array Nat) (maxBits : Nat) :
+    kraftSumFast count maxBits = Huffman.Spec.kraftSumFrom count maxBits 0 := by
+  rw [kraftSumFast, kraftSumFast_go_eq, Nat.zero_add]
+
+/-- The allocation-free Kraft sum `validateLengths` computes from the `count`
+    histogram equals the per-element Kraft fold `fromLengths` computes over the
+    non-zero lengths, whenever no length exceeds `maxBits` (the over-bound case is
+    rejected first by the shared `Array.any` guard). -/
+theorem validate_kraft_eq (lengths : Array UInt8) (maxBits : Nat)
+    (h : ¬ (lengths.any (fun l => l.toNat > maxBits) = true)) :
+    kraftSumFast (countLengthsFast lengths maxBits) maxBits
+      = ((lengths.toList.map UInt8.toNat).filter (· != 0)).foldl
+          (fun acc l => acc + 2 ^ (maxBits - l)) 0 := by
+  rw [kraftSumFast_eq, countLengthsFast_eq]
+  refine Huffman.Spec.kraftSumFrom_zero_eq_foldl (lengths.toList.map UInt8.toNat) maxBits ?_
+  intro l hl
+  simp only [List.mem_map] at hl
+  obtain ⟨u, hu, rfl⟩ := hl
+  rw [Array.mem_toList_iff, Array.mem_iff_getElem] at hu
+  obtain ⟨i, hi, rfl⟩ := hu
+  rw [Bool.not_eq_true, Array.any_eq_false] at h
+  simpa only [gt_iff_lt, decide_eq_true_eq, Nat.not_lt] using h i hi
 
 /-- `fromLengths` is `validateLengths` followed by the validation-free tree build:
     they share the identical `maxBits`/Kraft `if`-cascade, so `fromLengths` errors
@@ -52,7 +106,7 @@ theorem fromLengths_eq_validate (lengths : Array UInt8) (maxBits : Nat) :
   unfold fromLengths validateLengths
   by_cases h1 : lengths.any (fun l => l.toNat > maxBits) = true
   · rw [if_pos h1, if_pos h1]; rfl
-  · rw [if_neg h1, if_neg h1]
+  · rw [if_neg h1, if_neg h1, validate_kraft_eq lengths maxBits h1]
     by_cases h2 : ((lengths.toList.map UInt8.toNat).filter (· != 0)).foldl
         (fun acc l => acc + 2 ^ (maxBits - l)) 0 > 2 ^ maxBits
     · rw [if_pos h2, if_pos h2]; rfl
@@ -434,15 +488,6 @@ theorem buildSymbols_placement
     s' hs' h0' hm'
 
 /-! ## `buildLongDecode` instantiation and `codeFor` correspondence -/
-
-/-- The fast histogram equals the spec `countLengths` on the mapped lengths.
-    (Local restatement of the `hcount` step inside `buildTableCanonicalFast_eq`.) -/
-theorem countLengthsFast_eq (lengths : Array UInt8) (maxBits : Nat) :
-    countLengthsFast lengths maxBits
-      = Huffman.Spec.countLengths (lengths.toList.map UInt8.toNat) maxBits := by
-  rw [countLengthsFast,
-      countLengthsFast_go_eq lengths maxBits lengths.size 0 _ (by omega), List.drop_zero]
-  rfl
 
 /-- `numEarlier` over the whole length vector is the spec `countLengths`. -/
 theorem numEarlier_size_eq (lengths : Array UInt8) (maxBits L : Nat)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#paa307c7229)">
+   <g clip-path="url(#p0dc1c48d16)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz6rcdx3H4TMnk1DCIdhC/xhEpKC4cF9Kr6EbL8Qr6F30CgqCK7ciunTnJWgtIjQt7WnShNNkejKZnzv3hdeXjx2e5wrew8BnXvPdnZ7+Ybvgx+VwM71gncOz6QVLbC9vpycss3vw1vSENe6+Nr1gncvL6QVrvDxML1hnd57f2fbk0fSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+39fXE9vWOLl6TA9YZmf/uTd6QnLXG3vTE9YYvfd4+kJy/ztxT+mJyzxs3tvTU9Y5ni6nZ6wxM2r8737t6fj9IQl3nvw8+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNju2fd/3KZHrPDieDM9YZk3T/enJ6xzvJ1esMbN9fSCdd7+1fSCJW6259MTljnX+/jmdjU9YZlHF4+nJyzx8Prb6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7qyfX0hiWu9vemJ6xz+HJ6wTLbzdPpCWucTtMLltnd/2p6whLnfEOu9g+mJ6xx77XpBcs8fHE7PWGJ7fkX0xOW8YIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbb9dfTm/ghzqdphfA/2yffzY9YY1L/z9/dNxG/o+4IAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb/+7r/0xvWOLJ4dX0hGX+/ujZ9IRl/vTbD6YnLPHO/V9MT1jmN5/8fnrCEh/+8o3pCcv868lhegI/0J//8un0hCWef/zR9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbHc8/XWbHrHCq9NxesIyl7vz7eI7h+fTE9a4s59esM53j6cXLHF6/eH0hGW27TQ9YYk7Z/xm8HI7z9+0u8fz/FwXF16wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/PNfGutxPL1jm8qvPpicssz37ZnrCGsfj9IJltl+/Pz1hibO9jRcXF6fd9IJFbg/TC5a5+/3N9IQlts//OT1hmfO9IAAAQwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDsv2cHiwZH5S3pAAAAAElFTkSuQmCC" id="imagee68bed97e5" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image684a1339b4" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf956c79e97" d="M 0 0 
+       <path id="mc372897682" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf956c79e97" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf956c79e97" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf956c79e97" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf956c79e97" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf956c79e97" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf956c79e97" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf956c79e97" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf956c79e97" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf956c79e97" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf956c79e97" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf956c79e97" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc372897682" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m8492e361eb" d="M 0 0 
+       <path id="mcf0880a97b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m8492e361eb" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf0880a97b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1452,8 +1452,49 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +3 -->
+    <!-- +4 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -1 -->
+    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +8 -->
+    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -17 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -35 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1488,35 +1529,6 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -1 -->
-    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +6 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -18 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -35 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -1563,18 +1575,6 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2180,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagebcc872d18c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image68cf399e58" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m58214364c6" d="M 0 0 
+       <path id="m630ca2ee70" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m58214364c6" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m630ca2ee70" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.601719 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.991406 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,13 +3013,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3058,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="paa307c7229">
+  <clipPath id="p0dc1c48d16">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb952035da3" d="M 0 0 
+       <path id="m2865ccc6b1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb952035da3" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb952035da3" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb952035da3" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb952035da3" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb952035da3" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb952035da3" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb952035da3" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2865ccc6b1" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m4f1d12cecb" d="M 0 0 
+       <path id="m7b4b0d7fbc" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4f1d12cecb" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4f1d12cecb" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4f1d12cecb" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m689cf2f740" d="M 0 0 
+       <path id="m6a9b1a86a8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m689cf2f740" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 176.929412) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 176.211252) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.484087) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.412453) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7ade56cd58" d="M -2.5 2.5 
+     <path id="m841fc1c5ea" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m7ade56cd58" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ade56cd58" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m841fc1c5ea" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m841fc1c5ea" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m201a72eebf" d="M 0 -2.5 
+     <path id="m5303e1f53f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m201a72eebf" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m201a72eebf" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m5303e1f53f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5303e1f53f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me3b7657ed0" d="M -0 3.535534 
+     <path id="m2b40e4ecbc" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#me3b7657ed0" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b7657ed0" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m2b40e4ecbc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b40e4ecbc" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0f19908ff5" d="M -0 2.5 
+     <path id="md056289bf8" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m0f19908ff5" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#md056289bf8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3d7fcd1234" d="M -0.833333 2.5 
+     <path id="m07dc04bb49" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m3d7fcd1234" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d7fcd1234" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m07dc04bb49" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07dc04bb49" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md730be5a54" d="M -1.25 2.5 
+     <path id="mdc060585ba" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#md730be5a54" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md730be5a54" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#mdc060585ba" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc060585ba" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m143f54e1de" d="M 0 -2.5 
+     <path id="m0a311fcda9" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m143f54e1de" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m143f54e1de" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a311fcda9" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m16c8470b4b" d="M 0 -2.5 
+     <path id="m803daea7e0" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m16c8470b4b" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16c8470b4b" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#m803daea7e0" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m803daea7e0" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m58c03a45bf" d="M 0 3.5 
+      <path id="md68703fb66" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m58c03a45bf" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#md68703fb66" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7ade56cd58" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m841fc1c5ea" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m201a72eebf" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5303e1f53f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me3b7657ed0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2b40e4ecbc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0f19908ff5" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md056289bf8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3d7fcd1234" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m07dc04bb49" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md730be5a54" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdc060585ba" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m143f54e1de" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0a311fcda9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m16c8470b4b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m803daea7e0" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 181.929412 
-L 214.084819 184.558703 
-L 206.266533 187.021542 
-L 187.75787 192.983532 
-L 186.58897 193.923636 
-L 184.505355 196.021813 
-L 152.30308 249.703116 
-L 150.950891 251.545376 
-L 98.348822 336.484087 
-" clip-path="url(#pa671bb694f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pa671bb694f)">
-     <use xlink:href="#m58c03a45bf" x="226.647908" y="181.929412" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="214.084819" y="184.558703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="206.266533" y="187.021542" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="187.75787" y="192.983532" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="186.58897" y="193.923636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="184.505355" y="196.021813" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="152.30308" y="249.703116" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="150.950891" y="251.545376" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m58c03a45bf" x="98.348822" y="336.484087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 181.211252 
+L 214.084819 183.613159 
+L 206.266533 185.974471 
+L 187.75787 192.442867 
+L 186.58897 193.532688 
+L 184.505355 195.663284 
+L 152.30308 249.268718 
+L 150.950891 251.216261 
+L 98.348822 336.412453 
+" clip-path="url(#p00cd833124)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p00cd833124)">
+     <use xlink:href="#md68703fb66" x="226.647908" y="181.211252" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="214.084819" y="183.613159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="206.266533" y="185.974471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="187.75787" y="192.442867" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="186.58897" y="193.532688" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="184.505355" y="195.663284" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="152.30308" y="249.268718" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="150.950891" y="251.216261" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md68703fb66" x="98.348822" y="336.412453" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.601719 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.991406 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2918,39 +2918,34 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
 z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3051,13 +3046,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3096,109 +3091,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa671bb694f">
+  <clipPath id="p00cd833124">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd76c148a36)">
+   <g clip-path="url(#p987c9e72b7)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imaged74e7115d2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagef4539a7a21" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m6b53413a1a" d="M 0 0 
+       <path id="m3ccf22ac64" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6b53413a1a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m6b53413a1a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m6b53413a1a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6b53413a1a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m6b53413a1a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6b53413a1a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m6b53413a1a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6b53413a1a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m6b53413a1a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6b53413a1a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m6b53413a1a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ccf22ac64" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m181a40dec8" d="M 0 0 
+       <path id="md42f95b750" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m181a40dec8" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md42f95b750" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image185f8a1001" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image830015ad2c" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m905d4e044e" d="M 0 0 
+       <path id="mc485315922" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m905d4e044e" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc485315922" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.601719 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.991406 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2954,13 +2954,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd76c148a36">
+  <clipPath id="p987c9e72b7">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.196563pt" height="386.202469pt" viewBox="0 0 567.196563 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.417188pt" height="386.202469pt" viewBox="0 0 568.417188 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 567.196563 386.202469 
-L 567.196563 0 
+L 568.417188 386.202469 
+L 568.417188 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 185.723281 104.1264 
-L 290.348281 104.1264 
-L 290.348281 74.7432 
-L 185.723281 74.7432 
+    <path d="M 186.333594 104.1264 
+L 290.958594 104.1264 
+L 290.958594 74.7432 
+L 186.333594 74.7432 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.348281 104.1264 
-L 394.973281 104.1264 
-L 394.973281 74.7432 
-L 290.348281 74.7432 
+    <path d="M 290.958594 104.1264 
+L 395.583594 104.1264 
+L 395.583594 74.7432 
+L 290.958594 74.7432 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 394.973281 104.1264 
-L 499.598281 104.1264 
-L 499.598281 74.7432 
-L 394.973281 74.7432 
+    <path d="M 395.583594 104.1264 
+L 500.208594 104.1264 
+L 500.208594 74.7432 
+L 395.583594 74.7432 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 185.723281 133.5096 
-L 290.348281 133.5096 
-L 290.348281 104.1264 
-L 185.723281 104.1264 
+    <path d="M 186.333594 133.5096 
+L 290.958594 133.5096 
+L 290.958594 104.1264 
+L 186.333594 104.1264 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.348281 133.5096 
-L 394.973281 133.5096 
-L 394.973281 104.1264 
-L 290.348281 104.1264 
+    <path d="M 290.958594 133.5096 
+L 395.583594 133.5096 
+L 395.583594 104.1264 
+L 290.958594 104.1264 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 394.973281 133.5096 
-L 499.598281 133.5096 
-L 499.598281 104.1264 
-L 394.973281 104.1264 
+    <path d="M 395.583594 133.5096 
+L 500.208594 133.5096 
+L 500.208594 104.1264 
+L 395.583594 104.1264 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 185.723281 162.8928 
-L 290.348281 162.8928 
-L 290.348281 133.5096 
-L 185.723281 133.5096 
+    <path d="M 186.333594 162.8928 
+L 290.958594 162.8928 
+L 290.958594 133.5096 
+L 186.333594 133.5096 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.348281 162.8928 
-L 394.973281 162.8928 
-L 394.973281 133.5096 
-L 290.348281 133.5096 
+    <path d="M 290.958594 162.8928 
+L 395.583594 162.8928 
+L 395.583594 133.5096 
+L 290.958594 133.5096 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 394.973281 162.8928 
-L 499.598281 162.8928 
-L 499.598281 133.5096 
-L 394.973281 133.5096 
+    <path d="M 395.583594 162.8928 
+L 500.208594 162.8928 
+L 500.208594 133.5096 
+L 395.583594 133.5096 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 185.723281 192.276 
-L 290.348281 192.276 
-L 290.348281 162.8928 
-L 185.723281 162.8928 
+    <path d="M 186.333594 192.276 
+L 290.958594 192.276 
+L 290.958594 162.8928 
+L 186.333594 162.8928 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.348281 192.276 
-L 394.973281 192.276 
-L 394.973281 162.8928 
-L 290.348281 162.8928 
+    <path d="M 290.958594 192.276 
+L 395.583594 192.276 
+L 395.583594 162.8928 
+L 290.958594 162.8928 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 394.973281 192.276 
-L 499.598281 192.276 
-L 499.598281 162.8928 
-L 394.973281 162.8928 
+    <path d="M 395.583594 192.276 
+L 500.208594 192.276 
+L 500.208594 162.8928 
+L 395.583594 162.8928 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 185.723281 221.6592 
-L 290.348281 221.6592 
-L 290.348281 192.276 
-L 185.723281 192.276 
+    <path d="M 186.333594 221.6592 
+L 290.958594 221.6592 
+L 290.958594 192.276 
+L 186.333594 192.276 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.348281 221.6592 
-L 394.973281 221.6592 
-L 394.973281 192.276 
-L 290.348281 192.276 
+    <path d="M 290.958594 221.6592 
+L 395.583594 221.6592 
+L 395.583594 192.276 
+L 290.958594 192.276 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 394.973281 221.6592 
-L 499.598281 221.6592 
-L 499.598281 192.276 
-L 394.973281 192.276 
+    <path d="M 395.583594 221.6592 
+L 500.208594 221.6592 
+L 500.208594 192.276 
+L 395.583594 192.276 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 185.723281 251.0424 
-L 290.348281 251.0424 
-L 290.348281 221.6592 
-L 185.723281 221.6592 
+    <path d="M 186.333594 251.0424 
+L 290.958594 251.0424 
+L 290.958594 221.6592 
+L 186.333594 221.6592 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.348281 251.0424 
-L 394.973281 251.0424 
-L 394.973281 221.6592 
-L 290.348281 221.6592 
+    <path d="M 290.958594 251.0424 
+L 395.583594 251.0424 
+L 395.583594 221.6592 
+L 290.958594 221.6592 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 394.973281 251.0424 
-L 499.598281 251.0424 
-L 499.598281 221.6592 
-L 394.973281 221.6592 
+    <path d="M 395.583594 251.0424 
+L 500.208594 251.0424 
+L 500.208594 221.6592 
+L 395.583594 221.6592 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f46d43; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 185.723281 280.4256 
-L 290.348281 280.4256 
-L 290.348281 251.0424 
-L 185.723281 251.0424 
+    <path d="M 186.333594 280.4256 
+L 290.958594 280.4256 
+L 290.958594 251.0424 
+L 186.333594 251.0424 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.348281 280.4256 
-L 394.973281 280.4256 
-L 394.973281 251.0424 
-L 290.348281 251.0424 
+    <path d="M 290.958594 280.4256 
+L 395.583594 280.4256 
+L 395.583594 251.0424 
+L 290.958594 251.0424 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 394.973281 280.4256 
-L 499.598281 280.4256 
-L 499.598281 251.0424 
-L 394.973281 251.0424 
+    <path d="M 395.583594 280.4256 
+L 500.208594 280.4256 
+L 500.208594 251.0424 
+L 395.583594 251.0424 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 185.723281 309.8088 
-L 290.348281 309.8088 
-L 290.348281 280.4256 
-L 185.723281 280.4256 
+    <path d="M 186.333594 309.8088 
+L 290.958594 309.8088 
+L 290.958594 280.4256 
+L 186.333594 280.4256 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.348281 309.8088 
-L 394.973281 309.8088 
-L 394.973281 280.4256 
-L 290.348281 280.4256 
+    <path d="M 290.958594 309.8088 
+L 395.583594 309.8088 
+L 395.583594 280.4256 
+L 290.958594 280.4256 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 394.973281 309.8088 
-L 499.598281 309.8088 
-L 499.598281 280.4256 
-L 394.973281 280.4256 
+    <path d="M 395.583594 309.8088 
+L 500.208594 309.8088 
+L 500.208594 280.4256 
+L 395.583594 280.4256 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 185.723281 339.192 
-L 290.348281 339.192 
-L 290.348281 309.8088 
-L 185.723281 309.8088 
+    <path d="M 186.333594 339.192 
+L 290.958594 339.192 
+L 290.958594 309.8088 
+L 186.333594 309.8088 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.348281 339.192 
-L 394.973281 339.192 
-L 394.973281 309.8088 
-L 290.348281 309.8088 
+    <path d="M 290.958594 339.192 
+L 395.583594 339.192 
+L 395.583594 309.8088 
+L 290.958594 309.8088 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 394.973281 339.192 
-L 499.598281 339.192 
-L 499.598281 309.8088 
-L 394.973281 309.8088 
+    <path d="M 395.583594 339.192 
+L 500.208594 339.192 
+L 500.208594 309.8088 
+L 395.583594 309.8088 
 z
-" clip-path="url(#pdc820f49d7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1602a500d4)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(118.710547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.320859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(225.994766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.605078 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(304.566875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.177188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(402.918594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.528906 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(114.648281 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.258594 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(226.584531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.025781 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.636094 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(439.650781 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.286406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.896719 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(226.584531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(337.570781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(439.650781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(126.549531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.159844 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(226.584531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(337.570781 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(439.650781 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(109.855781 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.466094 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(226.584531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(337.570781 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(439.650781 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.012031 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.622344 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(226.584531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(337.570781 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(439.650781 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.357656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.967969 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(225.383906 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(225.994219 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(337.094531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(337.704844 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,8 +1755,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 150 -->
-    <g transform="translate(438.936406 238.5583) scale(0.08 -0.08)">
+    <!-- 160 -->
+    <g transform="translate(439.546719 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1772,15 +1772,45 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(94.472656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.082969 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1909,7 +1939,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(226.584531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1919,14 +1949,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(337.570781 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(439.650781 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1934,7 +1964,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(96.979531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.589844 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1990,7 +2020,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(226.584531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2000,21 +2030,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(337.570781 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(442.195781 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.806094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(122.693906 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.304219 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2055,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(226.584531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2035,13 +2065,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.115781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.726094 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.285781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.896094 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2087,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.107031 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.717344 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2196,36 +2226,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2270,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2412,13 +2412,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2457,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdc820f49d7">
-   <rect x="81.098281" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p1602a500d4">
+   <rect x="81.708594" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf4c8c6eb13)">
+   <g clip-path="url(#p6f7b9b454f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ50lEQVR4nO3Yu46VVQCG4dkzmwE5RBSEqAmxUStNiFY23oGFl2Fpa29pbWvvDVhprEyM0Q47CVooRCJyCDN7Zo9XYEXWu4Y/z3MF385/WO+/V9u/vzrZWbLN09kLeBbbo9kLxlrtzl4w1tHh7AVjnb88e8FYB49mLxhrb3/2Ap7F0u/P/fOzFwy18NMPAIDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBa/7S5PXvDUOvdvdkThtqenMyeMNS1S9dmTxjq9r+/z54w1sI/cd86d3n2hKE2Z/dnTxjq57u3Zk8Y6t2rb86eMNTB/nb2hKFWqyezJwy18OMBAIDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNY3Lr0xe8NQl89emz1hqHtP/5g9YajXniz7G+nilXdmTxhqb7WePWGo7c529oShXtm5OnvCUEdXD2dPGOr6+RuzJwy12S77+l04XPb7ZdmnOwAAp44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtV6tlt2gDzf3Z08Y6oW9i7MnDHV85eXZE4b688EvsycM9ejw6ewJQ7330vuzJwx1uDd7wViPNw9nT+AZ/HNwd/aEsc5em71gqGXXJwAAp44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtTr+/tOT2SOG2m5nL4D/t+sb8Lnm/fJ8W/rzt/T70/V7ri386gEAcNoIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUuvrP/46e8NQu+tlN/bdW/dmTxjqy09uzp4w1Oc//DV7wlAf3nhx9oShvv7ut9kThvrs47dnTxjqi2/vzJ4w1Ec3X509Yag7Dw5mTxjqg9cvzJ4w1LLrDACAU0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKRWm+NvTmaPGGnv6Gj2hLF217MXjHX0dPaCsfbPz14w1mrh37gn29kLxtp4/p5rx8s+/zarZT9/ZxbeLws/HQAAOG0EKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqfX2ZDt7w1B7Z87NnsCzeHB/9oKhjveXfX/uHR3NnjDWwt+fO4dPZi8Y6vHusu/PC8fL/o/pzGrZv2/n4NHsBUMt/OoBAHDaCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/AcaPfpyr8V7bAAAAAElFTkSuQmCC" id="imagecfbbd1ec65" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7klEQVR4nO3YvY5dZxmG4dkz2+PEToQhxhFBsmiACqQoqdJwBhQcBiUtfUpq2vQ5ASpQKiSEoAsdUaAAR0QxcSzP7Jk9HAGV9d3veOm6juCR1s93r7U7/uejm5MtO7yYXsDLOF5NL1hrdzq9YK2ry+kFa917ML1grYtn0wvWOjufXsDL2Pr9eX5vesFSGz/9AAC4bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/Z8Pn01vWGp/ejY9Yanjzc30hKUevfloesJSn/33H9MT1tr4J+6PXnswPWGpw93z6QlL/eXJp9MTlvrpwx9OT1jq4vw4PWGp3e759ISlNn48AABw2whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT+8Zs/mN6w1IO7j6YnLPXFi39OT1jqnefb/kZ6462fTE9Y6my3n56w1PHkOD1hqe+ePJyesNTVw8vpCUu9fe/x9ISlDsdtX7/7l9t+v2z7dAcA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPa73bYb9OvDl9MTlnr97I3pCUtdv/Wd6QlL/evpX6cnLPXs8sX0hKXe+/b70xOWujybXrDWN4evpyfwEr66eDI9Ya27j6YXLLXt+gQA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHbXn/zqZnrEUsfj9AL4/059A77SvF9ebVt//rZ+f7p+r7SNXz0AAG4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr/9p/+Nr1hqdP9thv7yadfTE9Y6re/fHd6wlIf/vHf0xOW+tnjb01PWOrjP/x9esJSv/7Fj6cnLPWb338+PWGpn7/7vekJS33+9GJ6wlIffP/+9ISltl1nAADcOgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7XP/uZnrESmdXV9MT1jrdTy9Y6+rF9IK1zu9NL1hrt/Fv3Jvj9IK1Dp6/V9r1ts+/w27bz9+djffLxk8HAABuGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqf7w5Tm9Y6uzOa9MTljqebPv6nT79cnrCUtfn274/z66upiestfH358nl8+kFS31zuu378/5xPz1hqTvTA1a7eDa9YCl/QAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS/wO754CaCBujSAAAAABJRU5ErkJggg==" id="imageb80a1b7592" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mfe89294e75" d="M 0 0 
+       <path id="m4a11c8d6f0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfe89294e75" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mfe89294e75" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mfe89294e75" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mfe89294e75" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mfe89294e75" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mfe89294e75" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfe89294e75" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mfe89294e75" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mfe89294e75" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mfe89294e75" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mfe89294e75" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mfe89294e75" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a11c8d6f0" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mae5849834e" d="M 0 0 
+       <path id="m84a58d34ed" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mae5849834e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84a58d34ed" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1225,30 +1225,35 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +1 -->
+    <!-- +4 -->
     <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -37 -->
+    <!-- -36 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1283,26 +1288,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +6 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1334,86 +1319,33 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +7 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -9 -->
+    <!-- -8 -->
     <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -10 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -25 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +18 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1455,6 +1387,66 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -24 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +18 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -1463,27 +1455,6 @@ z
    <g id="text_30">
     <!-- -14 -->
     <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
@@ -1498,11 +1469,11 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- -26 -->
+    <!-- -27 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1530,6 +1501,33 @@ z
    <g id="text_36">
     <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -2192,18 +2190,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image87e4afff01" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2be7a188b2" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mbe0b488c0f" d="M 0 0 
+       <path id="m35df5a0d2e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2224,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2238,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2252,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2265,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2278,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2291,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mbe0b488c0f" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35df5a0d2e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2907,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.601719 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.991406 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3002,13 +3000,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3047,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf4c8c6eb13">
+  <clipPath id="p6f7b9b454f">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m84f3ae95db" d="M 0 0 
+       <path id="mb5be9e6a52" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m84f3ae95db" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m84f3ae95db" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m84f3ae95db" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m84f3ae95db" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m84f3ae95db" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m84f3ae95db" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m84f3ae95db" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5be9e6a52" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf253587df3" d="M 0 0 
+       <path id="mb0afad8f1b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf253587df3" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0afad8f1b" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf253587df3" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0afad8f1b" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf253587df3" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0afad8f1b" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf73763f27e" d="M 0 0 
+       <path id="mbfe5594000" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf73763f27e" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbfe5594000" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 150.000152) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 149.2322) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 352.288525) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.015906) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0ea55cb809" d="M -2.5 2.5 
+     <path id="m672c735265" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m0ea55cb809" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0ea55cb809" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#m672c735265" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672c735265" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1a61b817df" d="M 0 -2.5 
+     <path id="mf97fba6bd1" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m1a61b817df" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a61b817df" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#mf97fba6bd1" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf97fba6bd1" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7e7e4e11ca" d="M -0 3.535534 
+     <path id="mfc837e60c3" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m7e7e4e11ca" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7e4e11ca" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#mfc837e60c3" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc837e60c3" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma332f02c1d" d="M -0 2.5 
+     <path id="m6986386c50" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#ma332f02c1d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#m6986386c50" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6f75adcb96" d="M -0.833333 2.5 
+     <path id="m01ea53dbd2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m6f75adcb96" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6f75adcb96" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#m01ea53dbd2" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m01ea53dbd2" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3aa3193e25" d="M -1.25 2.5 
+     <path id="m130c407029" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m3aa3193e25" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aa3193e25" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#m130c407029" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m130c407029" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc4a4797e20" d="M 0 -2.5 
+     <path id="maf38ed181b" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4a4797e20" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#maf38ed181b" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf38ed181b" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbf96da430d" d="M 0 -2.5 
+     <path id="mde3dbd2884" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#mbf96da430d" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf96da430d" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#mde3dbd2884" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mde3dbd2884" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m1d9c428c10" d="M 0 3.5 
+      <path id="m89836bc9f6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1d9c428c10" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m89836bc9f6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0ea55cb809" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m672c735265" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1a61b817df" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf97fba6bd1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7e7e4e11ca" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfc837e60c3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma332f02c1d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6986386c50" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6f75adcb96" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m01ea53dbd2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3aa3193e25" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m130c407029" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc4a4797e20" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#maf38ed181b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbf96da430d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mde3dbd2884" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 155.000152 
-L 236.23654 158.851774 
-L 222.073314 162.685682 
-L 202.315941 172.243788 
-L 199.905291 173.879715 
-L 195.893147 177.697078 
-L 157.982343 243.559043 
-L 157.246106 245.645559 
-L 95.319203 357.288525 
-" clip-path="url(#p28786db23d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p28786db23d)">
-     <use xlink:href="#m1d9c428c10" x="257.531237" y="155.000152" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="236.23654" y="158.851774" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="222.073314" y="162.685682" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="202.315941" y="172.243788" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="199.905291" y="173.879715" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="195.893147" y="177.697078" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="157.982343" y="243.559043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="157.246106" y="245.645559" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1d9c428c10" x="95.319203" y="357.288525" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 154.2322 
+L 236.23654 158.324189 
+L 222.073314 162.095564 
+L 202.315941 171.886354 
+L 199.905291 173.650535 
+L 195.893147 177.415507 
+L 157.982343 243.277899 
+L 157.246106 245.492324 
+L 95.319203 357.015906 
+" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p43f46e1528)">
+     <use xlink:href="#m89836bc9f6" x="257.531237" y="154.2322" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="236.23654" y="158.324189" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="222.073314" y="162.095564" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="202.315941" y="171.886354" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="199.905291" y="173.650535" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="195.893147" y="177.415507" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="157.982343" y="243.277899" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="157.246106" y="245.492324" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m89836bc9f6" x="95.319203" y="357.015906" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.601719 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.991406 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2830,39 +2830,34 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
 z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2963,13 +2958,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3008,109 +3003,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p28786db23d">
+  <clipPath id="p43f46e1528">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p4fa9c48c34)">
+   <g clip-path="url(#pe3e632cc77)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image6869720b13" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imagec4eb256689" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma4ef9b7f6a" d="M 0 0 
+       <path id="m78a67b19cb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma4ef9b7f6a" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78a67b19cb" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="me67669bc4c" d="M 0 0 
+       <path id="m13ffe1de0f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me67669bc4c" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13ffe1de0f" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageeb9d9fa5a4" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image19d6f85a95" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mfb5caf164b" d="M 0 0 
+       <path id="m370f10c34f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb5caf164b" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m370f10c34f" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfb5caf164b" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m370f10c34f" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfb5caf164b" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m370f10c34f" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfb5caf164b" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m370f10c34f" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfb5caf164b" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m370f10c34f" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.601719 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.991406 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2873,13 +2873,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4fa9c48c34">
+  <clipPath id="pe3e632cc77">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.196563pt" height="386.202469pt" viewBox="0 0 567.196563 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.417188pt" height="386.202469pt" viewBox="0 0 568.417188 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 567.196563 386.202469 
-L 567.196563 0 
+L 568.417188 386.202469 
+L 568.417188 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 185.723281 104.1264 
-L 290.348281 104.1264 
-L 290.348281 74.7432 
-L 185.723281 74.7432 
+    <path d="M 186.333594 104.1264 
+L 290.958594 104.1264 
+L 290.958594 74.7432 
+L 186.333594 74.7432 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.348281 104.1264 
-L 394.973281 104.1264 
-L 394.973281 74.7432 
-L 290.348281 74.7432 
+    <path d="M 290.958594 104.1264 
+L 395.583594 104.1264 
+L 395.583594 74.7432 
+L 290.958594 74.7432 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 394.973281 104.1264 
-L 499.598281 104.1264 
-L 499.598281 74.7432 
-L 394.973281 74.7432 
+    <path d="M 395.583594 104.1264 
+L 500.208594 104.1264 
+L 500.208594 74.7432 
+L 395.583594 74.7432 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 185.723281 133.5096 
-L 290.348281 133.5096 
-L 290.348281 104.1264 
-L 185.723281 104.1264 
+    <path d="M 186.333594 133.5096 
+L 290.958594 133.5096 
+L 290.958594 104.1264 
+L 186.333594 104.1264 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.348281 133.5096 
-L 394.973281 133.5096 
-L 394.973281 104.1264 
-L 290.348281 104.1264 
+    <path d="M 290.958594 133.5096 
+L 395.583594 133.5096 
+L 395.583594 104.1264 
+L 290.958594 104.1264 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 394.973281 133.5096 
-L 499.598281 133.5096 
-L 499.598281 104.1264 
-L 394.973281 104.1264 
+    <path d="M 395.583594 133.5096 
+L 500.208594 133.5096 
+L 500.208594 104.1264 
+L 395.583594 104.1264 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 185.723281 162.8928 
-L 290.348281 162.8928 
-L 290.348281 133.5096 
-L 185.723281 133.5096 
+    <path d="M 186.333594 162.8928 
+L 290.958594 162.8928 
+L 290.958594 133.5096 
+L 186.333594 133.5096 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.348281 162.8928 
-L 394.973281 162.8928 
-L 394.973281 133.5096 
-L 290.348281 133.5096 
+    <path d="M 290.958594 162.8928 
+L 395.583594 162.8928 
+L 395.583594 133.5096 
+L 290.958594 133.5096 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 394.973281 162.8928 
-L 499.598281 162.8928 
-L 499.598281 133.5096 
-L 394.973281 133.5096 
+    <path d="M 395.583594 162.8928 
+L 500.208594 162.8928 
+L 500.208594 133.5096 
+L 395.583594 133.5096 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 185.723281 192.276 
-L 290.348281 192.276 
-L 290.348281 162.8928 
-L 185.723281 162.8928 
+    <path d="M 186.333594 192.276 
+L 290.958594 192.276 
+L 290.958594 162.8928 
+L 186.333594 162.8928 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.348281 192.276 
-L 394.973281 192.276 
-L 394.973281 162.8928 
-L 290.348281 162.8928 
+    <path d="M 290.958594 192.276 
+L 395.583594 192.276 
+L 395.583594 162.8928 
+L 290.958594 162.8928 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 394.973281 192.276 
-L 499.598281 192.276 
-L 499.598281 162.8928 
-L 394.973281 162.8928 
+    <path d="M 395.583594 192.276 
+L 500.208594 192.276 
+L 500.208594 162.8928 
+L 395.583594 162.8928 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 185.723281 221.6592 
-L 290.348281 221.6592 
-L 290.348281 192.276 
-L 185.723281 192.276 
+    <path d="M 186.333594 221.6592 
+L 290.958594 221.6592 
+L 290.958594 192.276 
+L 186.333594 192.276 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.348281 221.6592 
-L 394.973281 221.6592 
-L 394.973281 192.276 
-L 290.348281 192.276 
+    <path d="M 290.958594 221.6592 
+L 395.583594 221.6592 
+L 395.583594 192.276 
+L 290.958594 192.276 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 394.973281 221.6592 
-L 499.598281 221.6592 
-L 499.598281 192.276 
-L 394.973281 192.276 
+    <path d="M 395.583594 221.6592 
+L 500.208594 221.6592 
+L 500.208594 192.276 
+L 395.583594 192.276 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 185.723281 251.0424 
-L 290.348281 251.0424 
-L 290.348281 221.6592 
-L 185.723281 221.6592 
+    <path d="M 186.333594 251.0424 
+L 290.958594 251.0424 
+L 290.958594 221.6592 
+L 186.333594 221.6592 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.348281 251.0424 
-L 394.973281 251.0424 
-L 394.973281 221.6592 
-L 290.348281 221.6592 
+    <path d="M 290.958594 251.0424 
+L 395.583594 251.0424 
+L 395.583594 221.6592 
+L 290.958594 221.6592 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 394.973281 251.0424 
-L 499.598281 251.0424 
-L 499.598281 221.6592 
-L 394.973281 221.6592 
+    <path d="M 395.583594 251.0424 
+L 500.208594 251.0424 
+L 500.208594 221.6592 
+L 395.583594 221.6592 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 185.723281 280.4256 
-L 290.348281 280.4256 
-L 290.348281 251.0424 
-L 185.723281 251.0424 
+    <path d="M 186.333594 280.4256 
+L 290.958594 280.4256 
+L 290.958594 251.0424 
+L 186.333594 251.0424 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.348281 280.4256 
-L 394.973281 280.4256 
-L 394.973281 251.0424 
-L 290.348281 251.0424 
+    <path d="M 290.958594 280.4256 
+L 395.583594 280.4256 
+L 395.583594 251.0424 
+L 290.958594 251.0424 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 394.973281 280.4256 
-L 499.598281 280.4256 
-L 499.598281 251.0424 
-L 394.973281 251.0424 
+    <path d="M 395.583594 280.4256 
+L 500.208594 280.4256 
+L 500.208594 251.0424 
+L 395.583594 251.0424 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 185.723281 309.8088 
-L 290.348281 309.8088 
-L 290.348281 280.4256 
-L 185.723281 280.4256 
+    <path d="M 186.333594 309.8088 
+L 290.958594 309.8088 
+L 290.958594 280.4256 
+L 186.333594 280.4256 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.348281 309.8088 
-L 394.973281 309.8088 
-L 394.973281 280.4256 
-L 290.348281 280.4256 
+    <path d="M 290.958594 309.8088 
+L 395.583594 309.8088 
+L 395.583594 280.4256 
+L 290.958594 280.4256 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 394.973281 309.8088 
-L 499.598281 309.8088 
-L 499.598281 280.4256 
-L 394.973281 280.4256 
+    <path d="M 395.583594 309.8088 
+L 500.208594 309.8088 
+L 500.208594 280.4256 
+L 395.583594 280.4256 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 185.723281 339.192 
-L 290.348281 339.192 
-L 290.348281 309.8088 
-L 185.723281 309.8088 
+    <path d="M 186.333594 339.192 
+L 290.958594 339.192 
+L 290.958594 309.8088 
+L 186.333594 309.8088 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.348281 339.192 
-L 394.973281 339.192 
-L 394.973281 309.8088 
-L 290.348281 309.8088 
+    <path d="M 290.958594 339.192 
+L 395.583594 339.192 
+L 395.583594 309.8088 
+L 290.958594 309.8088 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 394.973281 339.192 
-L 499.598281 339.192 
-L 499.598281 309.8088 
-L 394.973281 309.8088 
+    <path d="M 395.583594 339.192 
+L 500.208594 339.192 
+L 500.208594 309.8088 
+L 395.583594 309.8088 
 z
-" clip-path="url(#p68884c66fc)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd8e23cf786)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(118.710547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.320859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(225.994766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.605078 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(304.566875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.177188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(402.918594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.528906 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(114.648281 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.258594 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(226.584531 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.025781 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.636094 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(439.650781 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.286406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.896719 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(226.584531 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(337.570781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(439.650781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(96.979531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.589844 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(226.584531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(337.570781 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(439.650781 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.012031 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.622344 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(226.584531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(337.570781 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(439.650781 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(126.549531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.159844 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(226.584531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(337.570781 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(439.650781 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(109.855781 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.466094 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(226.584531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(337.570781 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(439.650781 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.261094 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.357656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.967969 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(225.383906 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(225.994219 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 34 -->
-    <g transform="translate(337.094531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(337.704844 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1881,8 +1881,8 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 182 -->
-    <g transform="translate(438.936406 267.9415) scale(0.08 -0.08)">
+    <!-- 190 -->
+    <g transform="translate(439.546719 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1898,54 +1898,45 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
 z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(94.472656 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.082969 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2010,7 +2001,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(226.584531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2020,21 +2011,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(337.570781 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.181094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.195781 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.806094 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(122.693906 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.304219 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2045,7 +2036,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(226.584531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.194844 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2055,13 +2046,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.115781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.726094 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.285781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.896094 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2077,7 +2068,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.2 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.810313 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2221,7 +2212,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T00:54:17Z  ·  Linux chungus x86_64  ·  commit df20821f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2363,13 +2354,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2408,110 +2399,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3460.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3492.041016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3523.828125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3555.615234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3587.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3619.189453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3646.972656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3708.496094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3769.775391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3833.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3896.630859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3935.494141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3996.675781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4055.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4117.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4158.492188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4192.183594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4219.966797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4281.490234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4342.769531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4406.148438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4469.771484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4503.462891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4562.642578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4626.265625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4658.052734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4721.675781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4785.298828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4817.085938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4880.708984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4916.792969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4955.65625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5010.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5074.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5106.046875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5137.833984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5169.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5201.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5233.195312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5272.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5335.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5374.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5435.828125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5499.207031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5562.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5626.0625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5689.539062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5752.917969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5792.126953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5823.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5907.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5939.490234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6036.902344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6098.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6161.902344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6189.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6250.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6314.34375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6346.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6461.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6522.888672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6586.365234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6638.464844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6701.84375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6763.025391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6802.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6835.925781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6867.712891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6908.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6970.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7009.314453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7037.097656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7098.279297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7130.066406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7157.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7209.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7241.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7305.212891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7366.736328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7405.945312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7467.46875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7506.832031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7604.244141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7632.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7695.40625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7723.189453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7775.289062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7814.498047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p68884c66fc">
-   <rect x="81.098281" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pd8e23cf786">
+   <rect x="81.708594" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-23T00:54:17Z",
+  "date": "2026-06-23T04:23:39Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "df20821f",
+  "git_commit": "f2d6c3a8",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.16,
-   "decompress_mbps": 133.39
+   "compress_mbps": 40.72,
+   "decompress_mbps": 136.7
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 36.27,
-   "decompress_mbps": 147.64
+   "compress_mbps": 37.43,
+   "decompress_mbps": 150.43
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 33.55,
-   "decompress_mbps": 163.66
+   "compress_mbps": 34.53,
+   "decompress_mbps": 165.95
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.65,
-   "decompress_mbps": 167.64
+   "compress_mbps": 27.67,
+   "decompress_mbps": 171.17
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.84,
-   "decompress_mbps": 172.99
+   "compress_mbps": 26.88,
+   "decompress_mbps": 176.46
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.02,
-   "decompress_mbps": 179.13
+   "compress_mbps": 25.07,
+   "decompress_mbps": 183.54
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.4,
-   "decompress_mbps": 178.63
+   "compress_mbps": 9.36,
+   "decompress_mbps": 182.76
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.25,
-   "decompress_mbps": 180.32
+   "compress_mbps": 9.22,
+   "decompress_mbps": 183.52
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.29,
-   "decompress_mbps": 179.96
+   "compress_mbps": 1.28,
+   "decompress_mbps": 183.32
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.24,
-   "decompress_mbps": 128.71
+   "compress_mbps": 37.72,
+   "decompress_mbps": 130.54
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.57,
-   "decompress_mbps": 135.66
+   "compress_mbps": 34.88,
+   "decompress_mbps": 138.86
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 31.94,
-   "decompress_mbps": 145.95
+   "compress_mbps": 32.75,
+   "decompress_mbps": 149.49
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.72,
-   "decompress_mbps": 152.68
+   "compress_mbps": 25.7,
+   "decompress_mbps": 155.98
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.96,
-   "decompress_mbps": 159.2
+   "compress_mbps": 25.03,
+   "decompress_mbps": 163.2
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.87,
-   "decompress_mbps": 161.62
+   "compress_mbps": 23.84,
+   "decompress_mbps": 165.8
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 9.0,
-   "decompress_mbps": 162.09
+   "compress_mbps": 8.96,
+   "decompress_mbps": 166.33
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.99,
-   "decompress_mbps": 163.39
+   "compress_mbps": 8.97,
+   "decompress_mbps": 166.48
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.41,
-   "decompress_mbps": 162.1
+   "compress_mbps": 1.4,
+   "decompress_mbps": 166.18
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.68,
-   "decompress_mbps": 142.97
+   "compress_mbps": 34.23,
+   "decompress_mbps": 151.05
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.82,
-   "decompress_mbps": 147.62
+   "compress_mbps": 33.17,
+   "decompress_mbps": 157.6
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 31.98,
-   "decompress_mbps": 150.44
+   "compress_mbps": 32.3,
+   "decompress_mbps": 161.36
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.28,
-   "decompress_mbps": 155.05
+   "compress_mbps": 30.77,
+   "decompress_mbps": 164.91
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.87,
-   "decompress_mbps": 158.93
+   "compress_mbps": 30.05,
+   "decompress_mbps": 171.86
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.07,
-   "decompress_mbps": 160.31
+   "compress_mbps": 29.22,
+   "decompress_mbps": 171.87
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.66,
-   "decompress_mbps": 162.62
+   "compress_mbps": 9.75,
+   "decompress_mbps": 173.96
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.69,
-   "decompress_mbps": 160.7
+   "compress_mbps": 9.77,
+   "decompress_mbps": 173.46
   },
   {
    "compressor": "native",
@@ -275,7 +275,7 @@
    "out_size": 7727,
    "ratio": 0.3141,
    "compress_mbps": 1.62,
-   "decompress_mbps": 159.43
+   "decompress_mbps": 172.73
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.08,
-   "decompress_mbps": 110.7
+   "compress_mbps": 23.05,
+   "decompress_mbps": 124.55
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.5,
-   "decompress_mbps": 114.03
+   "compress_mbps": 23.07,
+   "decompress_mbps": 128.52
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.2,
-   "decompress_mbps": 116.73
+   "compress_mbps": 22.73,
+   "decompress_mbps": 131.7
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.5,
-   "decompress_mbps": 119.57
+   "compress_mbps": 21.66,
+   "decompress_mbps": 135.38
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.28,
-   "decompress_mbps": 122.32
+   "compress_mbps": 21.21,
+   "decompress_mbps": 138.57
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.07,
-   "decompress_mbps": 122.03
+   "compress_mbps": 21.29,
+   "decompress_mbps": 139.03
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.03,
-   "decompress_mbps": 123.09
+   "compress_mbps": 7.13,
+   "decompress_mbps": 139.47
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.03,
-   "decompress_mbps": 123.08
+   "compress_mbps": 7.11,
+   "decompress_mbps": 139.59
   },
   {
    "compressor": "native",
@@ -365,7 +365,7 @@
    "out_size": 3027,
    "ratio": 0.2715,
    "compress_mbps": 1.53,
-   "decompress_mbps": 123.24
+   "decompress_mbps": 138.47
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.66,
-   "decompress_mbps": 60.23
+   "compress_mbps": 11.69,
+   "decompress_mbps": 70.55
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 61.47
+   "compress_mbps": 11.6,
+   "decompress_mbps": 71.83
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.46,
-   "decompress_mbps": 61.35
+   "compress_mbps": 11.58,
+   "decompress_mbps": 71.88
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.26,
-   "decompress_mbps": 62.04
+   "compress_mbps": 11.53,
+   "decompress_mbps": 73.03
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.33,
-   "decompress_mbps": 62.72
+   "compress_mbps": 11.41,
+   "decompress_mbps": 73.51
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 62.7
+   "compress_mbps": 11.51,
+   "decompress_mbps": 73.85
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.79,
-   "decompress_mbps": 62.59
+   "compress_mbps": 3.86,
+   "decompress_mbps": 73.98
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.8,
-   "decompress_mbps": 62.66
+   "compress_mbps": 3.87,
+   "decompress_mbps": 73.8
   },
   {
    "compressor": "native",
@@ -455,7 +455,7 @@
    "out_size": 1190,
    "ratio": 0.3198,
    "compress_mbps": 1.23,
-   "decompress_mbps": 61.95
+   "decompress_mbps": 73.77
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 62.86,
-   "decompress_mbps": 221.11
+   "compress_mbps": 64.88,
+   "decompress_mbps": 233.58
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 59.81,
-   "decompress_mbps": 268.21
+   "compress_mbps": 61.96,
+   "decompress_mbps": 280.67
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 59.03,
-   "decompress_mbps": 282.63
+   "compress_mbps": 59.97,
+   "decompress_mbps": 294.88
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 55.44,
-   "decompress_mbps": 294.04
+   "compress_mbps": 56.23,
+   "decompress_mbps": 303.86
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.47,
-   "decompress_mbps": 224.5
+   "compress_mbps": 55.25,
+   "decompress_mbps": 234.57
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.62,
-   "decompress_mbps": 224.57
+   "compress_mbps": 52.18,
+   "decompress_mbps": 235.91
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.55,
-   "decompress_mbps": 207.6
+   "compress_mbps": 9.62,
+   "decompress_mbps": 218.81
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.65,
-   "decompress_mbps": 202.91
+   "compress_mbps": 7.62,
+   "decompress_mbps": 213.95
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 0.95,
-   "decompress_mbps": 202.51
+   "compress_mbps": 0.97,
+   "decompress_mbps": 211.76
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 43.42,
-   "decompress_mbps": 141.66
+   "compress_mbps": 44.16,
+   "decompress_mbps": 143.52
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 39.67,
-   "decompress_mbps": 151.1
+   "compress_mbps": 40.41,
+   "decompress_mbps": 154.13
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.1,
-   "decompress_mbps": 167.99
+   "compress_mbps": 37.48,
+   "decompress_mbps": 171.33
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 29.16,
-   "decompress_mbps": 172.85
+   "compress_mbps": 29.31,
+   "decompress_mbps": 176.93
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.41,
-   "decompress_mbps": 180.23
+   "compress_mbps": 28.47,
+   "decompress_mbps": 184.46
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.32,
-   "decompress_mbps": 184.09
+   "compress_mbps": 26.34,
+   "decompress_mbps": 187.27
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 10.03,
-   "decompress_mbps": 184.72
+   "compress_mbps": 10.04,
+   "decompress_mbps": 187.81
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.94,
-   "decompress_mbps": 185.04
+   "compress_mbps": 9.93,
+   "decompress_mbps": 187.65
   },
   {
    "compressor": "native",
@@ -635,7 +635,7 @@
    "out_size": 138661,
    "ratio": 0.3249,
    "compress_mbps": 1.3,
-   "decompress_mbps": 185.0
+   "decompress_mbps": 188.07
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 36.88,
-   "decompress_mbps": 123.2
+   "compress_mbps": 37.5,
+   "decompress_mbps": 124.71
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 33.9,
-   "decompress_mbps": 133.96
+   "compress_mbps": 34.71,
+   "decompress_mbps": 136.09
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.2,
-   "decompress_mbps": 143.41
+   "compress_mbps": 31.85,
+   "decompress_mbps": 145.69
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.09,
-   "decompress_mbps": 148.82
+   "compress_mbps": 23.44,
+   "decompress_mbps": 151.77
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.26,
-   "decompress_mbps": 156.19
+   "compress_mbps": 22.54,
+   "decompress_mbps": 158.87
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.69,
-   "decompress_mbps": 159.82
+   "compress_mbps": 21.0,
+   "decompress_mbps": 162.64
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.43,
-   "decompress_mbps": 159.87
+   "compress_mbps": 8.49,
+   "decompress_mbps": 162.9
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 160.56
+   "compress_mbps": 8.46,
+   "decompress_mbps": 163.65
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.26,
-   "decompress_mbps": 160.87
+   "compress_mbps": 1.25,
+   "decompress_mbps": 164.15
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 117.53,
-   "decompress_mbps": 383.91
+   "compress_mbps": 120.73,
+   "decompress_mbps": 399.35
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 103.95,
-   "decompress_mbps": 405.95
+   "compress_mbps": 107.24,
+   "decompress_mbps": 415.51
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 89.99,
-   "decompress_mbps": 428.5
+   "compress_mbps": 92.5,
+   "decompress_mbps": 444.09
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 72.9,
-   "decompress_mbps": 388.76
+   "compress_mbps": 73.84,
+   "decompress_mbps": 400.47
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 69.99,
-   "decompress_mbps": 415.12
+   "compress_mbps": 71.11,
+   "decompress_mbps": 427.42
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 63.55,
-   "decompress_mbps": 444.26
+   "compress_mbps": 64.47,
+   "decompress_mbps": 460.28
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 18.72,
-   "decompress_mbps": 464.07
+   "compress_mbps": 19.27,
+   "decompress_mbps": 485.81
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 496.05
+   "compress_mbps": 16.99,
+   "decompress_mbps": 519.55
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.96,
-   "decompress_mbps": 512.72
+   "compress_mbps": 0.97,
+   "decompress_mbps": 528.9
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 107.26
+   "compress_mbps": 26.42,
+   "decompress_mbps": 113.93
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.99,
-   "decompress_mbps": 111.68
+   "compress_mbps": 25.82,
+   "decompress_mbps": 118.94
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.06,
-   "decompress_mbps": 115.56
+   "compress_mbps": 25.38,
+   "decompress_mbps": 124.06
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.3,
-   "decompress_mbps": 114.02
+   "compress_mbps": 23.26,
+   "decompress_mbps": 122.43
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.92,
-   "decompress_mbps": 121.67
+   "compress_mbps": 22.95,
+   "decompress_mbps": 130.38
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.7,
-   "decompress_mbps": 122.81
+   "compress_mbps": 21.75,
+   "decompress_mbps": 132.34
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 5.75,
-   "decompress_mbps": 123.85
+   "compress_mbps": 5.76,
+   "decompress_mbps": 133.32
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.4,
-   "decompress_mbps": 126.94
+   "compress_mbps": 5.39,
+   "decompress_mbps": 138.08
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.2,
-   "decompress_mbps": 125.85
+   "compress_mbps": 1.21,
+   "decompress_mbps": 136.92
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.42,
-   "decompress_mbps": 64.0
+   "compress_mbps": 12.8,
+   "decompress_mbps": 73.14
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.37,
-   "decompress_mbps": 64.08
+   "compress_mbps": 12.76,
+   "decompress_mbps": 73.1
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.34,
-   "decompress_mbps": 64.03
+   "compress_mbps": 12.73,
+   "decompress_mbps": 73.23
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.23,
-   "decompress_mbps": 65.37
+   "compress_mbps": 12.64,
+   "decompress_mbps": 74.58
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.19,
-   "decompress_mbps": 65.58
+   "compress_mbps": 12.57,
+   "decompress_mbps": 75.41
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.44,
-   "decompress_mbps": 65.6
+   "compress_mbps": 12.53,
+   "decompress_mbps": 75.42
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.09,
-   "decompress_mbps": 65.45
+   "compress_mbps": 4.18,
+   "decompress_mbps": 75.34
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 65.49
+   "compress_mbps": 4.18,
+   "decompress_mbps": 75.49
   },
   {
    "compressor": "native",
@@ -995,7 +995,7 @@
    "out_size": 1696,
    "ratio": 0.4012,
    "compress_mbps": 1.39,
-   "decompress_mbps": 65.6
+   "decompress_mbps": 75.51
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 36.67,
-   "decompress_mbps": 126.39
+   "compress_mbps": 37.93,
+   "decompress_mbps": 127.71
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 33.73,
-   "decompress_mbps": 136.53
+   "compress_mbps": 34.39,
+   "decompress_mbps": 137.03
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.6,
-   "decompress_mbps": 151.16
+   "compress_mbps": 33.76,
+   "decompress_mbps": 151.94
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 153.72
+   "compress_mbps": 25.89,
+   "decompress_mbps": 155.57
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.88,
-   "decompress_mbps": 159.14
+   "compress_mbps": 25.11,
+   "decompress_mbps": 161.82
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.12,
-   "decompress_mbps": 162.63
+   "compress_mbps": 23.22,
+   "decompress_mbps": 165.1
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.93,
-   "decompress_mbps": 167.21
+   "compress_mbps": 8.9,
+   "decompress_mbps": 169.18
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.9,
-   "decompress_mbps": 165.4
+   "compress_mbps": 8.98,
+   "decompress_mbps": 169.61
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.24,
-   "decompress_mbps": 168.65
+   "compress_mbps": 1.27,
+   "decompress_mbps": 170.26
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 50.0,
-   "decompress_mbps": 122.03
+   "compress_mbps": 51.51,
+   "decompress_mbps": 129.72
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 47.47,
-   "decompress_mbps": 127.42
+   "compress_mbps": 48.56,
+   "decompress_mbps": 137.74
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 44.67,
-   "decompress_mbps": 133.83
+   "compress_mbps": 45.84,
+   "decompress_mbps": 141.58
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.18,
-   "decompress_mbps": 139.49
+   "compress_mbps": 38.62,
+   "decompress_mbps": 146.19
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.76,
-   "decompress_mbps": 147.86
+   "compress_mbps": 36.58,
+   "decompress_mbps": 155.85
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.9,
-   "decompress_mbps": 148.81
+   "compress_mbps": 32.83,
+   "decompress_mbps": 155.08
   },
   {
    "compressor": "native",
@@ -4125,7 +4125,7 @@
    "out_size": 19177172,
    "ratio": 0.3744,
    "compress_mbps": 7.5,
-   "decompress_mbps": 150.19
+   "decompress_mbps": 158.38
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.93,
-   "decompress_mbps": 151.23
+   "compress_mbps": 6.85,
+   "decompress_mbps": 159.9
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.17,
-   "decompress_mbps": 150.32
+   "compress_mbps": 1.18,
+   "decompress_mbps": 158.91
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 49.98,
-   "decompress_mbps": 120.27
+   "compress_mbps": 51.6,
+   "decompress_mbps": 124.15
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.02,
-   "decompress_mbps": 123.03
+   "compress_mbps": 47.71,
+   "decompress_mbps": 129.02
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 41.65,
-   "decompress_mbps": 127.73
+   "compress_mbps": 42.56,
+   "decompress_mbps": 132.59
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 119.56
+   "compress_mbps": 31.44,
+   "decompress_mbps": 124.42
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.63,
-   "decompress_mbps": 124.89
+   "compress_mbps": 29.89,
+   "decompress_mbps": 130.46
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 26.78,
-   "decompress_mbps": 129.06
+   "compress_mbps": 27.51,
+   "decompress_mbps": 135.07
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.3,
-   "decompress_mbps": 131.12
+   "compress_mbps": 8.46,
+   "decompress_mbps": 135.33
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.09,
-   "decompress_mbps": 134.82
+   "compress_mbps": 8.21,
+   "decompress_mbps": 141.49
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 0.99,
-   "decompress_mbps": 134.77
+   "compress_mbps": 1.0,
+   "decompress_mbps": 141.5
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 116.52,
-   "decompress_mbps": 437.22
+   "compress_mbps": 121.5,
+   "decompress_mbps": 449.89
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 104.56,
-   "decompress_mbps": 489.87
+   "compress_mbps": 105.69,
+   "decompress_mbps": 502.85
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 89.26,
-   "decompress_mbps": 540.78
+   "compress_mbps": 89.04,
+   "decompress_mbps": 558.27
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 79.46,
-   "decompress_mbps": 559.59
+   "compress_mbps": 80.46,
+   "decompress_mbps": 572.69
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 77.15,
-   "decompress_mbps": 628.82
+   "compress_mbps": 78.34,
+   "decompress_mbps": 648.58
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 71.39,
-   "decompress_mbps": 672.12
+   "compress_mbps": 72.49,
+   "decompress_mbps": 695.69
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 25.88,
-   "decompress_mbps": 667.9
+   "compress_mbps": 26.33,
+   "decompress_mbps": 689.37
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 690.12
+   "compress_mbps": 22.87,
+   "decompress_mbps": 710.5
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.77,
-   "decompress_mbps": 633.79
+   "compress_mbps": 0.78,
+   "decompress_mbps": 649.76
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 37.27,
-   "decompress_mbps": 82.63
+   "compress_mbps": 37.41,
+   "decompress_mbps": 86.29
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 35.75,
-   "decompress_mbps": 84.68
+   "compress_mbps": 36.12,
+   "decompress_mbps": 88.44
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 34.65,
-   "decompress_mbps": 90.13
+   "compress_mbps": 35.05,
+   "decompress_mbps": 94.1
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.42,
-   "decompress_mbps": 92.44
+   "compress_mbps": 29.67,
+   "decompress_mbps": 96.6
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 28.97,
-   "decompress_mbps": 93.74
+   "compress_mbps": 28.72,
+   "decompress_mbps": 100.32
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 27.97,
-   "decompress_mbps": 97.84
+   "compress_mbps": 28.01,
+   "decompress_mbps": 103.43
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 7.0,
-   "decompress_mbps": 99.27
+   "compress_mbps": 7.03,
+   "decompress_mbps": 103.88
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.85,
-   "decompress_mbps": 100.94
+   "compress_mbps": 6.81,
+   "decompress_mbps": 104.85
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.47,
-   "decompress_mbps": 100.77
+   "compress_mbps": 1.48,
+   "decompress_mbps": 104.78
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 52.58,
-   "decompress_mbps": 124.14
+   "compress_mbps": 52.75,
+   "decompress_mbps": 131.25
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.63,
-   "decompress_mbps": 128.14
+   "compress_mbps": 49.87,
+   "decompress_mbps": 135.75
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 48.63,
-   "decompress_mbps": 131.49
+   "compress_mbps": 49.37,
+   "decompress_mbps": 139.63
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 44.98,
-   "decompress_mbps": 133.57
+   "compress_mbps": 45.33,
+   "decompress_mbps": 141.94
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 44.78,
-   "decompress_mbps": 130.66
+   "compress_mbps": 45.55,
+   "decompress_mbps": 140.03
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 44.77,
-   "decompress_mbps": 132.19
+   "compress_mbps": 45.36,
+   "decompress_mbps": 141.18
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.01,
-   "decompress_mbps": 136.37
+   "compress_mbps": 12.26,
+   "decompress_mbps": 144.78
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.07,
-   "decompress_mbps": 135.82
+   "compress_mbps": 12.12,
+   "decompress_mbps": 144.19
   },
   {
    "compressor": "native",
@@ -4505,7 +4505,7 @@
    "out_size": 3647083,
    "ratio": 0.3616,
    "compress_mbps": 1.78,
-   "decompress_mbps": 135.94
+   "decompress_mbps": 144.16
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 47.27,
-   "decompress_mbps": 154.55
+   "compress_mbps": 47.87,
+   "decompress_mbps": 156.41
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 41.82,
-   "decompress_mbps": 175.6
+   "compress_mbps": 41.38,
+   "decompress_mbps": 173.2
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 35.54,
-   "decompress_mbps": 190.12
+   "compress_mbps": 36.67,
+   "decompress_mbps": 192.57
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.62,
-   "decompress_mbps": 191.89
+   "compress_mbps": 26.96,
+   "decompress_mbps": 195.59
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.54,
-   "decompress_mbps": 202.44
+   "compress_mbps": 24.85,
+   "decompress_mbps": 207.7
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.46,
-   "decompress_mbps": 212.31
+   "compress_mbps": 20.59,
+   "decompress_mbps": 216.86
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.37,
-   "decompress_mbps": 230.03
+   "compress_mbps": 8.51,
+   "decompress_mbps": 229.74
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.77,
-   "decompress_mbps": 224.87
+   "compress_mbps": 7.78,
+   "decompress_mbps": 229.93
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 0.93,
-   "decompress_mbps": 219.48
+   "compress_mbps": 0.92,
+   "decompress_mbps": 232.17
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 66.0,
-   "decompress_mbps": 226.5
+   "compress_mbps": 66.82,
+   "decompress_mbps": 237.08
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 60.29,
-   "decompress_mbps": 238.62
+   "compress_mbps": 61.07,
+   "decompress_mbps": 248.56
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 55.57,
-   "decompress_mbps": 249.99
+   "compress_mbps": 56.23,
+   "decompress_mbps": 261.12
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.73,
-   "decompress_mbps": 259.52
+   "compress_mbps": 47.29,
+   "decompress_mbps": 271.97
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.33,
-   "decompress_mbps": 269.75
+   "compress_mbps": 45.92,
+   "decompress_mbps": 281.67
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.42,
-   "decompress_mbps": 276.8
+   "compress_mbps": 42.84,
+   "decompress_mbps": 290.38
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.26,
-   "decompress_mbps": 262.53
+   "compress_mbps": 13.17,
+   "decompress_mbps": 271.25
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.76,
-   "decompress_mbps": 262.3
+   "compress_mbps": 12.7,
+   "decompress_mbps": 273.44
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5169629,
    "ratio": 0.2393,
-   "compress_mbps": 1.3,
-   "decompress_mbps": 272.5
+   "compress_mbps": 1.32,
+   "decompress_mbps": 292.12
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.27,
-   "decompress_mbps": 103.73
+   "compress_mbps": 32.26,
+   "decompress_mbps": 112.57
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 106.56
+   "compress_mbps": 31.39,
+   "decompress_mbps": 115.91
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 29.6,
-   "decompress_mbps": 109.82
+   "compress_mbps": 29.86,
+   "decompress_mbps": 120.52
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.35,
-   "decompress_mbps": 113.5
+   "compress_mbps": 25.37,
+   "decompress_mbps": 124.38
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.91,
-   "decompress_mbps": 114.65
+   "compress_mbps": 24.86,
+   "decompress_mbps": 125.87
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.31,
-   "decompress_mbps": 116.63
+   "compress_mbps": 24.17,
+   "decompress_mbps": 128.28
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.17,
-   "decompress_mbps": 117.74
+   "compress_mbps": 6.22,
+   "decompress_mbps": 129.05
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.18,
-   "decompress_mbps": 118.64
+   "compress_mbps": 6.19,
+   "decompress_mbps": 128.69
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.58,
-   "decompress_mbps": 118.66
+   "compress_mbps": 1.56,
+   "decompress_mbps": 129.92
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 49.56,
-   "decompress_mbps": 163.2
+   "compress_mbps": 50.48,
+   "decompress_mbps": 166.33
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 45.83,
-   "decompress_mbps": 176.19
+   "compress_mbps": 46.38,
+   "decompress_mbps": 179.47
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 188.83
+   "compress_mbps": 43.66,
+   "decompress_mbps": 192.51
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.72,
-   "decompress_mbps": 197.7
+   "compress_mbps": 36.04,
+   "decompress_mbps": 201.68
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.48,
-   "decompress_mbps": 204.93
+   "compress_mbps": 34.56,
+   "decompress_mbps": 209.1
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 210.43
+   "compress_mbps": 31.49,
+   "decompress_mbps": 214.99
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.65,
-   "decompress_mbps": 210.0
+   "compress_mbps": 11.6,
+   "decompress_mbps": 214.38
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.44,
-   "decompress_mbps": 210.6
+   "compress_mbps": 11.48,
+   "decompress_mbps": 214.7
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.21,
-   "decompress_mbps": 211.67
+   "compress_mbps": 1.22,
+   "decompress_mbps": 214.25
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 32.78,
-   "decompress_mbps": 67.21
+   "compress_mbps": 32.28,
+   "decompress_mbps": 69.53
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.43,
-   "decompress_mbps": 71.75
+   "compress_mbps": 32.6,
+   "decompress_mbps": 75.1
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 75.68
+   "compress_mbps": 32.47,
+   "decompress_mbps": 79.31
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.89,
-   "decompress_mbps": 74.28
+   "compress_mbps": 30.64,
+   "decompress_mbps": 78.07
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.88,
-   "decompress_mbps": 76.12
+   "compress_mbps": 30.8,
+   "decompress_mbps": 78.86
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 77.38
+   "compress_mbps": 30.65,
+   "decompress_mbps": 80.46
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.73,
-   "decompress_mbps": 78.1
+   "compress_mbps": 4.67,
+   "decompress_mbps": 81.53
   },
   {
    "compressor": "native",
@@ -4945,7 +4945,7 @@
    "out_size": 6278507,
    "ratio": 0.7409,
    "compress_mbps": 4.69,
-   "decompress_mbps": 77.08
+   "decompress_mbps": 82.42
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.69,
-   "decompress_mbps": 77.5
+   "compress_mbps": 1.67,
+   "decompress_mbps": 82.03
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 96.77,
-   "decompress_mbps": 312.8
+   "compress_mbps": 96.61,
+   "decompress_mbps": 319.69
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 86.89,
-   "decompress_mbps": 366.86
+   "compress_mbps": 87.11,
+   "decompress_mbps": 354.03
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 77.59,
-   "decompress_mbps": 393.73
+   "compress_mbps": 77.53,
+   "decompress_mbps": 394.02
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 64.74,
-   "decompress_mbps": 378.86
+   "compress_mbps": 64.47,
+   "decompress_mbps": 385.23
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.92,
-   "decompress_mbps": 406.24
+   "compress_mbps": 62.35,
+   "decompress_mbps": 427.02
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 58.44,
-   "decompress_mbps": 450.19
+   "compress_mbps": 57.84,
+   "decompress_mbps": 460.74
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.51,
-   "decompress_mbps": 470.1
+   "compress_mbps": 21.59,
+   "decompress_mbps": 475.93
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 19.98,
-   "decompress_mbps": 475.29
+   "compress_mbps": 20.37,
+   "decompress_mbps": 487.3
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 637424,
    "ratio": 0.1192,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 513.93
+   "compress_mbps": 0.98,
+   "decompress_mbps": 481.02
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR computes the dynamic-block code-length Kraft check (`HuffTree.validateLengths`, run per dynamic Huffman block by the tree-free `decodeDynamicLengthsOnly`) from the per-length `count` histogram (`countLengthsFast` — the same array the canonical table build already needs) via a new allocation-free `O(maxBits)` fold `kraftSumFast`, replacing the per-block `lengths.toList.map`/`filter` `List` of up to 320 boxed `Nat`s that `fromLengths` allocates. The over-bound check stays a plain `Array.any`; no tree is built. This removes a per-dynamic-block allocation regression versus the intent of https://github.com/kim-em/lean-zip/issues/2682, on the header-setup path.

The `validateLengths` ↔ `fromLengths` correspondence is re-proven against the count-array form without weakening any statement: `validate_kraft_eq` certifies that the count-histogram Kraft sum equals the filtered-list Kraft sum on every length set with no over-bound length, resting on a new `Huffman.Spec.kraftSumFrom_zero_eq_foldl` factored out of the existing `kraftSumFrom_eq_kraft_foldl` (the Kraft-sum-over-count = Kraft-sum-over-filtered-list identity). `kraftSumFast` is bridged to the spec recurrence `kraftSumFrom` by `kraftSumFast_go_eq` / `kraftSumFast_eq`. `fromLengths_eq_validate` and every downstream lemma (`validateLengths_ok_iff_fromLengths`, `validateLengths_valid`, ...) keep their statements, so the proven accept-set is unchanged. Full build and `lake exe test` pass with no `sorry`s.

Sharing the single `countLengthsFast` result across validate and the table build (the issue's "ideally" follow-up) is left out: the table is built later in a different function (`decodeHuffmanFastBufTreeFree`), and threading the array across that boundary would touch verified signatures for a second cheap `O(n)` array pass. The large per-block `List` allocation — the actual regression — is gone either way.

Closes https://github.com/kim-em/lean-zip/issues/2686

🤖 Prepared with Claude Code