### PR TITLE
perf(decode): widen the root decode table to 11 bits (Phase 5 of #2668)

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -135,8 +135,11 @@ up to 15) fall back to the tree walk. `decode` stays the canonical spec;
 `decodeWithTable_eq`) and the fast block loop `decodeHuffmanFast` is proven
 equal to `decodeHuffman` — there is no `@[implemented_by]` trust gap. -/
 
-/-- Number of bits the fast decode table indexes on (the common "fast bits"). -/
-def fastBits : Nat := 9
+/-- Number of bits the fast decode table indexes on (the common "fast bits").
+    Widened to libdeflate's `LITLEN_TABLEBITS = 11`: fewer codewords spill to the
+    slow/subtable path, and the canonical O(2^bits) table build (#2671) keeps the
+    wider table cheap to construct. -/
+def fastBits : Nat := 11
 
 /-- Walk `tree` using the low bits of `idx` (LSB first, matching `readBit`),
     for up to `fastBits` steps. Returns `(symbol, codeLen)` if a leaf is reached
@@ -411,12 +414,15 @@ def bitsAvail (br : BitReader) : Nat :=
   if br.pos ≥ br.data.size then 0 else (br.data.size - br.pos) * 8 - br.bitOff
 
 /-- Peek the next `fastBits` bits at `(pos, bitOff)`, LSB-first, without
-    consuming. Bytes past the end of the stream read as zero; the caller uses
-    `bitsAvail` to decide whether the looked-up code actually fits. -/
+    consuming. Reads 3 bytes: a `≤ 7`-bit `bitOff` plus the 11-bit window spans
+    bits `0 … 17`, so three bytes (bits `0 … 23`) always cover it. Bytes past the
+    end of the stream read as zero; the caller uses `bitsAvail` to decide whether
+    the looked-up code actually fits. -/
 def peekFast (br : BitReader) : UInt32 :=
   let b0 : UInt32 := if br.pos < br.data.size then br.data[br.pos]!.toUInt32 else 0
   let b1 : UInt32 := if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toUInt32 else 0
-  ((b0 ||| (b1 <<< 8)) >>> br.bitOff.toUInt32) &&& 0x1FF
+  let b2 : UInt32 := if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toUInt32 else 0
+  ((b0 ||| (b1 <<< 8) ||| (b2 <<< 16)) >>> br.bitOff.toUInt32) &&& 0x7FF
 
 /-- Table-driven single-symbol decode. Peeks `fastBits` bits, reads the
     `(symbol, codeLen)` from `table`, and consumes `codeLen` bits in one step.
@@ -831,12 +837,12 @@ theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size 
 /-- The inline-literal guard read in `USize` matches the `Nat` guard (the length
     field round-trips since it is a `UInt8`). -/
 theorem litGuard_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : USize) :
-    ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-        ∧ ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize ≤ cnt
-        ∧ table.symAt (bitBuf &&& 0x1FF).toNat < 256)
-      ↔ ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-        ∧ (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt.toNat
-        ∧ table.symAt (bitBuf &&& 0x1FF).toNat < 256) := by
+    ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+        ∧ ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
+        ∧ table.symAt (bitBuf &&& 0x7FF).toNat < 256)
+      ↔ ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+        ∧ (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat
+        ∧ table.symAt (bitBuf &&& 0x7FF).toNat < 256) := by
   rw [USize.le_iff_toNat_le, toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)]
 
 /-- Load whole bytes into the high end of `bitBuf` until it holds > 56 bits or
@@ -850,7 +856,7 @@ termination_by data.size - pos
 decreasing_by simp_wf; omega
 
 /-- Bit-by-bit tree walk over the buffer (fallback for codes longer than the
-    9-bit table or near end-of-input). Mirrors `HuffTree.decode.go` exactly
+    11-bit table or near end-of-input). Mirrors `HuffTree.decode.go` exactly
     (same `depth > 20` guard, same error strings), so it is provably equal;
     `depth` is the tree-walk depth. Returns the symbol, the remaining buffer,
     and the number of bits consumed. -/
@@ -867,12 +873,12 @@ def walkTree (t : HuffTree) (bitBuf : UInt64) (cnt depth : Nat) :
       | .error e => .error e
       | .ok (s, bb, c, used) => .ok (s, bb, c, used + 1)
 
-/-- Decode one Huffman symbol from the (refilled) buffer via the 9-bit table,
+/-- Decode one Huffman symbol from the (refilled) buffer via the 11-bit table,
     falling back to the tree walk for long codes / near EOF. Returns the symbol,
     remaining buffer state, and bits consumed. -/
 @[inline] def decodeSym (tree : HuffTree) (table : HuffTree.DecodeTable)
     (bitBuf : UInt64) (cnt : Nat) : Except String (UInt16 × UInt64 × Nat × Nat) :=
-  let idx := (bitBuf &&& 0x1FF).toNat
+  let idx := (bitBuf &&& 0x7FF).toNat
   let len := (table.lenAt idx).toNat
   if len == 0 || len > cnt then walkTree tree bitBuf cnt 0
   else .ok (table.symAt idx, bitBuf >>> len.toUInt64, cnt - len, len)
@@ -1032,15 +1038,15 @@ def goFusedP (litTable distTable : HuffTree.DecodeTable)
     goFusedP litTable distTable data litTree distTree maxOut
       (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-      ∧ (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+      ∧ (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goFusedP litTable distTable data litTree distTree maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
-        (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)
-        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
+        (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat)
+        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
   else
   let cnt0 := cnt
   match decodeSym litTree litTable bitBuf cnt with
@@ -1112,16 +1118,16 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
       (cnt + 8) hsz output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-      ∧ ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+      ∧ ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goFusedPU litTable distTable data litTree distTree maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
-        (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
+        (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize)
         hsz
-        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
+        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
   else
   let cnt0 := cnt.toNat
   match decodeSym litTree litTable bitBuf cnt.toNat with
@@ -1183,13 +1189,13 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
       rw [hpa, hca]; omega
     · -- inline literal: cnt drops by len ≥ 1
       obtain ⟨hne, hle, _⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
         toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hle, hlen]
-      have hlecnt : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt.toNat :=
+      have hlecnt : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat :=
         hlen ▸ USize.le_iff_toNat_le.mp hle
       rw [hsub]; omega
     · -- slow literal: cnt' < cnt0 = cnt.toNat from the no-progress guard

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -4,8 +4,8 @@ import Zip.Native.Inflate
 # Tree-free canonical decode — the production DEFLATE decoder
 
 This file defines the **production** decoders `Inflate.inflate` / `inflateRaw`: a
-DEFLATE Huffman decode that builds **no** Huffman tree. The fast ≤9-bit codes go
-through the canonical 9-bit table (`buildTableCanonicalFast`), and the rare >9-bit
+DEFLATE Huffman decode that builds **no** Huffman tree. The fast ≤11-bit codes go
+through the canonical 11-bit table (`buildTableCanonicalFast`), and the rare >11-bit
 codes go through a canonical bit-by-bit decode keyed off the per-length
 `count` / `firstCode` / sorted-symbol arrays — never a tree walk. This skips the
 `fromLengths`/`insertLoop` build entirely (the ~7% decode win).
@@ -29,7 +29,7 @@ open ZipCommon (BitReader)
 
 namespace HuffTree
 
-/-- Canonical long-code decode tables (for codes longer than the 9-bit window):
+/-- Canonical long-code decode tables (for codes longer than the 11-bit window):
     `count[len]` codes of each length, `firstCode[len]` the first canonical code
     of that length, `firstIndex[len]` the offset into `symbols` (symbols sorted by
     `(length, symbol)`). -/
@@ -104,7 +104,7 @@ where
 /-- `decodeSym` with the canonical long-code fallback (no tree). -/
 @[inline] def decodeSymCanon (ld : LongDecode) (table : DecodeTable) (maxBits : Nat)
     (bitBuf : UInt64) (cnt : Nat) : Except String (UInt16 × UInt64 × Nat × Nat) :=
-  let idx := (bitBuf &&& 0x1FF).toNat
+  let idx := (bitBuf &&& 0x7FF).toNat
   let len := (table.lenAt idx).toNat
   if len == 0 || len > cnt then walkCanonical ld maxBits bitBuf cnt
   else .ok (table.symAt idx, bitBuf >>> len.toUInt64, cnt - len, len)
@@ -124,15 +124,15 @@ def goTreeFree (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
     goTreeFree litTable distTable litLD distLD maxBits data maxOut
       (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-      ∧ (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+      ∧ (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goTreeFree litTable distTable litLD distLD maxBits data maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
-        (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)
-        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
+        (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat)
+        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
   else
   let cnt0 := cnt
   match decodeSymCanon litLD litTable maxBits bitBuf cnt with
@@ -194,16 +194,16 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
       (cnt + 8) hsz output
   else
-  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-      ∧ ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize ≤ cnt
-      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+      ∧ ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goTreeFreeU litTable distTable litLD distLD maxBits data maxOut pos
-        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
-        (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
+        (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize)
         hsz
-        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
+        (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8)
   else
   let cnt0 := cnt.toNat
   match decodeSymCanon litLD litTable maxBits bitBuf cnt.toNat with
@@ -264,13 +264,13 @@ def goTreeFreeU (litTable distTable : DecodeTable) (litLD distLD : LongDecode)
         rw [USize.toNat_add, h8]; apply Nat.mod_eq_of_lt; omega
       rw [hpa, hca]; omega
     · obtain ⟨hne, hle, _⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
         toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hle, hlen]
-      have hlecnt : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt.toNat :=
+      have hlecnt : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt.toNat :=
         hlen ▸ USize.le_iff_toNat_le.mp hle
       rw [hsub]; omega
     · have hcsz : cnt.toNat < USize.size := cnt.toNat_lt_two_pow_numBits

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -215,36 +215,36 @@ theorem mask_lt {bitBuf : UInt64} {n : Nat} (hn64 : n < 64) :
   exact Nat.mod_lt _ (Nat.two_pow_pos n)
 
 open HuffTree in
-/-- `peekFast` is `(_ &&& 0x1FF)`, so its value is `< 512`. -/
-theorem peekFast_lt (br : BitReader) : (peekFast br).toNat < 512 := by
+/-- `peekFast` is `(_ &&& 0x7FF)`, so its value is `< 2048`. -/
+theorem peekFast_lt (br : BitReader) : (peekFast br).toNat < 2048 := by
   simp only [peekFast, UInt32.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
 
 open HuffTree in
-/-- **9-bit table peek matches `peekFast`** when the buffer holds ≥ 9 bits (the
-    common, non-EOF case). Both index the same 9 stream bits at the cursor. -/
+/-- **11-bit table peek matches `peekFast`** when the buffer holds ≥ 11 bits (the
+    common, non-EOF case). Both index the same 11 stream bits at the cursor. -/
 theorem peek_eq {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : UInt64} {cnt : Nat}
     (h : BufCorr data br.bitPos pos bitBuf cnt) (hwf : br.bitOff < 8) (hdata : br.data = data)
-    (hcnt : 9 ≤ cnt) :
-    (bitBuf &&& 0x1FF).toNat = (peekFast br).toNat := by
-  have h9 : (0x1FF : UInt64) = (1 <<< (9 : Nat).toUInt64) - 1 := by decide
+    (hcnt : 11 ≤ cnt) :
+    (bitBuf &&& 0x7FF).toNat = (peekFast br).toNat := by
+  have h9 : (0x7FF : UInt64) = (1 <<< (11 : Nat).toUInt64) - 1 := by decide
   have hbp : br.bitPos = br.pos * 8 + br.bitOff := rfl
   apply Nat.eq_of_testBit_eq
   intro j
-  by_cases hj9 : j < 9
-  · have hbuf : (bitBuf &&& 0x1FF).toNat.testBit j = streamBit data (br.bitPos + j) := by
+  by_cases hj9 : j < 11
+  · have hbuf : (bitBuf &&& 0x7FF).toNat.testBit j = streamBit data (br.bitPos + j) := by
       rw [h9]; exact mask_testBit h (by omega) (by omega) hj9
     have hin : br.pos * 8 + br.bitOff + j < br.data.size * 8 := by
       have hs := h.span; have hp := h.posLe; rw [hdata, ← hbp]; omega
     rw [hbuf, peekFast_testBit br j hwf (by simp only [fastBits]; omega) hin]
     simp only [streamBit, ← hbp, hdata]
-  · have h2j : (512 : Nat) ≤ 2 ^ j := by
-      calc (512 : Nat) = 2 ^ 9 := by decide
+  · have h2j : (2048 : Nat) ≤ 2 ^ j := by
+      calc (2048 : Nat) = 2 ^ 11 := by decide
         _ ≤ 2 ^ j := Nat.pow_le_pow_right (by omega) (by omega)
-    have hbuf : (bitBuf &&& 0x1FF).toNat.testBit j = false := by
+    have hbuf : (bitBuf &&& 0x7FF).toNat.testBit j = false := by
       apply Nat.testBit_lt_two_pow
       rw [h9]; exact Nat.lt_of_lt_of_le (mask_lt (by omega)) (by
-        calc (2 : Nat) ^ 9 ≤ 2 ^ j := Nat.pow_le_pow_right (by omega) (by omega))
+        calc (2 : Nat) ^ 11 ≤ 2 ^ j := Nat.pow_le_pow_right (by omega) (by omega))
     rw [hbuf, Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le (peekFast_lt br) h2j)]
 
 /-- A `BitReader`'s bit-list view is the stream from its cursor. -/
@@ -406,12 +406,12 @@ theorem takeBits_corr {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : 
       rw [show br.readBits n = BitReader.readBits.go br 0 0 n from rfl, hok] at h'
       exact absurd h' (by simp)
 
-/-- The buffer's 9-bit table index, bit by bit: the stream bit while `j < cnt`,
+/-- The buffer's 11-bit table index, bit by bit: the stream bit while `j < cnt`,
     else 0 (works for any `cnt`, unlike `mask_testBit`). -/
-theorem peek9_buf_testBit {data : ByteArray} {bitpos pos : Nat} {bitBuf : UInt64} {cnt : Nat}
-    (h : BufCorr data bitpos pos bitBuf cnt) (j : Nat) (hj : j < 9) :
-    (bitBuf &&& 0x1FF).toNat.testBit j = if j < cnt then streamBit data (bitpos + j) else false := by
-  rw [UInt64.toNat_and, show (0x1FF : UInt64).toNat = 2 ^ 9 - 1 from by decide,
+theorem peek11_buf_testBit {data : ByteArray} {bitpos pos : Nat} {bitBuf : UInt64} {cnt : Nat}
+    (h : BufCorr data bitpos pos bitBuf cnt) (j : Nat) (hj : j < 11) :
+    (bitBuf &&& 0x7FF).toNat.testBit j = if j < cnt then streamBit data (bitpos + j) else false := by
+  rw [UInt64.toNat_and, show (0x7FF : UInt64).toNat = 2 ^ 11 - 1 from by decide,
     Nat.and_two_pow_sub_one_eq_mod, Nat.testBit_mod_two_pow]
   simp only [hj, decide_true, Bool.true_and]
   split
@@ -423,11 +423,11 @@ open HuffTree in
 /-- **`peekFast` past end-of-stream reads 0.** The mirror of `peekFast_testBit`
     for bit positions at or beyond `data.size * 8`: the contributing byte is out
     of range, so the bit is 0. -/
-theorem peekFast_testBit_eof (br : BitReader) (j : Nat) (hwf : br.bitOff < 8) (hj : j < 9)
+theorem peekFast_testBit_eof (br : BitReader) (j : Nat) (hwf : br.bitOff < 8) (hj : j < 11)
     (hge : br.data.size * 8 ≤ br.pos * 8 + br.bitOff + j) :
     (peekFast br).toNat.testBit j = false := by
-  have hmask : (0x1FF : UInt32).toNat.testBit j = true := by
-    rw [show (0x1FF : UInt32).toNat = 2 ^ 9 - 1 from by decide, Nat.testBit_two_pow_sub_one]
+  have hmask : (0x7FF : UInt32).toNat.testBit j = true := by
+    rw [show (0x7FF : UInt32).toNat = 2 ^ 11 - 1 from by decide, Nat.testBit_two_pow_sub_one]
     simp only [decide_eq_true_eq]; omega
   have hshift : br.bitOff.toUInt32.toNat % 32 = br.bitOff := by
     simp only [Nat.toUInt32, UInt32.ofNat, UInt32.toNat, BitVec.toNat_ofNat, Nat.reducePow]; omega
@@ -441,6 +441,11 @@ theorem peekFast_testBit_eof (br : BitReader) (j : Nat) (hwf : br.bitOff < 8) (h
     split
     · rw [UInt8.toNat_toUInt32]
     · rfl
+  have hb2eq : (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toUInt32 else (0 : UInt32)).toNat
+      = (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toNat else 0) := by
+    split
+    · rw [UInt8.toNat_toUInt32]
+    · rfl
   have hb1lt : (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toNat else 0) < 256 := by
     split
     · have := UInt8.toNat_lt br.data[br.pos + 1]!; omega
@@ -449,42 +454,71 @@ theorem peekFast_testBit_eof (br : BitReader) (j : Nat) (hwf : br.bitOff < 8) (h
     split
     · have := UInt8.toNat_lt br.data[br.pos]!; omega
     · decide
+  have hb2lt : (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toNat else 0) < 256 := by
+    split
+    · have := UInt8.toNat_lt br.data[br.pos + 2]!; omega
+    · decide
   -- byte-out-of-range facts, derived while the context still has plain `br.bitOff`
   have hbyte : (br.bitOff + j < 8 → br.data.size ≤ br.pos)
-      ∧ (8 ≤ br.bitOff + j → br.data.size ≤ br.pos + 1) := by
-    constructor <;> intro h8 <;> omega
+      ∧ (8 ≤ br.bitOff + j → br.bitOff + j < 16 → br.data.size ≤ br.pos + 1)
+      ∧ (16 ≤ br.bitOff + j → br.data.size ≤ br.pos + 2) :=
+    ⟨fun _ => by omega, fun _ _ => by omega, fun _ => by omega⟩
   unfold peekFast
   rw [UInt32.toNat_and, Nat.testBit_and, UInt32.toNat_shiftRight, Nat.testBit_shiftRight,
-    hmask, Bool.and_true, hshift, UInt32.toNat_or, Nat.testBit_or, hb0eq,
+    hmask, Bool.and_true, hshift, UInt32.toNat_or, UInt32.toNat_or, Nat.testBit_or,
+    Nat.testBit_or, hb0eq,
     UInt32.toNat_shiftLeft, show (8 : UInt32).toNat % 32 = 8 from by decide, hb1eq,
     Nat.mod_eq_of_lt (by rw [Nat.shiftLeft_eq, show (2 : Nat) ^ 8 = 256 from by decide,
       show (2 : Nat) ^ 32 = 4294967296 from by decide]; omega),
-    Nat.testBit_shiftLeft]
+    UInt32.toNat_shiftLeft, show (16 : UInt32).toNat % 32 = 16 from by decide, hb2eq,
+    Nat.mod_eq_of_lt (by rw [Nat.shiftLeft_eq, show (2 : Nat) ^ 16 = 65536 from by decide,
+      show (2 : Nat) ^ 32 = 4294967296 from by decide]; omega),
+    Nat.testBit_shiftLeft, Nat.testBit_shiftLeft]
   by_cases hlo : br.bitOff + j < 8
-  · -- byte `pos` holds the bit, but it is out of range (pos ≥ size); `b1<<8` vanishes
-    rw [if_neg (Nat.not_lt.mpr (hbyte.1 hlo)),
-      show decide (br.bitOff + j ≥ 8) = false from by
-        simp only [decide_eq_false_iff_not]; exact Nat.not_le.mpr hlo]
-    simp
-  · -- `b0`'s bit is past its 8-bit width (false); byte `pos+1` is out of range
-    have h8 : 8 ≤ br.bitOff + j := Nat.not_lt.mp hlo
-    have h256 : (256 : Nat) ≤ 2 ^ (br.bitOff + j) := by
-      calc (256 : Nat) = 2 ^ 8 := by decide
-        _ ≤ 2 ^ (br.bitOff + j) := Nat.pow_le_pow_right (by omega) h8
-    rw [show (if br.pos < br.data.size then br.data[br.pos]!.toNat else 0).testBit (br.bitOff + j) = false from
-        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hb0lt h256),
-      if_neg (Nat.not_lt.mpr (hbyte.2 h8))]
-    simp
+  · -- byte `pos` holds the bit, but it is out of range (pos ≥ size); high bytes vanish
+    have e8 : decide (br.bitOff + j ≥ 8) = false := by simp only [decide_eq_false_iff_not]; omega
+    have e16 : decide (br.bitOff + j ≥ 16) = false := by simp only [decide_eq_false_iff_not]; omega
+    rw [if_neg (Nat.not_lt.mpr (hbyte.1 hlo))]
+    simp only [e8, e16, Bool.false_and, Bool.or_false, Nat.zero_testBit]
+  · by_cases hmid : br.bitOff + j < 16
+    · -- byte `pos`'s bit is past its width; byte `pos+1` is out of range
+      have h8 : 8 ≤ br.bitOff + j := Nat.not_lt.mp hlo
+      have hb0f : (if br.pos < br.data.size then br.data[br.pos]!.toNat else 0).testBit
+            (br.bitOff + j) = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hb0lt (by
+          calc (256 : Nat) = 2 ^ 8 := by decide
+            _ ≤ 2 ^ (br.bitOff + j) := Nat.pow_le_pow_right (by omega) h8))
+      have e8 : decide (br.bitOff + j ≥ 8) = true := by simp only [decide_eq_true_eq]; omega
+      have e16 : decide (br.bitOff + j ≥ 16) = false := by simp only [decide_eq_false_iff_not]; omega
+      rw [if_neg (Nat.not_lt.mpr (hbyte.2.1 h8 hmid))]
+      simp only [hb0f, e8, e16, Bool.true_and, Bool.false_and, Bool.false_or, Bool.or_false,
+        Nat.zero_testBit]
+    · -- bytes `pos`, `pos+1` contribute no bit; byte `pos+2` is out of range
+      have h16 : 16 ≤ br.bitOff + j := Nat.not_lt.mp hmid
+      have hb0f : (if br.pos < br.data.size then br.data[br.pos]!.toNat else 0).testBit
+            (br.bitOff + j) = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hb0lt (by
+          calc (256 : Nat) = 2 ^ 8 := by decide
+            _ ≤ 2 ^ (br.bitOff + j) := Nat.pow_le_pow_right (by omega) (by omega)))
+      have hb1f : (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toNat else 0).testBit
+            (br.bitOff + j - 8) = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hb1lt (by
+          calc (256 : Nat) = 2 ^ 8 := by decide
+            _ ≤ 2 ^ (br.bitOff + j - 8) := Nat.pow_le_pow_right (by omega) (by omega)))
+      have e8 : decide (br.bitOff + j ≥ 8) = true := by simp only [decide_eq_true_eq]; omega
+      have e16 : decide (br.bitOff + j ≥ 16) = true := by simp only [decide_eq_true_eq]; omega
+      rw [if_neg (Nat.not_lt.mpr (hbyte.2.2 h16))]
+      simp only [hb0f, hb1f, e8, e16, Bool.true_and, Bool.false_or, Nat.zero_testBit]
 
 open HuffTree in
-/-- **9-bit table peek = `peekFast`, including end-of-stream.** Under the
-    post-`refill` condition (`56 < cnt`, i.e. ≥ 9 bits, or input exhausted),
+/-- **11-bit table peek = `peekFast`, including end-of-stream.** Under the
+    post-`refill` condition (`56 < cnt`, i.e. ≥ 11 bits, or input exhausted),
     the wide-buffer index equals `peekFast`'s — matching even the zero-padded
     high bits past the end of the stream. -/
 theorem peek_eq_refilled {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : UInt64} {cnt : Nat}
     (h : BufCorr data br.bitPos pos bitBuf cnt) (hwf : br.bitOff < 8) (hdata : br.data = data)
-    (hr : 8 < cnt ∨ pos = data.size) :
-    (bitBuf &&& 0x1FF).toNat = (peekFast br).toNat := by
+    (hr : 10 < cnt ∨ pos = data.size) :
+    (bitBuf &&& 0x7FF).toNat = (peekFast br).toNat := by
   rcases hr with hc | hpos
   · exact peek_eq h hwf hdata (by omega)
   · have hbp : br.bitPos = br.pos * 8 + br.bitOff := rfl
@@ -492,8 +526,8 @@ theorem peek_eq_refilled {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf
     have hsp := h.span
     apply Nat.eq_of_testBit_eq
     intro j
-    by_cases hj9 : j < 9
-    · rw [peek9_buf_testBit h j hj9]
+    by_cases hj9 : j < 11
+    · rw [peek11_buf_testBit h j hj9]
       split
       · rename_i hjc
         have hin : br.pos * 8 + br.bitOff + j < br.data.size * 8 := by omega
@@ -502,10 +536,10 @@ theorem peek_eq_refilled {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf
       · rename_i hjc
         have hge : br.data.size * 8 ≤ br.pos * 8 + br.bitOff + j := by omega
         rw [peekFast_testBit_eof br j hwf hj9 hge]
-    · have h2j : (512 : Nat) ≤ 2 ^ j := by
-        calc (512 : Nat) = 2 ^ 9 := by decide
+    · have h2j : (2048 : Nat) ≤ 2 ^ j := by
+        calc (2048 : Nat) = 2 ^ 11 := by decide
           _ ≤ 2 ^ j := Nat.pow_le_pow_right (by omega) (by omega)
-      have hb : (bitBuf &&& 0x1FF).toNat.testBit j = false :=
+      have hb : (bitBuf &&& 0x7FF).toNat.testBit j = false :=
         Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le
           (by rw [UInt64.toNat_and]; exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)) h2j)
       rw [hb, Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le (peekFast_lt br) h2j)]
@@ -730,7 +764,7 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
     {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : UInt64} {cnt : Nat}
     (h : BufCorr data br.bitPos pos bitBuf cnt) (hwf : br.bitOff < 8) (hdata : br.data = data)
     (hr : 21 < cnt ∨ pos = data.size)
-    (hlen : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ 9) (hdep : treeDepthLE tree 15) :
+    (hlen : (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ 11) (hdep : treeDepthLE tree 15) :
     match HuffTree.decodeWithTable tree table br, decodeSym tree table bitBuf cnt with
     | .error e1, .error e2 => e1 = e2
     | .ok (s1, br'), .ok (s2, bb, c, used) =>
@@ -746,7 +780,7 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
     by_cases hpe : br.pos ≥ br.data.size
     · rw [if_pos hpe]; exact ⟨by omega, fun _ => by omega⟩
     · rw [if_neg hpe]; exact ⟨by omega, fun hh => by subst hh; omega⟩
-  have hidx : (bitBuf &&& 0x1FF).toNat = (peekFast br).toNat :=
+  have hidx : (bitBuf &&& 0x7FF).toNat = (peekFast br).toNat :=
     peek_eq_refilled h hwf hdata (hr.imp (fun hc => by omega) id)
   rw [hidx] at hlen
   unfold HuffTree.decodeWithTable decodeSym
@@ -755,7 +789,7 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
   -- generalize the packed table's len/sym projections of this slot
   generalize hlenv : table.lenAt (peekFast br).toNat = lenB at hlen ⊢
   generalize hsymv : table.symAt (peekFast br).toNat = symV
-  -- the two guards have the same truth value (cnt vs bitsAvail, with len ≤ 9)
+  -- the two guards have the same truth value (cnt vs bitsAvail, with len ≤ 11)
   have hgd : (lenB.toNat == 0 || decide (lenB.toNat > HuffTree.bitsAvail br))
            = (lenB.toNat == 0 || decide (lenB.toNat > cnt)) := by
     rcases hr with hc | hpe
@@ -784,20 +818,20 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
     have hbpe : ({ br with pos := br.pos + (br.bitOff + lenB.toNat) / 8, bitOff := (br.bitOff + lenB.toNat) % 8 } : BitReader).bitPos = br.bitPos + lenB.toNat := by simp only [BitReader.bitPos]; omega
     exact ⟨rfl, hbpe.symm ▸ hcc, hdata, Nat.mod_lt _ (by decide), Nat.sub_le cnt _, by omega⟩
 
-/-- Every `buildTable` entry's code length is at most `fastBits = 9`
+/-- Every `buildTable` entry's code length is at most `fastBits = 11`
     (the table walk stops at `fastBits`, or returns the `0` sentinel). -/
 theorem buildTable_codeLen_le (tree : HuffTree) (idx : Nat) (hidx : idx < 2 ^ HuffTree.fastBits) :
-    (tree.buildTable.lenAt idx).toNat ≤ 9 := by
+    (tree.buildTable.lenAt idx).toNat ≤ 11 := by
   rw [HuffTree.buildTable_lenAt tree idx hidx, HuffTree.tableEntry]
   rcases hg : HuffTree.tableEntry.go tree idx 0 with ⟨sym, lenB⟩
-  show lenB.toNat ≤ 9
+  show lenB.toNat ≤ 11
   by_cases hp : 0 < lenB.toNat
   · have := HuffTree.tableEntry_go_len_le tree idx 0 sym lenB hg (by simp [HuffTree.fastBits]) hp
     simp only [HuffTree.fastBits] at this; omega
   · omega
 
-/-- The 9-bit buffer index is `< 2^fastBits`. -/
-theorem buf_idx_lt (bitBuf : UInt64) : (bitBuf &&& 0x1FF).toNat < 2 ^ HuffTree.fastBits := by
+/-- The 11-bit buffer index is `< 2^fastBits`. -/
+theorem buf_idx_lt (bitBuf : UInt64) : (bitBuf &&& 0x7FF).toNat < 2 ^ HuffTree.fastBits := by
   simp only [HuffTree.fastBits]
   rw [UInt64.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
@@ -821,13 +855,16 @@ open HuffTree in
     equals `Inflate.decodeHuffmanFastBR.go`: same output/error, and on success the
     final buffer corresponds to the final reader. `go` refills internally, so the
     only precondition is the buffer invariant. -/
-theorem go_corr (litTree distTree : HuffTree) (maxOut dataSize : Nat) {data : ByteArray}
-    (hldep : treeDepthLE litTree 15) (hddep : treeDepthLE distTree 15) :
+theorem go_corr (litTree distTree : HuffTree) (litTable distTable : HuffTree.DecodeTable)
+    (maxOut dataSize : Nat) {data : ByteArray}
+    (hldep : treeDepthLE litTree 15) (hddep : treeDepthLE distTree 15)
+    (hlitlen : ∀ bb : UInt64, (litTable.lenAt (bb &&& 0x7FF).toNat).toNat ≤ 11)
+    (hdistlen : ∀ bb : UInt64, (distTable.lenAt (bb &&& 0x7FF).toNat).toNat ≤ 11) :
     ∀ (br : BitReader) (output : ByteArray) (pos : Nat) (bitBuf : UInt64) (cnt : Nat),
     BufCorr data br.bitPos pos bitBuf cnt → br.bitOff < 8 → br.data = data →
-    match Inflate.decodeHuffmanFastBR.go litTree distTree maxOut litTree.buildTable distTree.buildTable
+    match Inflate.decodeHuffmanFastBR.go litTree distTree maxOut litTable distTable
             dataSize br output,
-          go litTree.buildTable distTree.buildTable data litTree distTree maxOut dataSize pos bitBuf cnt
+          go litTable distTable data litTree distTree maxOut dataSize pos bitBuf cnt
             br.bitPos output with
     | .error e1, .error e2 => e1 = e2
     | .ok (out1, br'), .ok (out2, _pos', bitBuf', cnt', bitpos') =>
@@ -843,14 +880,15 @@ theorem go_corr (litTree distTree : HuffTree) (maxOut dataSize : Nat) {data : By
     rcases hrf : refill data pos bitBuf cnt with ⟨pos1, bitBuf1, cnt1⟩
     obtain ⟨hbc1, hr1⟩ := refill_corr hbc hrf
     -- decodeSym ↔ decodeWithTable (literal symbol)
-    have hsy := decodeSym_corr' litTree hbc1 hwf hdata (hr1.imp (fun h => by omega) id) hldep
+    have hsy := decodeSym_corr litTree litTable hbc1 hwf hdata (hr1.imp (fun h => by omega) id)
+      (hlitlen _) hldep
     -- Split on the symbol decode BEFORE unfolding the loop bodies: while `go` is
     -- still an opaque application the goal contains no `decodeWithTable`/`decodeSym`
     -- subterm, so the `cases` does no `kabstract` over the giant inlined body. We
     -- unfold and reduce with targeted `rw` inside each branch instead.
-    cases hdwt : litTree.decodeWithTable litTree.buildTable br with
+    cases hdwt : litTree.decodeWithTable litTable br with
     | error e1 =>
-      cases hds2 : decodeSym litTree litTree.buildTable bitBuf1 cnt1 with
+      cases hds2 : decodeSym litTree litTable bitBuf1 cnt1 with
       | error e2 =>
         rw [hdwt, hds2] at hsy
         rw [Inflate.decodeHuffmanFastBR.go, InflateBuf.go, hrf]
@@ -861,7 +899,7 @@ theorem go_corr (litTree distTree : HuffTree) (maxOut dataSize : Nat) {data : By
       | ok p2 => rw [hdwt, hds2] at hsy; simp at hsy
     | ok p1 =>
       obtain ⟨sym, br₁⟩ := p1
-      cases hds2 : decodeSym litTree litTree.buildTable bitBuf1 cnt1 with
+      cases hds2 : decodeSym litTree litTable bitBuf1 cnt1 with
       | error e2 => rw [hdwt, hds2] at hsy; simp at hsy
       | ok p2 =>
         obtain ⟨symB, bb, c, used⟩ := p2
@@ -927,10 +965,10 @@ theorem go_corr (litTree distTree : HuffTree) (maxOut dataSize : Nat) {data : By
                   rcases hr1 with h56 | hp
                   · exact Or.inl (by omega)
                   · exact Or.inr hp
-                have htd := decodeSym_corr' distTree hbc3 hbo3 hbd3 hbud_d hddep
-                cases hXd : distTree.decodeWithTable distTree.buildTable br₂ with
+                have htd := decodeSym_corr distTree distTable hbc3 hbo3 hbd3 hbud_d (hdistlen _) hddep
+                cases hXd : distTree.decodeWithTable distTable br₂ with
                 | error e1 =>
-                  cases hYd : decodeSym distTree distTree.buildTable bb2 c2 with
+                  cases hYd : decodeSym distTree distTable bb2 c2 with
                   | error e2 =>
                     rw [hXd, hYd] at htd
                     rw [Inflate.decodeHuffmanFastBR.go, InflateBuf.go, hrf]
@@ -943,7 +981,7 @@ theorem go_corr (litTree distTree : HuffTree) (maxOut dataSize : Nat) {data : By
                   | ok q => rw [hXd, hYd] at htd; exact absurd htd (by simp)
                 | ok pd =>
                   obtain ⟨distSym, br₃⟩ := pd
-                  cases hYd : decodeSym distTree distTree.buildTable bb2 c2 with
+                  cases hYd : decodeSym distTree distTable bb2 c2 with
                   | error e2 => rw [hXd, hYd] at htd; exact absurd htd (by simp)
                   | ok q =>
                     obtain ⟨dsymB, bb3, c3, dused⟩ := q
@@ -1126,13 +1164,13 @@ theorem go_refill_step (litTable distTable : HuffTree.DecodeTable) (data : ByteA
     inline table read does it — near-definitional, the else branch of `decodeSym`. -/
 theorem decodeSym_inline (tree : HuffTree) (table : HuffTree.DecodeTable)
     (bitBuf : UInt64) (cnt : Nat)
-    (h0 : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0)
-    (hle : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt) :
+    (h0 : (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0)
+    (hle : (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt) :
     decodeSym tree table bitBuf cnt =
-      .ok (table.symAt (bitBuf &&& 0x1FF).toNat,
-        bitBuf >>> ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64,
-        cnt - (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat,
-        (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat) := by
+      .ok (table.symAt (bitBuf &&& 0x7FF).toNat,
+        bitBuf >>> ((table.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64,
+        cnt - (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat,
+        (table.lenAt (bitBuf &&& 0x7FF).toNat).toNat) := by
   unfold decodeSym
   simp only []
   rw [if_neg (by simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq]; omega)]
@@ -1226,11 +1264,11 @@ theorem goFusedP_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArra
           goFused, dif_neg hrc, decodeSym_inline litTree litTable bitBuf cnt hl0 hl1]
       simp only []
       rw [if_pos hl2, if_neg hmax,
-          dif_neg (show ¬ bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)) ≤ bp by omega),
-          dif_neg (show ¬ data.size * 8 < bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)) by
+          dif_neg (show ¬ bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat)) ≤ bp by omega),
+          dif_neg (show ¬ data.size * 8 < bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat)) by
             have : pos * 8 ≤ data.size * 8 := by omega
             omega)]
-      exact ih (bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat))) (by omega) (by omega)
+      exact ih (bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat))) (by omega) (by omega)
   | case4 pos bitBuf cnt output hrc hlit e hde =>
       intro bp hpos hbp
       rw [goFusedP, dif_neg hrc, dif_neg hlit, goFused, dif_neg hrc]
@@ -1467,11 +1505,11 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
   | case3 pos bitBuf cnt output hrc hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
         InflateBuf.toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hl1, hlen]
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),
@@ -1616,7 +1654,9 @@ theorem decodeHuffmanFastBuf_eq (br : BitReader) (output : ByteArray)
     · have hs := hbc1.span; rw [hpe] at hs; omega
   have hbc2 : BufCorr br.data br.bitPos pos0 (bitBuf0 >>> br.bitOff.toUInt64) (cnt0 - br.bitOff) :=
     consume_corr hbc1 hboff (by omega)
-  have hco := go_corr litTree distTree maxOut br.data.size hldep hddep br output pos0
+  have hco := go_corr litTree distTree litTree.buildTable distTree.buildTable maxOut br.data.size
+    hldep hddep (fun bb => buildTable_codeLen_le litTree _ (buf_idx_lt bb))
+    (fun bb => buildTable_codeLen_le distTree _ (buf_idx_lt bb)) br output pos0
     (bitBuf0 >>> br.bitOff.toUInt64) (cnt0 - br.bitOff) hbc2 hwf rfl
   unfold InflateBuf.decodeHuffmanFastBuf Inflate.decodeHuffmanFastBR
   rw [hrf]

--- a/Zip/Spec/InflateCanonical.lean
+++ b/Zip/Spec/InflateCanonical.lean
@@ -724,7 +724,7 @@ theorem buildTableCanonical_packed_getElem (lengths : Array UInt8) (maxBits : Na
     rw [Huffman.Spec.allCodes_mem_iff] at hmem
     exact hmatch ⟨s, cw, hmem.2, hlen, hcw⟩
 
-set_option maxRecDepth 4096 in
+set_option maxRecDepth 16384 in
 /-- **`buildTableCanonical_eq`.** The canonical O(n) decode-table build equals the
     tree-built decode table, under the validity envelope. Drop-in: every decode
     proof transferring through `buildTable` transfers through the canonical build. -/

--- a/Zip/Spec/InflateTable.lean
+++ b/Zip/Spec/InflateTable.lean
@@ -133,22 +133,22 @@ theorem peekFast_testBit (br : BitReader) (j : Nat)
         ((br.pos * 8 + br.bitOff + j) % 8) := by
   have hpos : br.pos < br.data.size := by omega
   simp only [fastBits] at hj
-  have hmask : (0x1FF : UInt32).toNat.testBit j = true := by
-    rw [show (0x1FF : UInt32).toNat = 2 ^ 9 - 1 from by decide, Nat.testBit_two_pow_sub_one]
+  have hmask : (0x7FF : UInt32).toNat.testBit j = true := by
+    rw [show (0x7FF : UInt32).toNat = 2 ^ 11 - 1 from by decide, Nat.testBit_two_pow_sub_one]
     simp only [decide_eq_true_eq]; omega
   have hshift : br.bitOff.toUInt32.toNat % 32 = br.bitOff := by
     simp only [Nat.toUInt32, UInt32.ofNat, UInt32.toNat, BitVec.toNat_ofNat, Nat.reducePow]
     omega
-  unfold peekFast
-  -- Reduce to a single-bit query on the 16-bit window `b0 ||| (b1 <<< 8)`.
-  rw [UInt32.toNat_and, Nat.testBit_and, UInt32.toNat_shiftRight, Nat.testBit_shiftRight,
-    hmask, Bool.and_true, hshift, UInt32.toNat_or, Nat.testBit_or,
-    show (if br.pos < br.data.size then br.data[br.pos]!.toUInt32 else (0 : UInt32)).toNat
-        = br.data[br.pos]!.toNat from by rw [if_pos hpos, UInt8.toNat_toUInt32]]
-  -- The high byte `b1 <<< 8` (no UInt32 overflow: the value is < 2^16).
+  -- The two high bytes `b1 <<< 8` / `b2 <<< 16` (no UInt32 overflow: < 2^24).
   have hb1eq : (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toUInt32
         else (0 : UInt32)).toNat
       = (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toNat else 0) := by
+    split
+    · rw [UInt8.toNat_toUInt32]
+    · rfl
+  have hb2eq : (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toUInt32
+        else (0 : UInt32)).toNat
+      = (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toNat else 0) := by
     split
     · rw [UInt8.toNat_toUInt32]
     · rfl
@@ -156,24 +156,60 @@ theorem peekFast_testBit (br : BitReader) (j : Nat)
     split
     · have := UInt8.toNat_lt br.data[br.pos + 1]!; omega
     · decide
-  rw [UInt32.toNat_shiftLeft, show (8 : UInt32).toNat % 32 = 8 from by decide, hb1eq,
+  have hb2lt : (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toNat else 0) < 256 := by
+    split
+    · have := UInt8.toNat_lt br.data[br.pos + 2]!; omega
+    · decide
+  unfold peekFast
+  -- Reduce to a single-bit query on the 24-bit window `b0 ||| (b1 <<< 8) ||| (b2 <<< 16)`.
+  rw [UInt32.toNat_and, Nat.testBit_and, UInt32.toNat_shiftRight, Nat.testBit_shiftRight,
+    hmask, Bool.and_true, hshift, UInt32.toNat_or, UInt32.toNat_or, Nat.testBit_or,
+    Nat.testBit_or,
+    show (if br.pos < br.data.size then br.data[br.pos]!.toUInt32 else (0 : UInt32)).toNat
+        = br.data[br.pos]!.toNat from by rw [if_pos hpos, UInt8.toNat_toUInt32],
+    UInt32.toNat_shiftLeft, show (8 : UInt32).toNat % 32 = 8 from by decide, hb1eq,
     Nat.mod_eq_of_lt (by rw [Nat.shiftLeft_eq, show (2 : Nat) ^ 8 = 256 from by decide,
       show (2 : Nat) ^ 32 = 4294967296 from by decide]; omega),
-    Nat.testBit_shiftLeft]
+    UInt32.toNat_shiftLeft, show (16 : UInt32).toNat % 32 = 16 from by decide, hb2eq,
+    Nat.mod_eq_of_lt (by rw [Nat.shiftLeft_eq, show (2 : Nat) ^ 16 = 65536 from by decide,
+      show (2 : Nat) ^ 32 = 4294967296 from by decide]; omega),
+    Nat.testBit_shiftLeft, Nat.testBit_shiftLeft]
   by_cases hlo : br.bitOff + j < 8
-  · -- low byte: the shift-left term vanishes; cursor stays in byte `pos`
-    rw [show (decide (br.bitOff + j ≥ 8)) = false from by
-        simp only [decide_eq_false_iff_not]; omega, Bool.false_and, Bool.or_false,
-      show (br.pos * 8 + br.bitOff + j) / 8 = br.pos from by omega,
-      show (br.pos * 8 + br.bitOff + j) % 8 = br.bitOff + j from by omega]
-  · -- high byte: byte `pos`'s bit is past its width (false); use byte `pos+1`
-    rw [show br.data[br.pos]!.toNat.testBit (br.bitOff + j) = false from
+  · -- byte `pos`: both shift-left terms vanish
+    have e8 : decide (br.bitOff + j ≥ 8) = false := by simp only [decide_eq_false_iff_not]; omega
+    have e16 : decide (br.bitOff + j ≥ 16) = false := by simp only [decide_eq_false_iff_not]; omega
+    have hdiv : (br.pos * 8 + br.bitOff + j) / 8 = br.pos := by omega
+    have hmod : (br.pos * 8 + br.bitOff + j) % 8 = br.bitOff + j := by omega
+    simp only [e8, e16, Bool.false_and, Bool.or_false, hdiv, hmod]
+  · by_cases hmid : br.bitOff + j < 16
+    · -- byte `pos+1`: byte `pos`'s bit is past its width (false)
+      have hb0 : br.data[br.pos]!.toNat.testBit (br.bitOff + j) = false :=
         Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le (UInt8.toNat_lt br.data[br.pos]!)
-          (Nat.pow_le_pow_right (by omega) (by omega))),
-      show (decide (br.bitOff + j ≥ 8)) = true from by simp only [decide_eq_true_eq]; omega,
-      Bool.true_and, Bool.false_or, if_pos (show br.pos + 1 < br.data.size from by omega),
-      show (br.pos * 8 + br.bitOff + j) / 8 = br.pos + 1 from by omega,
-      show (br.pos * 8 + br.bitOff + j) % 8 = br.bitOff + j - 8 from by omega]
+          (Nat.pow_le_pow_right (by omega) (by omega)))
+      have e8 : decide (br.bitOff + j ≥ 8) = true := by simp only [decide_eq_true_eq]; omega
+      have e16 : decide (br.bitOff + j ≥ 16) = false := by simp only [decide_eq_false_iff_not]; omega
+      have hif1 : (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toNat else 0)
+          = br.data[br.pos + 1]!.toNat := if_pos (by omega)
+      have hdiv : (br.pos * 8 + br.bitOff + j) / 8 = br.pos + 1 := by omega
+      have hmod : (br.pos * 8 + br.bitOff + j) % 8 = br.bitOff + j - 8 := by omega
+      simp only [hb0, e8, e16, Bool.true_and, Bool.false_and, Bool.false_or, Bool.or_false,
+        hif1, hdiv, hmod]
+    · -- byte `pos+2`: bytes `pos` and `pos+1` contribute no bit at this position
+      have hb0 : br.data[br.pos]!.toNat.testBit (br.bitOff + j) = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le (UInt8.toNat_lt br.data[br.pos]!)
+          (Nat.pow_le_pow_right (by omega) (by omega)))
+      have hb1 : (if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toNat else 0).testBit
+            (br.bitOff + j - 8) = false :=
+        Nat.testBit_lt_two_pow (Nat.lt_of_lt_of_le hb1lt (by
+          calc (256 : Nat) = 2 ^ 8 := by decide
+            _ ≤ 2 ^ (br.bitOff + j - 8) := Nat.pow_le_pow_right (by omega) (by omega)))
+      have e8 : decide (br.bitOff + j ≥ 8) = true := by simp only [decide_eq_true_eq]; omega
+      have e16 : decide (br.bitOff + j ≥ 16) = true := by simp only [decide_eq_true_eq]; omega
+      have hif2 : (if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toNat else 0)
+          = br.data[br.pos + 2]!.toNat := if_pos (by omega)
+      have hdiv : (br.pos * 8 + br.bitOff + j) / 8 = br.pos + 2 := by omega
+      have hmod : (br.pos * 8 + br.bitOff + j) % 8 = br.bitOff + j - 16 := by omega
+      simp only [hb0, hb1, e8, e16, Bool.true_and, Bool.false_or, hif2, hdiv, hmod]
 
 /-- **Codeword = stream prefix.** With `bitOff < 8`, `len ≤ fastBits`, and at
     least `len` bits available, the codeword read from the peeked bits is the

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1129,7 +1129,7 @@ theorem walkCanonical_ok_iff_walkTree (lengths : Array UInt8) (maxBits : Nat)
     rw [hwc, hsymrt, ← hbb, show cnt - used = c from by omega]
 
 /-- **`decodeSymCanon` and `decodeSym` accept the same inputs.** They share the
-    9-bit table branch verbatim; the long-code fallback agrees by
+    11-bit table branch verbatim; the long-code fallback agrees by
     `walkCanonical_ok_iff_walkTree`. -/
 theorem decodeSymCanon_ok_iff_decodeSym (lengths : Array UInt8) (maxBits : Nat)
     (hmb : 1 ≤ maxBits) (hmb15 : maxBits ≤ 15)
@@ -1236,17 +1236,17 @@ theorem goTreeFree_ok_iff_goFusedP (litTable distTable : HuffTree.DecodeTable)
     exact goTreeFree_ok_iff_goFusedP litTable distTable litLengths distLengths hlv hlb hdv hdb
       data maxOut (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output r
   · rw [dif_neg hrc, dif_neg hrc]
-    by_cases hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
-        ∧ (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt
-        ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256
+    by_cases hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
+        ∧ (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt
+        ∧ litTable.symAt (bitBuf &&& 0x7FF).toNat < 256
     · rw [dif_pos hlit, dif_pos hlit]
       by_cases hout : output.size ≥ maxOut
       · simp [hout]
       · rw [if_neg hout, if_neg hout]
         exact goTreeFree_ok_iff_goFusedP litTable distTable litLengths distLengths hlv hlb hdv hdb
-          data maxOut pos (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
-          (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)
-          (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8) r
+          data maxOut pos (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUInt64)
+          (cnt - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat)
+          (output.push (litTable.symAt (bitBuf &&& 0x7FF).toNat).toUInt8) r
     · rw [dif_neg hlit, dif_neg hlit]
       -- literal/length symbol decode
       cases hdec : decodeSymCanon (buildLongDecode litLengths 15) litTable 15 bitBuf cnt with
@@ -1364,11 +1364,11 @@ theorem goTreeFreeU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteA
   | case3 pos bitBuf cnt output hrc hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
-          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat :=
         toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
-          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hl1, hlen]
       rw [goTreeFreeU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           goTreeFree, dif_neg (fun h => hrc ((refillGuard_usize data pos cnt hsz).mpr h)),

--- a/ZipTest/InflateTable.lean
+++ b/ZipTest/InflateTable.lean
@@ -48,7 +48,7 @@ private def spineLengths : Array UInt8 :=
 /-- The trees exercised by the differential check, paired with a label. -/
 private def trees : Array (String × HuffTree) := Id.run do
   let mut acc : Array (String × HuffTree) := #[]
-  for d in [1, 4, 8, 9, 10, 12] do
+  for d in [1, 4, 8, 10, 11, 13] do
     match HuffTree.fromLengths (completeLengths d) 15 with
     | .ok t => acc := acc.push (s!"complete-{d}", t)
     | .error _ => pure ()
@@ -112,15 +112,15 @@ def tests : IO Unit := do
     codes past it (sentinel slots), a 1…15 mix, and the RFC fixed code lengths. -/
 private def lengthVectors : Array (String × Array UInt8) := Id.run do
   let mut acc : Array (String × Array UInt8) := #[]
-  for d in [1, 4, 8, 9, 10, 12] do
+  for d in [1, 4, 8, 10, 11, 13] do
     acc := acc.push (s!"complete-{d}", completeLengths d)
   acc := acc.push ("spine-1..15", spineLengths)
   acc := acc.push ("fixed-lit", Zip.Native.Inflate.fixedLitLengths)
   acc := acc.push ("fixed-dist", Zip.Native.Inflate.fixedDistLengths)
   -- A sparse, irregular *incomplete* code (Kraft sum < 1, so some ≤ fastBits
-  -- slots stay sentinel) mixing short codes with one length-10 fallback code —
+  -- slots stay sentinel) mixing short codes with one length-13 fallback code —
   -- the realistic dynamic-block shape.
-  acc := acc.push ("sparse", #[3, 3, 2, 0, 4, 4, 0, 0, 2, 10, 10] ++ Array.replicate 5 (0 : UInt8))
+  acc := acc.push ("sparse", #[3, 3, 2, 0, 4, 4, 0, 0, 2, 13, 13] ++ Array.replicate 5 (0 : UInt8))
   return acc
 
 /-- Differential check: the canonical O(n) table build (`buildTableCanonical`)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0dc1c48d16)">
+   <g clip-path="url(#p89b693f849)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image684a1339b4" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3YQYrk5R2H8eqemkGGZkgCGh1EgpCQRfZBPIMbD+IJvEVOIAiu3EqIS3cewRgJASdiOjM6tD1tT0393WUvPC+/WHw+J/gWBb966j07fv/RtuOX5eZqesE6N0+nFyyxPb+dnrDM2YNXpiescfel6QXrnJ9PL1jj+c30gnXOTvM72548mp6wzGl+YwAAgwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBs/8/d5fSGJZ4fb6YnLPPar96cnrDMxfbq9IQlzn54PD1hmc+efTE9YYnX770yPWGZw/F2esISVy9O9+7fHg/TE5b484M3pics4wULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYmdPf/x4mx6xwrPD1fSEZV4+3p+esM7hdnrBGleX0wvW+e0fphcscbVdT09Y5lTv48vbxfSEZR7tHk9PWOLh5XfTE5bxggUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/cWTy+kNS1zs701PWOfmm+kFy2xX309PWON4nF6wzNn9b6cnLHHKN+Ri/2B6whr3XppesMzDZ7fTE5bYrv89PWEZL1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH9dvnN9AZ+ruNxegH8z/b1V9MT1jj3//MXx23k/4gLAgAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH9e//51/SGJZ7cvJiesMznj55OT1jmk3ffnp6wxKv3fzc9YZk/ffDh9IQl3vn9b6YnLPOPJzfTE/iZ/vq3L6cnLHH9l/enJyzjBQsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiZ4fjp9v0iBVeHA/TE5Y5PzvdLr5zcz09YY07++kF6/zweHrBEsdfP5yesMy2HacnLHHnhN8Mnm+n+Zt293Can2u384IFAJATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsf35qTbW+X56wTLn3341PWGZ7el/pyescThML1hm++Nb0xOWONnbuNvtXuyO0xPWuL2eXrDM3RP9bNvXf5+esMzpXhAAgCECCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAg9hPDF4wDyPFijAAAAABJRU5ErkJggg==" id="imagea06a2a3a34" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc372897682" d="M 0 0 
+       <path id="m21a970fe14" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc372897682" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc372897682" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc372897682" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc372897682" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc372897682" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc372897682" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc372897682" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc372897682" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc372897682" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc372897682" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc372897682" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21a970fe14" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mcf0880a97b" d="M 0 0 
+       <path id="m9851813037" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mcf0880a97b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9851813037" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,10 +1303,44 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -2 -->
+    <!-- -3 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
@@ -1466,15 +1500,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- +8 -->
+    <!-- +7 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -17 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1487,48 +1514,21 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -19 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- -35 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -2180,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image68cf399e58" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagecbef3674b4" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m630ca2ee70" d="M 0 0 
+       <path id="m1a7fd885d8" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m630ca2ee70" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1a7fd885d8" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.991406 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.909375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,12 +3013,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3058,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0dc1c48d16">
+  <clipPath id="p89b693f849">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2865ccc6b1" d="M 0 0 
+       <path id="m570de4d4f6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2865ccc6b1" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2865ccc6b1" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m570de4d4f6" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7b4b0d7fbc" d="M 0 0 
+       <path id="m690faf921b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m690faf921b" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m690faf921b" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7b4b0d7fbc" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m690faf921b" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6a9b1a86a8" d="M 0 0 
+       <path id="m4b6252effc" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m6a9b1a86a8" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4b6252effc" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 176.211252) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 176.740076) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.412453) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.874491) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m841fc1c5ea" d="M -2.5 2.5 
+     <path id="md7cc39afd3" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m841fc1c5ea" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841fc1c5ea" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#md7cc39afd3" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7cc39afd3" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5303e1f53f" d="M 0 -2.5 
+     <path id="mf23ef64c3d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m5303e1f53f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5303e1f53f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#mf23ef64c3d" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf23ef64c3d" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2b40e4ecbc" d="M -0 3.535534 
+     <path id="m1693382207" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m2b40e4ecbc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b40e4ecbc" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#m1693382207" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1693382207" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md056289bf8" d="M -0 2.5 
+     <path id="mc4c3bd234f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#md056289bf8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#mc4c3bd234f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m07dc04bb49" d="M -0.833333 2.5 
+     <path id="m755eb2ead7" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m07dc04bb49" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07dc04bb49" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#m755eb2ead7" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m755eb2ead7" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdc060585ba" d="M -1.25 2.5 
+     <path id="me12c86be29" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#mdc060585ba" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc060585ba" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#me12c86be29" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me12c86be29" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0a311fcda9" d="M 0 -2.5 
+     <path id="m6bb91a412a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a311fcda9" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#m6bb91a412a" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6bb91a412a" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m803daea7e0" d="M 0 -2.5 
+     <path id="mc02e28910b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#m803daea7e0" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m803daea7e0" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#mc02e28910b" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc02e28910b" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="md68703fb66" d="M 0 3.5 
+      <path id="m9c84e820a6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md68703fb66" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9c84e820a6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m841fc1c5ea" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md7cc39afd3" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5303e1f53f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf23ef64c3d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2b40e4ecbc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1693382207" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md056289bf8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc4c3bd234f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m07dc04bb49" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m755eb2ead7" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdc060585ba" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me12c86be29" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0a311fcda9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m6bb91a412a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m803daea7e0" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc02e28910b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 181.211252 
-L 214.084819 183.613159 
-L 206.266533 185.974471 
-L 187.75787 192.442867 
-L 186.58897 193.532688 
-L 184.505355 195.663284 
-L 152.30308 249.268718 
-L 150.950891 251.216261 
-L 98.348822 336.412453 
-" clip-path="url(#p00cd833124)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p00cd833124)">
-     <use xlink:href="#md68703fb66" x="226.647908" y="181.211252" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="214.084819" y="183.613159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="206.266533" y="185.974471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="187.75787" y="192.442867" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="186.58897" y="193.532688" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="184.505355" y="195.663284" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="152.30308" y="249.268718" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="150.950891" y="251.216261" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md68703fb66" x="98.348822" y="336.412453" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 181.740076 
+L 214.084819 184.209948 
+L 206.266533 186.417451 
+L 187.75787 193.134474 
+L 186.58897 193.853515 
+L 184.505355 195.919585 
+L 152.30308 249.451727 
+L 150.950891 251.358909 
+L 98.348822 336.874491 
+" clip-path="url(#pb802fbcd75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pb802fbcd75)">
+     <use xlink:href="#m9c84e820a6" x="226.647908" y="181.740076" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="214.084819" y="184.209948" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="206.266533" y="186.417451" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="187.75787" y="193.134474" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="186.58897" y="193.853515" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="184.505355" y="195.919585" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="152.30308" y="249.451727" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="150.950891" y="251.358909" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9c84e820a6" x="98.348822" y="336.874491" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.991406 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.909375 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,6 +2903,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -3046,12 +3071,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3091,109 +3116,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p00cd833124">
+  <clipPath id="pb802fbcd75">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p987c9e72b7)">
+   <g clip-path="url(#p49300d0b44)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagef4539a7a21" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagee7bd003a23" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3ccf22ac64" d="M 0 0 
+       <path id="mfa5e4a77e0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3ccf22ac64" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3ccf22ac64" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa5e4a77e0" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md42f95b750" d="M 0 0 
+       <path id="ma136366755" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md42f95b750" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma136366755" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image830015ad2c" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image4cbcd6f363" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mc485315922" d="M 0 0 
+       <path id="md088f333e6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc485315922" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md088f333e6" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.991406 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.909375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2954,12 +2954,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p987c9e72b7">
+  <clipPath id="p49300d0b44">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.417188pt" height="386.202469pt" viewBox="0 0 568.417188 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.58125pt" height="386.202469pt" viewBox="0 0 568.58125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.417188 386.202469 
-L 568.417188 0 
+L 568.58125 386.202469 
+L 568.58125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.333594 104.1264 
-L 290.958594 104.1264 
-L 290.958594 74.7432 
-L 186.333594 74.7432 
+    <path d="M 186.415625 104.1264 
+L 291.040625 104.1264 
+L 291.040625 74.7432 
+L 186.415625 74.7432 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.958594 104.1264 
-L 395.583594 104.1264 
-L 395.583594 74.7432 
-L 290.958594 74.7432 
+    <path d="M 291.040625 104.1264 
+L 395.665625 104.1264 
+L 395.665625 74.7432 
+L 291.040625 74.7432 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.583594 104.1264 
-L 500.208594 104.1264 
-L 500.208594 74.7432 
-L 395.583594 74.7432 
+    <path d="M 395.665625 104.1264 
+L 500.290625 104.1264 
+L 500.290625 74.7432 
+L 395.665625 74.7432 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.333594 133.5096 
-L 290.958594 133.5096 
-L 290.958594 104.1264 
-L 186.333594 104.1264 
+    <path d="M 186.415625 133.5096 
+L 291.040625 133.5096 
+L 291.040625 104.1264 
+L 186.415625 104.1264 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.958594 133.5096 
-L 395.583594 133.5096 
-L 395.583594 104.1264 
-L 290.958594 104.1264 
+    <path d="M 291.040625 133.5096 
+L 395.665625 133.5096 
+L 395.665625 104.1264 
+L 291.040625 104.1264 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.583594 133.5096 
-L 500.208594 133.5096 
-L 500.208594 104.1264 
-L 395.583594 104.1264 
+    <path d="M 395.665625 133.5096 
+L 500.290625 133.5096 
+L 500.290625 104.1264 
+L 395.665625 104.1264 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.333594 162.8928 
-L 290.958594 162.8928 
-L 290.958594 133.5096 
-L 186.333594 133.5096 
+    <path d="M 186.415625 162.8928 
+L 291.040625 162.8928 
+L 291.040625 133.5096 
+L 186.415625 133.5096 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.958594 162.8928 
-L 395.583594 162.8928 
-L 395.583594 133.5096 
-L 290.958594 133.5096 
+    <path d="M 291.040625 162.8928 
+L 395.665625 162.8928 
+L 395.665625 133.5096 
+L 291.040625 133.5096 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.583594 162.8928 
-L 500.208594 162.8928 
-L 500.208594 133.5096 
-L 395.583594 133.5096 
+    <path d="M 395.665625 162.8928 
+L 500.290625 162.8928 
+L 500.290625 133.5096 
+L 395.665625 133.5096 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.333594 192.276 
-L 290.958594 192.276 
-L 290.958594 162.8928 
-L 186.333594 162.8928 
+    <path d="M 186.415625 192.276 
+L 291.040625 192.276 
+L 291.040625 162.8928 
+L 186.415625 162.8928 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.958594 192.276 
-L 395.583594 192.276 
-L 395.583594 162.8928 
-L 290.958594 162.8928 
+    <path d="M 291.040625 192.276 
+L 395.665625 192.276 
+L 395.665625 162.8928 
+L 291.040625 162.8928 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.583594 192.276 
-L 500.208594 192.276 
-L 500.208594 162.8928 
-L 395.583594 162.8928 
+    <path d="M 395.665625 192.276 
+L 500.290625 192.276 
+L 500.290625 162.8928 
+L 395.665625 162.8928 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.333594 221.6592 
-L 290.958594 221.6592 
-L 290.958594 192.276 
-L 186.333594 192.276 
+    <path d="M 186.415625 221.6592 
+L 291.040625 221.6592 
+L 291.040625 192.276 
+L 186.415625 192.276 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.958594 221.6592 
-L 395.583594 221.6592 
-L 395.583594 192.276 
-L 290.958594 192.276 
+    <path d="M 291.040625 221.6592 
+L 395.665625 221.6592 
+L 395.665625 192.276 
+L 291.040625 192.276 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.583594 221.6592 
-L 500.208594 221.6592 
-L 500.208594 192.276 
-L 395.583594 192.276 
+    <path d="M 395.665625 221.6592 
+L 500.290625 221.6592 
+L 500.290625 192.276 
+L 395.665625 192.276 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.333594 251.0424 
-L 290.958594 251.0424 
-L 290.958594 221.6592 
-L 186.333594 221.6592 
+    <path d="M 186.415625 251.0424 
+L 291.040625 251.0424 
+L 291.040625 221.6592 
+L 186.415625 221.6592 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.958594 251.0424 
-L 395.583594 251.0424 
-L 395.583594 221.6592 
-L 290.958594 221.6592 
+    <path d="M 291.040625 251.0424 
+L 395.665625 251.0424 
+L 395.665625 221.6592 
+L 291.040625 221.6592 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.583594 251.0424 
-L 500.208594 251.0424 
-L 500.208594 221.6592 
-L 395.583594 221.6592 
+    <path d="M 395.665625 251.0424 
+L 500.290625 251.0424 
+L 500.290625 221.6592 
+L 395.665625 221.6592 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.333594 280.4256 
-L 290.958594 280.4256 
-L 290.958594 251.0424 
-L 186.333594 251.0424 
+    <path d="M 186.415625 280.4256 
+L 291.040625 280.4256 
+L 291.040625 251.0424 
+L 186.415625 251.0424 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.958594 280.4256 
-L 395.583594 280.4256 
-L 395.583594 251.0424 
-L 290.958594 251.0424 
+    <path d="M 291.040625 280.4256 
+L 395.665625 280.4256 
+L 395.665625 251.0424 
+L 291.040625 251.0424 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.583594 280.4256 
-L 500.208594 280.4256 
-L 500.208594 251.0424 
-L 395.583594 251.0424 
+    <path d="M 395.665625 280.4256 
+L 500.290625 280.4256 
+L 500.290625 251.0424 
+L 395.665625 251.0424 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.333594 309.8088 
-L 290.958594 309.8088 
-L 290.958594 280.4256 
-L 186.333594 280.4256 
+    <path d="M 186.415625 309.8088 
+L 291.040625 309.8088 
+L 291.040625 280.4256 
+L 186.415625 280.4256 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.958594 309.8088 
-L 395.583594 309.8088 
-L 395.583594 280.4256 
-L 290.958594 280.4256 
+    <path d="M 291.040625 309.8088 
+L 395.665625 309.8088 
+L 395.665625 280.4256 
+L 291.040625 280.4256 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.583594 309.8088 
-L 500.208594 309.8088 
-L 500.208594 280.4256 
-L 395.583594 280.4256 
+    <path d="M 395.665625 309.8088 
+L 500.290625 309.8088 
+L 500.290625 280.4256 
+L 395.665625 280.4256 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.333594 339.192 
-L 290.958594 339.192 
-L 290.958594 309.8088 
-L 186.333594 309.8088 
+    <path d="M 186.415625 339.192 
+L 291.040625 339.192 
+L 291.040625 309.8088 
+L 186.415625 309.8088 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.958594 339.192 
-L 395.583594 339.192 
-L 395.583594 309.8088 
-L 290.958594 309.8088 
+    <path d="M 291.040625 339.192 
+L 395.665625 339.192 
+L 395.665625 309.8088 
+L 291.040625 309.8088 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.583594 339.192 
-L 500.208594 339.192 
-L 500.208594 309.8088 
-L 395.583594 309.8088 
+    <path d="M 395.665625 339.192 
+L 500.290625 339.192 
+L 500.290625 309.8088 
+L 395.665625 309.8088 
 z
-" clip-path="url(#p1602a500d4)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p30d4235248)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.320859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.402891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.605078 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.687109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.177188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.259219 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.528906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.610938 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.258594 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.340625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.194844 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.636094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.718125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.261094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.896719 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.97875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.194844 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.181094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.261094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.159844 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.241875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.194844 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.181094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.261094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.466094 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.548125 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.194844 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.181094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.261094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.622344 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.704375 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.194844 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.181094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.261094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.967969 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.05 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(225.994219 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.07625 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(337.704844 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(337.786875 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,8 +1755,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 160 -->
-    <g transform="translate(439.546719 238.5583) scale(0.08 -0.08)">
+    <!-- 158 -->
+    <g transform="translate(439.62875 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1772,45 +1772,54 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.082969 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.165 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1939,7 +1948,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.194844 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1949,14 +1958,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.181094 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.261094 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1964,7 +1973,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.589844 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.671875 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2020,7 +2029,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.194844 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2030,21 +2039,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.181094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(442.806094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.888125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.304219 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.38625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2055,7 +2064,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.194844 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2065,13 +2074,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.726094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.808125 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.896094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.978125 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2087,7 +2096,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.717344 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.799375 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2226,6 +2235,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2270,7 +2309,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2412,12 +2451,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2457,110 +2496,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1602a500d4">
-   <rect x="81.708594" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p30d4235248">
+   <rect x="81.790625" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p6f7b9b454f)">
+   <g clip-path="url(#p0bc5488fd6)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7klEQVR4nO3YvY5dZxmG4dkz2+PEToQhxhFBsmiACqQoqdJwBhQcBiUtfUpq2vQ5ASpQKiSEoAsdUaAAR0QxcSzP7Jk9HAGV9d3veOm6juCR1s93r7U7/uejm5MtO7yYXsDLOF5NL1hrdzq9YK2ry+kFa917ML1grYtn0wvWOjufXsDL2Pr9eX5vesFSGz/9AAC4bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/Z8Pn01vWGp/ejY9Yanjzc30hKUevfloesJSn/33H9MT1tr4J+6PXnswPWGpw93z6QlL/eXJp9MTlvrpwx9OT1jq4vw4PWGp3e759ISlNn48AABw2whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT+8Zs/mN6w1IO7j6YnLPXFi39OT1jqnefb/kZ6462fTE9Y6my3n56w1PHkOD1hqe+ePJyesNTVw8vpCUu9fe/x9ISlDsdtX7/7l9t+v2z7dAcA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPa73bYb9OvDl9MTlnr97I3pCUtdv/Wd6QlL/evpX6cnLPXs8sX0hKXe+/b70xOWujybXrDWN4evpyfwEr66eDI9Ya27j6YXLLXt+gQA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHbXn/zqZnrEUsfj9AL4/059A77SvF9ebVt//rZ+f7p+r7SNXz0AAG4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr/9p/+Nr1hqdP9thv7yadfTE9Y6re/fHd6wlIf/vHf0xOW+tnjb01PWOrjP/x9esJSv/7Fj6cnLPWb338+PWGpn7/7vekJS33+9GJ6wlIffP/+9ISltl1nAADcOgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7XP/uZnrESmdXV9MT1jrdTy9Y6+rF9IK1zu9NL1hrt/Fv3Jvj9IK1Dp6/V9r1ts+/w27bz9+djffLxk8HAABuGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqf7w5Tm9Y6uzOa9MTljqebPv6nT79cnrCUtfn274/z66upiestfH358nl8+kFS31zuu378/5xPz1hqTvTA1a7eDa9YCl/QAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS/wO754CaCBujSAAAAABJRU5ErkJggg==" id="imageb80a1b7592" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7ElEQVR4nO3Yv45dVx2GYZ+ZM+NgJ8IhxhFBsmiAikhRqGi4gxS5DEpaekpqWnpugAqUCgkh6EJHFCjAUaL8sS3PnJkzXAGVtd7feOt5ruCT9t5nvevsjp//7ubOlh1eTC/gZRyvphestTuZXrDW1eX0grXuPZhesNbF0+kFa52eTy/gZWz9/Ty/N71gqY2ffgAA3DYCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P6vh0+mNyy1PzmdnrDU8eZmesJSj954ND1hqU++/tf0hLU2fsX90WsPpicsdbh7Pj1hqb89+Xh6wlLvPvzh9ISlLs6P0xOW2u2eT09YauPHAwAAt40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtH7/xg+kNSz24+2h6wlKfvfj39ISl3nm+7TvS62/9ZHrCUqe7/fSEpY53jtMTlvrunYfTE5a6eng5PWGpt+89np6w1OG47ed3/3Lbvy/bPt0BALh1BCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9brftBv3m8MX0hKW+dfr69ISlrt/6zvSEpf7z1d+nJyz19PLF9ISl3n/zp9MTlro8nV6w1rPDN9MTeAlfXjyZnrDW3UfTC5badn0CAHDrCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7649+eTM9YqnjcXoB/H8n7oCvNL8vr7atf39bfz89v1faxp8eAAC3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f/sv/5jesNTJftuN/eTjz6YnLPXbX7w3PWGpX//5v9MTlvr5429PT1jq93/65/SEpX714Y+nJyz1mz9+Oj1hqQ/e+970hKU+/epiesJSP/v+/ekJS227zgAAuHUEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqd7j+w830iJVOr66mJ6x1sp9esNbVi+kFa53fm16w1m7jd9yb4/SCtQ6+v1fa9bbPv8Nu29/f2cb7ZeOnAwAAt40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtZ8esNzZa9ML1ro5Ti9Y69kX0wuWOpydT09Y6ux6esFiW//+Lp9PL1jq2cnV9ISl7l9v+z+ms5ONJ8zF0+kFS2377QQA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApP4HmlB8pJ7h0DEAAAAASUVORK5CYII=" id="image70862b557e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4a11c8d6f0" d="M 0 0 
+       <path id="md05933e082" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4a11c8d6f0" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md05933e082" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m84a58d34ed" d="M 0 0 
+       <path id="m1b996a6307" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m84a58d34ed" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1b996a6307" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +9 -->
+    <!-- +6 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,39 +1156,39 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1225,8 +1225,8 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +4 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+    <!-- -4 -->
+    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1248,12 +1248,12 @@ L 2253 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -36 -->
+    <!-- -37 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1288,46 +1288,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +7 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1339,13 +1299,14 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -8 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- +8 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1387,8 +1348,47 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -9 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1437,35 +1437,62 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -24 -->
+    <!-- -25 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- +18 -->
+    <!-- +17 -->
     <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -14 -->
+    <!-- -15 -->
     <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -12 -->
+    <!-- -11 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1501,33 +1528,6 @@ z
    <g id="text_36">
     <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -2190,18 +2190,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2be7a188b2" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef805a68ef1" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m35df5a0d2e" d="M 0 0 
+       <path id="md33de390e6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2224,7 +2224,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2238,7 +2238,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2252,7 +2252,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2265,7 +2265,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2278,7 +2278,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2291,7 +2291,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m35df5a0d2e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md33de390e6" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2907,8 +2907,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.991406 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.909375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,12 +3000,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3045,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6f7b9b454f">
+  <clipPath id="p0bc5488fd6">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb5be9e6a52" d="M 0 0 
+       <path id="ma8d4df3eca" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb5be9e6a52" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb5be9e6a52" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8d4df3eca" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb0afad8f1b" d="M 0 0 
+       <path id="me9d5c12aeb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb0afad8f1b" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9d5c12aeb" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb0afad8f1b" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9d5c12aeb" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb0afad8f1b" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9d5c12aeb" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mbfe5594000" d="M 0 0 
+       <path id="ma17c93ab12" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mbfe5594000" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma17c93ab12" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 149.2322) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 149.603351) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 352.015906) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.27249) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m672c735265" d="M -2.5 2.5 
+     <path id="m6ac30e4609" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#m672c735265" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672c735265" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m6ac30e4609" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ac30e4609" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf97fba6bd1" d="M 0 -2.5 
+     <path id="m127e90c717" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#mf97fba6bd1" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf97fba6bd1" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m127e90c717" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m127e90c717" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mfc837e60c3" d="M -0 3.535534 
+     <path id="m324c25db50" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#mfc837e60c3" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc837e60c3" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m324c25db50" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m324c25db50" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6986386c50" d="M -0 2.5 
+     <path id="m6bcd868a32" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#m6986386c50" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m6bcd868a32" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m01ea53dbd2" d="M -0.833333 2.5 
+     <path id="m4914b2a755" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#m01ea53dbd2" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m01ea53dbd2" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m4914b2a755" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4914b2a755" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m130c407029" d="M -1.25 2.5 
+     <path id="mca56870014" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#m130c407029" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m130c407029" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#mca56870014" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca56870014" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="maf38ed181b" d="M 0 -2.5 
+     <path id="m0ed57dcad2" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#maf38ed181b" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf38ed181b" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m0ed57dcad2" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0ed57dcad2" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mde3dbd2884" d="M 0 -2.5 
+     <path id="ma868744b5a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#mde3dbd2884" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mde3dbd2884" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#ma868744b5a" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma868744b5a" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m89836bc9f6" d="M 0 3.5 
+      <path id="m787e898b2e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m89836bc9f6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m787e898b2e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m672c735265" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6ac30e4609" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf97fba6bd1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m127e90c717" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mfc837e60c3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m324c25db50" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6986386c50" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6bcd868a32" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m01ea53dbd2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4914b2a755" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m130c407029" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mca56870014" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#maf38ed181b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0ed57dcad2" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mde3dbd2884" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma868744b5a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 154.2322 
-L 236.23654 158.324189 
-L 222.073314 162.095564 
-L 202.315941 171.886354 
-L 199.905291 173.650535 
-L 195.893147 177.415507 
-L 157.982343 243.277899 
-L 157.246106 245.492324 
-L 95.319203 357.015906 
-" clip-path="url(#p43f46e1528)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p43f46e1528)">
-     <use xlink:href="#m89836bc9f6" x="257.531237" y="154.2322" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="236.23654" y="158.324189" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="222.073314" y="162.095564" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="202.315941" y="171.886354" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="199.905291" y="173.650535" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="195.893147" y="177.415507" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="157.982343" y="243.277899" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="157.246106" y="245.492324" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m89836bc9f6" x="95.319203" y="357.015906" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 154.603351 
+L 236.23654 158.568289 
+L 222.073314 162.946307 
+L 202.315941 172.312481 
+L 199.905291 174.195748 
+L 195.893147 178.003923 
+L 157.982343 243.511647 
+L 157.246106 245.475527 
+L 95.319203 357.27249 
+" clip-path="url(#p90669e94fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p90669e94fd)">
+     <use xlink:href="#m787e898b2e" x="257.531237" y="154.603351" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="236.23654" y="158.568289" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="222.073314" y="162.946307" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="202.315941" y="172.312481" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="199.905291" y="174.195748" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="195.893147" y="178.003923" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="157.982343" y="243.511647" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="157.246106" y="245.475527" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m787e898b2e" x="95.319203" y="357.27249" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.991406 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.909375 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2815,6 +2815,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2958,12 +2983,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3003,109 +3028,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p43f46e1528">
+  <clipPath id="p90669e94fd">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe3e632cc77)">
+   <g clip-path="url(#pec72a2cab4)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imagec4eb256689" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image3598a66d0a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m78a67b19cb" d="M 0 0 
+       <path id="m15bca04955" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m78a67b19cb" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m78a67b19cb" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m78a67b19cb" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m78a67b19cb" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m78a67b19cb" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m78a67b19cb" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m78a67b19cb" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m78a67b19cb" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m78a67b19cb" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m78a67b19cb" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m78a67b19cb" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m78a67b19cb" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15bca04955" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m13ffe1de0f" d="M 0 0 
+       <path id="m1e3cccce44" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m13ffe1de0f" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e3cccce44" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image19d6f85a95" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageaca4b0b993" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m370f10c34f" d="M 0 0 
+       <path id="mf322051bbf" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m370f10c34f" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf322051bbf" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m370f10c34f" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf322051bbf" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m370f10c34f" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf322051bbf" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m370f10c34f" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf322051bbf" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m370f10c34f" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf322051bbf" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.991406 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.909375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2873,12 +2873,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe3e632cc77">
+  <clipPath id="pec72a2cab4">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.417188pt" height="386.202469pt" viewBox="0 0 568.417188 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.58125pt" height="386.202469pt" viewBox="0 0 568.58125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.417188 386.202469 
-L 568.417188 0 
+L 568.58125 386.202469 
+L 568.58125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.333594 104.1264 
-L 290.958594 104.1264 
-L 290.958594 74.7432 
-L 186.333594 74.7432 
+    <path d="M 186.415625 104.1264 
+L 291.040625 104.1264 
+L 291.040625 74.7432 
+L 186.415625 74.7432 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.958594 104.1264 
-L 395.583594 104.1264 
-L 395.583594 74.7432 
-L 290.958594 74.7432 
+    <path d="M 291.040625 104.1264 
+L 395.665625 104.1264 
+L 395.665625 74.7432 
+L 291.040625 74.7432 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.583594 104.1264 
-L 500.208594 104.1264 
-L 500.208594 74.7432 
-L 395.583594 74.7432 
+    <path d="M 395.665625 104.1264 
+L 500.290625 104.1264 
+L 500.290625 74.7432 
+L 395.665625 74.7432 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.333594 133.5096 
-L 290.958594 133.5096 
-L 290.958594 104.1264 
-L 186.333594 104.1264 
+    <path d="M 186.415625 133.5096 
+L 291.040625 133.5096 
+L 291.040625 104.1264 
+L 186.415625 104.1264 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.958594 133.5096 
-L 395.583594 133.5096 
-L 395.583594 104.1264 
-L 290.958594 104.1264 
+    <path d="M 291.040625 133.5096 
+L 395.665625 133.5096 
+L 395.665625 104.1264 
+L 291.040625 104.1264 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.583594 133.5096 
-L 500.208594 133.5096 
-L 500.208594 104.1264 
-L 395.583594 104.1264 
+    <path d="M 395.665625 133.5096 
+L 500.290625 133.5096 
+L 500.290625 104.1264 
+L 395.665625 104.1264 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.333594 162.8928 
-L 290.958594 162.8928 
-L 290.958594 133.5096 
-L 186.333594 133.5096 
+    <path d="M 186.415625 162.8928 
+L 291.040625 162.8928 
+L 291.040625 133.5096 
+L 186.415625 133.5096 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.958594 162.8928 
-L 395.583594 162.8928 
-L 395.583594 133.5096 
-L 290.958594 133.5096 
+    <path d="M 291.040625 162.8928 
+L 395.665625 162.8928 
+L 395.665625 133.5096 
+L 291.040625 133.5096 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.583594 162.8928 
-L 500.208594 162.8928 
-L 500.208594 133.5096 
-L 395.583594 133.5096 
+    <path d="M 395.665625 162.8928 
+L 500.290625 162.8928 
+L 500.290625 133.5096 
+L 395.665625 133.5096 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.333594 192.276 
-L 290.958594 192.276 
-L 290.958594 162.8928 
-L 186.333594 162.8928 
+    <path d="M 186.415625 192.276 
+L 291.040625 192.276 
+L 291.040625 162.8928 
+L 186.415625 162.8928 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.958594 192.276 
-L 395.583594 192.276 
-L 395.583594 162.8928 
-L 290.958594 162.8928 
+    <path d="M 291.040625 192.276 
+L 395.665625 192.276 
+L 395.665625 162.8928 
+L 291.040625 162.8928 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.583594 192.276 
-L 500.208594 192.276 
-L 500.208594 162.8928 
-L 395.583594 162.8928 
+    <path d="M 395.665625 192.276 
+L 500.290625 192.276 
+L 500.290625 162.8928 
+L 395.665625 162.8928 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.333594 221.6592 
-L 290.958594 221.6592 
-L 290.958594 192.276 
-L 186.333594 192.276 
+    <path d="M 186.415625 221.6592 
+L 291.040625 221.6592 
+L 291.040625 192.276 
+L 186.415625 192.276 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.958594 221.6592 
-L 395.583594 221.6592 
-L 395.583594 192.276 
-L 290.958594 192.276 
+    <path d="M 291.040625 221.6592 
+L 395.665625 221.6592 
+L 395.665625 192.276 
+L 291.040625 192.276 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.583594 221.6592 
-L 500.208594 221.6592 
-L 500.208594 192.276 
-L 395.583594 192.276 
+    <path d="M 395.665625 221.6592 
+L 500.290625 221.6592 
+L 500.290625 192.276 
+L 395.665625 192.276 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.333594 251.0424 
-L 290.958594 251.0424 
-L 290.958594 221.6592 
-L 186.333594 221.6592 
+    <path d="M 186.415625 251.0424 
+L 291.040625 251.0424 
+L 291.040625 221.6592 
+L 186.415625 221.6592 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.958594 251.0424 
-L 395.583594 251.0424 
-L 395.583594 221.6592 
-L 290.958594 221.6592 
+    <path d="M 291.040625 251.0424 
+L 395.665625 251.0424 
+L 395.665625 221.6592 
+L 291.040625 221.6592 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.583594 251.0424 
-L 500.208594 251.0424 
-L 500.208594 221.6592 
-L 395.583594 221.6592 
+    <path d="M 395.665625 251.0424 
+L 500.290625 251.0424 
+L 500.290625 221.6592 
+L 395.665625 221.6592 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.333594 280.4256 
-L 290.958594 280.4256 
-L 290.958594 251.0424 
-L 186.333594 251.0424 
+    <path d="M 186.415625 280.4256 
+L 291.040625 280.4256 
+L 291.040625 251.0424 
+L 186.415625 251.0424 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.958594 280.4256 
-L 395.583594 280.4256 
-L 395.583594 251.0424 
-L 290.958594 251.0424 
+    <path d="M 291.040625 280.4256 
+L 395.665625 280.4256 
+L 395.665625 251.0424 
+L 291.040625 251.0424 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.583594 280.4256 
-L 500.208594 280.4256 
-L 500.208594 251.0424 
-L 395.583594 251.0424 
+    <path d="M 395.665625 280.4256 
+L 500.290625 280.4256 
+L 500.290625 251.0424 
+L 395.665625 251.0424 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.333594 309.8088 
-L 290.958594 309.8088 
-L 290.958594 280.4256 
-L 186.333594 280.4256 
+    <path d="M 186.415625 309.8088 
+L 291.040625 309.8088 
+L 291.040625 280.4256 
+L 186.415625 280.4256 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.958594 309.8088 
-L 395.583594 309.8088 
-L 395.583594 280.4256 
-L 290.958594 280.4256 
+    <path d="M 291.040625 309.8088 
+L 395.665625 309.8088 
+L 395.665625 280.4256 
+L 291.040625 280.4256 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.583594 309.8088 
-L 500.208594 309.8088 
-L 500.208594 280.4256 
-L 395.583594 280.4256 
+    <path d="M 395.665625 309.8088 
+L 500.290625 309.8088 
+L 500.290625 280.4256 
+L 395.665625 280.4256 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.333594 339.192 
-L 290.958594 339.192 
-L 290.958594 309.8088 
-L 186.333594 309.8088 
+    <path d="M 186.415625 339.192 
+L 291.040625 339.192 
+L 291.040625 309.8088 
+L 186.415625 309.8088 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.958594 339.192 
-L 395.583594 339.192 
-L 395.583594 309.8088 
-L 290.958594 309.8088 
+    <path d="M 291.040625 339.192 
+L 395.665625 339.192 
+L 395.665625 309.8088 
+L 291.040625 309.8088 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.583594 339.192 
-L 500.208594 339.192 
-L 500.208594 309.8088 
-L 395.583594 309.8088 
+    <path d="M 395.665625 339.192 
+L 500.290625 339.192 
+L 500.290625 309.8088 
+L 395.665625 309.8088 
 z
-" clip-path="url(#pd8e23cf786)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pe9d4a18125)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.320859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.402891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.605078 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.687109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.177188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.259219 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.528906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.610938 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.258594 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.340625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.194844 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.636094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.718125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.261094 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.896719 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.97875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.194844 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.181094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.261094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.589844 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.671875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.194844 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.181094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.261094 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.622344 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.704375 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.194844 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.181094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.261094 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.159844 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.241875 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.194844 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.181094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.261094 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.466094 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.548125 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.194844 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.181094 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.261094 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.343125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.967969 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.05 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(225.994219 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.07625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 34 -->
-    <g transform="translate(337.704844 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(337.786875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1881,23 +1881,9 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 190 -->
-    <g transform="translate(439.546719 267.9415) scale(0.08 -0.08)">
+    <!-- 209 -->
+    <g transform="translate(439.62875 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
 Q 928 831 1190 764 
@@ -1929,14 +1915,14 @@ Q 1809 2350 2125 2350
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.082969 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.165 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2001,7 +1987,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.194844 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2011,21 +1997,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.181094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.263125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.806094 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.888125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.304219 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.38625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2036,7 +2022,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.194844 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.276875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2046,13 +2032,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.726094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.808125 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.896094 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.978125 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2068,7 +2054,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.810313 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.892344 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2212,7 +2198,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T04:23:39Z  ·  Linux chungus x86_64  ·  commit f2d6c3a8  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T05:33:29Z  ·  Linux chungus x86_64  ·  commit 8c62bf80  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2354,12 +2340,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2399,110 +2385,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3289.160156 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3352.783203 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3414.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3477.685547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3509.472656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3573.046875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3604.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3636.621094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3664.404297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3725.927734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.207031 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3850.585938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3914.0625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3952.925781 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4014.107422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4073.287109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4134.810547 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4175.923828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4209.615234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4237.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4298.921875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.201172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4423.580078 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.203125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4520.894531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4580.074219 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4643.697266 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4675.484375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4739.107422 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4802.730469 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4834.517578 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4934.224609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4973.087891 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5028.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5091.691406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5123.478516 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.265625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5187.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5218.839844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5250.626953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5289.835938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5353.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5453.259766 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5516.638672 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5580.115234 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5770.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5809.558594 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.345703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5925.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5956.921875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6054.333984 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6115.857422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6179.333984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6207.117188 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6331.775391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6363.5625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6415.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6479.041016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6540.320312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6603.796875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6655.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.275391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6780.457031 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6819.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6853.357422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6885.144531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6926.257812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6987.537109 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7026.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7115.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7147.498047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7175.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7227.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7259.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7322.644531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7384.167969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.376953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7484.900391 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7621.675781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.458984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7712.837891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7740.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7792.720703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7831.929688 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7859.712891 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3352.783203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3416.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.816406 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.177734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3638.964844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.748047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3852.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.269531 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.451172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.267578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4211.958984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.742188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.265625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.544922 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4425.923828 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.546875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.238281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.417969 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.041016 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.828125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.451172 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.074219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4836.861328 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.484375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.568359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.412109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.035156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.822266 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.609375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.183594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5252.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.179688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.421875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.603516 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5518.982422 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.458984 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.837891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.314453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.693359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5811.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.265625 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.677734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.677734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.119141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6365.90625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.005859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.384766 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.664062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.619141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.800781 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.701172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.488281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6989.880859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7056.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.054688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.841797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7324.988281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.511719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.607422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.019531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.802734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7742.964844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.273438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.056641 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd8e23cf786">
-   <rect x="81.708594" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pe9d4a18125">
+   <rect x="81.790625" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-23T04:23:39Z",
+  "date": "2026-06-23T05:33:29Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "f2d6c3a8",
+  "git_commit": "8c62bf80",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.72,
-   "decompress_mbps": 136.7
+   "compress_mbps": 40.3,
+   "decompress_mbps": 135.16
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.43,
-   "decompress_mbps": 150.43
+   "compress_mbps": 36.94,
+   "decompress_mbps": 151.44
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.53,
-   "decompress_mbps": 165.95
+   "compress_mbps": 34.35,
+   "decompress_mbps": 165.33
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.67,
-   "decompress_mbps": 171.17
+   "compress_mbps": 27.51,
+   "decompress_mbps": 168.2
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.88,
-   "decompress_mbps": 176.46
+   "compress_mbps": 26.67,
+   "decompress_mbps": 174.57
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.07,
-   "decompress_mbps": 183.54
+   "compress_mbps": 24.83,
+   "decompress_mbps": 179.12
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.36,
-   "decompress_mbps": 182.76
+   "compress_mbps": 9.26,
+   "decompress_mbps": 179.6
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.22,
-   "decompress_mbps": 183.52
+   "compress_mbps": 9.12,
+   "decompress_mbps": 179.43
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.28,
-   "decompress_mbps": 183.32
+   "compress_mbps": 1.25,
+   "decompress_mbps": 179.47
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.72,
-   "decompress_mbps": 130.54
+   "compress_mbps": 36.91,
+   "decompress_mbps": 127.49
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.88,
-   "decompress_mbps": 138.86
+   "compress_mbps": 34.26,
+   "decompress_mbps": 137.43
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.75,
-   "decompress_mbps": 149.49
+   "compress_mbps": 32.31,
+   "decompress_mbps": 148.55
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.7,
-   "decompress_mbps": 155.98
+   "compress_mbps": 25.42,
+   "decompress_mbps": 153.66
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 163.2
+   "compress_mbps": 24.6,
+   "decompress_mbps": 159.36
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.84,
-   "decompress_mbps": 165.8
+   "compress_mbps": 23.87,
+   "decompress_mbps": 162.4
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.96,
-   "decompress_mbps": 166.33
+   "compress_mbps": 8.97,
+   "decompress_mbps": 162.72
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.97,
-   "decompress_mbps": 166.48
+   "compress_mbps": 9.02,
+   "decompress_mbps": 163.08
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.4,
-   "decompress_mbps": 166.18
+   "compress_mbps": 1.35,
+   "decompress_mbps": 162.74
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 34.23,
-   "decompress_mbps": 151.05
+   "compress_mbps": 34.14,
+   "decompress_mbps": 144.42
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.17,
-   "decompress_mbps": 157.6
+   "compress_mbps": 32.89,
+   "decompress_mbps": 149.27
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.3,
-   "decompress_mbps": 161.36
+   "compress_mbps": 32.21,
+   "decompress_mbps": 152.24
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.77,
-   "decompress_mbps": 164.91
+   "compress_mbps": 30.18,
+   "decompress_mbps": 157.97
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.05,
-   "decompress_mbps": 171.86
+   "compress_mbps": 29.61,
+   "decompress_mbps": 163.48
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.22,
-   "decompress_mbps": 171.87
+   "compress_mbps": 28.81,
+   "decompress_mbps": 164.93
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.75,
-   "decompress_mbps": 173.96
+   "compress_mbps": 9.7,
+   "decompress_mbps": 167.15
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.77,
-   "decompress_mbps": 173.46
+   "compress_mbps": 9.71,
+   "decompress_mbps": 167.44
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.62,
-   "decompress_mbps": 172.73
+   "compress_mbps": 1.61,
+   "decompress_mbps": 166.97
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.05,
-   "decompress_mbps": 124.55
+   "compress_mbps": 23.14,
+   "decompress_mbps": 112.36
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.07,
-   "decompress_mbps": 128.52
+   "compress_mbps": 22.62,
+   "decompress_mbps": 115.49
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.73,
-   "decompress_mbps": 131.7
+   "compress_mbps": 22.47,
+   "decompress_mbps": 116.65
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.66,
-   "decompress_mbps": 135.38
+   "compress_mbps": 21.29,
+   "decompress_mbps": 121.58
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.21,
-   "decompress_mbps": 138.57
+   "compress_mbps": 21.36,
+   "decompress_mbps": 122.32
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.29,
-   "decompress_mbps": 139.03
+   "compress_mbps": 21.3,
+   "decompress_mbps": 123.97
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.13,
-   "decompress_mbps": 139.47
+   "compress_mbps": 7.12,
+   "decompress_mbps": 124.31
   },
   {
    "compressor": "native",
@@ -355,7 +355,7 @@
    "out_size": 3128,
    "ratio": 0.2805,
    "compress_mbps": 7.11,
-   "decompress_mbps": 139.59
+   "decompress_mbps": 124.41
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.53,
-   "decompress_mbps": 138.47
+   "compress_mbps": 1.52,
+   "decompress_mbps": 124.05
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.69,
-   "decompress_mbps": 70.55
+   "compress_mbps": 11.55,
+   "decompress_mbps": 60.05
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.6,
-   "decompress_mbps": 71.83
+   "compress_mbps": 11.71,
+   "decompress_mbps": 60.96
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.58,
-   "decompress_mbps": 71.88
+   "compress_mbps": 11.62,
+   "decompress_mbps": 61.01
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.53,
-   "decompress_mbps": 73.03
+   "compress_mbps": 11.18,
+   "decompress_mbps": 62.02
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.41,
-   "decompress_mbps": 73.51
+   "compress_mbps": 11.4,
+   "decompress_mbps": 62.5
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 73.85
+   "compress_mbps": 11.41,
+   "decompress_mbps": 62.81
   },
   {
    "compressor": "native",
@@ -435,7 +435,7 @@
    "out_size": 1209,
    "ratio": 0.3249,
    "compress_mbps": 3.86,
-   "decompress_mbps": 73.98
+   "decompress_mbps": 62.82
   },
   {
    "compressor": "native",
@@ -445,7 +445,7 @@
    "out_size": 1209,
    "ratio": 0.3249,
    "compress_mbps": 3.87,
-   "decompress_mbps": 73.8
+   "decompress_mbps": 62.8
   },
   {
    "compressor": "native",
@@ -455,7 +455,7 @@
    "out_size": 1190,
    "ratio": 0.3198,
    "compress_mbps": 1.23,
-   "decompress_mbps": 73.77
+   "decompress_mbps": 62.57
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 64.88,
-   "decompress_mbps": 233.58
+   "compress_mbps": 62.78,
+   "decompress_mbps": 253.23
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 61.96,
-   "decompress_mbps": 280.67
+   "compress_mbps": 59.86,
+   "decompress_mbps": 277.15
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 59.97,
-   "decompress_mbps": 294.88
+   "compress_mbps": 59.47,
+   "decompress_mbps": 290.4
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 56.23,
-   "decompress_mbps": 303.86
+   "compress_mbps": 55.14,
+   "decompress_mbps": 300.86
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 55.25,
-   "decompress_mbps": 234.57
+   "compress_mbps": 55.13,
+   "decompress_mbps": 291.25
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 52.18,
-   "decompress_mbps": 235.91
+   "compress_mbps": 52.19,
+   "decompress_mbps": 299.63
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.62,
-   "decompress_mbps": 218.81
+   "compress_mbps": 9.52,
+   "decompress_mbps": 303.1
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.62,
-   "decompress_mbps": 213.95
+   "compress_mbps": 7.53,
+   "decompress_mbps": 306.96
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 211.76
+   "compress_mbps": 0.96,
+   "decompress_mbps": 307.38
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.16,
-   "decompress_mbps": 143.52
+   "compress_mbps": 43.47,
+   "decompress_mbps": 142.8
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.41,
-   "decompress_mbps": 154.13
+   "compress_mbps": 40.09,
+   "decompress_mbps": 154.41
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 37.48,
-   "decompress_mbps": 171.33
+   "compress_mbps": 37.03,
+   "decompress_mbps": 170.96
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 29.31,
-   "decompress_mbps": 176.93
+   "compress_mbps": 29.1,
+   "decompress_mbps": 175.58
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.47,
-   "decompress_mbps": 184.46
+   "compress_mbps": 28.42,
+   "decompress_mbps": 182.88
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.34,
-   "decompress_mbps": 187.27
+   "compress_mbps": 26.3,
+   "decompress_mbps": 187.02
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 10.04,
-   "decompress_mbps": 187.81
+   "compress_mbps": 10.02,
+   "decompress_mbps": 187.72
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.93,
-   "decompress_mbps": 187.65
+   "compress_mbps": 9.87,
+   "decompress_mbps": 187.48
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.3,
-   "decompress_mbps": 188.07
+   "compress_mbps": 1.29,
+   "decompress_mbps": 188.81
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 37.5,
-   "decompress_mbps": 124.71
+   "compress_mbps": 37.73,
+   "decompress_mbps": 120.97
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 34.71,
-   "decompress_mbps": 136.09
+   "compress_mbps": 34.33,
+   "decompress_mbps": 132.39
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.85,
-   "decompress_mbps": 145.69
+   "compress_mbps": 31.58,
+   "decompress_mbps": 145.96
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.44,
-   "decompress_mbps": 151.77
+   "compress_mbps": 23.23,
+   "decompress_mbps": 150.29
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 158.87
+   "compress_mbps": 22.5,
+   "decompress_mbps": 155.51
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 21.0,
-   "decompress_mbps": 162.64
+   "compress_mbps": 20.96,
+   "decompress_mbps": 159.5
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.49,
-   "decompress_mbps": 162.9
+   "compress_mbps": 8.5,
+   "decompress_mbps": 159.67
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.46,
-   "decompress_mbps": 163.65
+   "compress_mbps": 8.49,
+   "decompress_mbps": 159.83
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 164.15
+   "compress_mbps": 1.24,
+   "decompress_mbps": 159.83
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 120.73,
-   "decompress_mbps": 399.35
+   "compress_mbps": 118.06,
+   "decompress_mbps": 394.87
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 107.24,
-   "decompress_mbps": 415.51
+   "compress_mbps": 104.81,
+   "decompress_mbps": 413.2
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 92.5,
-   "decompress_mbps": 444.09
+   "compress_mbps": 90.12,
+   "decompress_mbps": 440.4
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 73.84,
-   "decompress_mbps": 400.47
+   "compress_mbps": 72.22,
+   "decompress_mbps": 401.32
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 71.11,
-   "decompress_mbps": 427.42
+   "compress_mbps": 69.9,
+   "decompress_mbps": 424.36
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 64.47,
-   "decompress_mbps": 460.28
+   "compress_mbps": 63.33,
+   "decompress_mbps": 456.93
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 19.27,
-   "decompress_mbps": 485.81
+   "compress_mbps": 19.14,
+   "decompress_mbps": 483.82
   },
   {
    "compressor": "native",
@@ -805,7 +805,7 @@
    "out_size": 52897,
    "ratio": 0.1031,
    "compress_mbps": 16.99,
-   "decompress_mbps": 519.55
+   "decompress_mbps": 515.83
   },
   {
    "compressor": "native",
@@ -815,7 +815,7 @@
    "out_size": 51490,
    "ratio": 0.1003,
    "compress_mbps": 0.97,
-   "decompress_mbps": 528.9
+   "decompress_mbps": 527.47
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.42,
-   "decompress_mbps": 113.93
+   "compress_mbps": 26.44,
+   "decompress_mbps": 131.63
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.82,
-   "decompress_mbps": 118.94
+   "compress_mbps": 25.91,
+   "decompress_mbps": 135.36
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.38,
-   "decompress_mbps": 124.06
+   "compress_mbps": 25.3,
+   "decompress_mbps": 137.27
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.26,
-   "decompress_mbps": 122.43
+   "compress_mbps": 23.24,
+   "decompress_mbps": 143.49
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.95,
-   "decompress_mbps": 130.38
+   "compress_mbps": 22.89,
+   "decompress_mbps": 150.71
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.75,
-   "decompress_mbps": 132.34
+   "compress_mbps": 21.74,
+   "decompress_mbps": 153.33
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 5.76,
-   "decompress_mbps": 133.32
+   "compress_mbps": 5.74,
+   "decompress_mbps": 155.04
   },
   {
    "compressor": "native",
@@ -895,7 +895,7 @@
    "out_size": 13028,
    "ratio": 0.3407,
    "compress_mbps": 5.39,
-   "decompress_mbps": 138.08
+   "decompress_mbps": 155.99
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.21,
-   "decompress_mbps": 136.92
+   "compress_mbps": 1.2,
+   "decompress_mbps": 157.98
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.8,
-   "decompress_mbps": 73.14
+   "compress_mbps": 12.6,
+   "decompress_mbps": 62.86
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.76,
-   "decompress_mbps": 73.1
+   "compress_mbps": 12.56,
+   "decompress_mbps": 63.05
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.73,
-   "decompress_mbps": 73.23
+   "compress_mbps": 12.54,
+   "decompress_mbps": 63.25
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.64,
-   "decompress_mbps": 74.58
+   "compress_mbps": 12.42,
+   "decompress_mbps": 64.22
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.57,
-   "decompress_mbps": 75.41
+   "compress_mbps": 12.38,
+   "decompress_mbps": 64.7
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.53,
-   "decompress_mbps": 75.42
+   "compress_mbps": 12.44,
+   "decompress_mbps": 64.59
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 75.34
+   "compress_mbps": 4.16,
+   "decompress_mbps": 64.85
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 75.49
+   "compress_mbps": 4.15,
+   "decompress_mbps": 64.96
   },
   {
    "compressor": "native",
@@ -995,7 +995,7 @@
    "out_size": 1696,
    "ratio": 0.4012,
    "compress_mbps": 1.39,
-   "decompress_mbps": 75.51
+   "decompress_mbps": 64.8
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 37.93,
-   "decompress_mbps": 127.71
+   "compress_mbps": 37.62,
+   "decompress_mbps": 125.0
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 34.39,
-   "decompress_mbps": 137.03
+   "compress_mbps": 34.47,
+   "decompress_mbps": 137.14
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.76,
-   "decompress_mbps": 151.94
+   "compress_mbps": 33.63,
+   "decompress_mbps": 149.83
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.89,
-   "decompress_mbps": 155.57
+   "compress_mbps": 25.8,
+   "decompress_mbps": 152.53
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.11,
-   "decompress_mbps": 161.82
+   "compress_mbps": 25.0,
+   "decompress_mbps": 158.7
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.22,
-   "decompress_mbps": 165.1
+   "compress_mbps": 22.55,
+   "decompress_mbps": 163.58
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.9,
-   "decompress_mbps": 169.18
+   "compress_mbps": 8.94,
+   "decompress_mbps": 168.67
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.98,
-   "decompress_mbps": 169.61
+   "compress_mbps": 8.94,
+   "decompress_mbps": 170.15
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.27,
-   "decompress_mbps": 170.26
+   "compress_mbps": 1.25,
+   "decompress_mbps": 168.41
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 51.51,
-   "decompress_mbps": 129.72
+   "compress_mbps": 50.68,
+   "decompress_mbps": 156.24
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 48.56,
-   "decompress_mbps": 137.74
+   "compress_mbps": 48.28,
+   "decompress_mbps": 163.86
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 45.84,
-   "decompress_mbps": 141.58
+   "compress_mbps": 45.41,
+   "decompress_mbps": 168.58
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.62,
-   "decompress_mbps": 146.19
+   "compress_mbps": 38.39,
+   "decompress_mbps": 176.44
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.58,
-   "decompress_mbps": 155.85
+   "compress_mbps": 36.52,
+   "decompress_mbps": 185.11
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.83,
-   "decompress_mbps": 155.08
+   "compress_mbps": 32.93,
+   "decompress_mbps": 191.2
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177172,
    "ratio": 0.3744,
-   "compress_mbps": 7.5,
-   "decompress_mbps": 158.38
+   "compress_mbps": 7.55,
+   "decompress_mbps": 186.12
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.85,
-   "decompress_mbps": 159.9
+   "compress_mbps": 6.92,
+   "decompress_mbps": 190.89
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.18,
-   "decompress_mbps": 158.91
+   "compress_mbps": 1.17,
+   "decompress_mbps": 190.06
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 51.6,
-   "decompress_mbps": 124.15
+   "compress_mbps": 51.19,
+   "decompress_mbps": 150.21
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.71,
-   "decompress_mbps": 129.02
+   "compress_mbps": 47.56,
+   "decompress_mbps": 155.82
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 42.56,
-   "decompress_mbps": 132.59
+   "compress_mbps": 38.48,
+   "decompress_mbps": 165.93
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.44,
-   "decompress_mbps": 124.42
+   "compress_mbps": 30.91,
+   "decompress_mbps": 158.15
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.89,
-   "decompress_mbps": 130.46
+   "compress_mbps": 27.98,
+   "decompress_mbps": 162.73
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.51,
-   "decompress_mbps": 135.07
+   "compress_mbps": 25.42,
+   "decompress_mbps": 168.36
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.46,
-   "decompress_mbps": 135.33
+   "compress_mbps": 8.32,
+   "decompress_mbps": 165.58
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.21,
-   "decompress_mbps": 141.49
+   "compress_mbps": 8.23,
+   "decompress_mbps": 174.11
   },
   {
    "compressor": "native",
@@ -4235,7 +4235,7 @@
    "out_size": 3520112,
    "ratio": 0.3531,
    "compress_mbps": 1.0,
-   "decompress_mbps": 141.5
+   "decompress_mbps": 182.84
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 121.5,
-   "decompress_mbps": 449.89
+   "compress_mbps": 119.68,
+   "decompress_mbps": 428.77
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 105.69,
-   "decompress_mbps": 502.85
+   "compress_mbps": 104.01,
+   "decompress_mbps": 492.36
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 89.04,
-   "decompress_mbps": 558.27
+   "compress_mbps": 87.44,
+   "decompress_mbps": 546.73
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 80.46,
-   "decompress_mbps": 572.69
+   "compress_mbps": 79.82,
+   "decompress_mbps": 560.3
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 78.34,
-   "decompress_mbps": 648.58
+   "compress_mbps": 76.39,
+   "decompress_mbps": 630.06
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 72.49,
-   "decompress_mbps": 695.69
+   "compress_mbps": 71.18,
+   "decompress_mbps": 675.59
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 26.33,
-   "decompress_mbps": 689.37
+   "compress_mbps": 25.95,
+   "decompress_mbps": 675.52
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.87,
-   "decompress_mbps": 710.5
+   "compress_mbps": 22.8,
+   "decompress_mbps": 696.61
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 2868751,
    "ratio": 0.0855,
    "compress_mbps": 0.78,
-   "decompress_mbps": 649.76
+   "decompress_mbps": 639.92
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 86.29
+   "compress_mbps": 37.55,
+   "decompress_mbps": 106.62
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 36.12,
-   "decompress_mbps": 88.44
+   "compress_mbps": 36.2,
+   "decompress_mbps": 108.91
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 35.05,
-   "decompress_mbps": 94.1
+   "compress_mbps": 35.07,
+   "decompress_mbps": 111.83
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.67,
-   "decompress_mbps": 96.6
+   "compress_mbps": 29.62,
+   "decompress_mbps": 120.55
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 100.32
+   "compress_mbps": 29.28,
+   "decompress_mbps": 125.09
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 28.01,
-   "decompress_mbps": 103.43
+   "compress_mbps": 28.34,
+   "decompress_mbps": 127.5
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 7.03,
-   "decompress_mbps": 103.88
+   "compress_mbps": 6.9,
+   "decompress_mbps": 128.56
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.81,
-   "decompress_mbps": 104.85
+   "compress_mbps": 6.79,
+   "decompress_mbps": 130.57
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.48,
-   "decompress_mbps": 104.78
+   "compress_mbps": 1.46,
+   "decompress_mbps": 129.94
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 52.75,
-   "decompress_mbps": 131.25
+   "compress_mbps": 53.22,
+   "decompress_mbps": 179.75
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.87,
-   "decompress_mbps": 135.75
+   "compress_mbps": 50.01,
+   "decompress_mbps": 185.51
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 49.37,
-   "decompress_mbps": 139.63
+   "compress_mbps": 48.79,
+   "decompress_mbps": 189.21
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 45.33,
-   "decompress_mbps": 141.94
+   "compress_mbps": 44.89,
+   "decompress_mbps": 202.29
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 45.55,
-   "decompress_mbps": 140.03
+   "compress_mbps": 45.02,
+   "decompress_mbps": 206.49
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 45.36,
-   "decompress_mbps": 141.18
+   "compress_mbps": 44.84,
+   "decompress_mbps": 216.74
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.26,
-   "decompress_mbps": 144.78
+   "compress_mbps": 12.02,
+   "decompress_mbps": 224.18
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.12,
-   "decompress_mbps": 144.19
+   "compress_mbps": 12.09,
+   "decompress_mbps": 229.52
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.78,
-   "decompress_mbps": 144.16
+   "compress_mbps": 1.76,
+   "decompress_mbps": 224.32
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 47.87,
-   "decompress_mbps": 156.41
+   "compress_mbps": 47.25,
+   "decompress_mbps": 156.07
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 41.38,
-   "decompress_mbps": 173.2
+   "compress_mbps": 41.16,
+   "decompress_mbps": 175.15
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 36.67,
-   "decompress_mbps": 192.57
+   "compress_mbps": 35.67,
+   "decompress_mbps": 188.35
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.96,
-   "decompress_mbps": 195.59
+   "compress_mbps": 26.57,
+   "decompress_mbps": 197.54
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.85,
-   "decompress_mbps": 207.7
+   "compress_mbps": 24.65,
+   "decompress_mbps": 201.55
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 216.86
+   "compress_mbps": 20.6,
+   "decompress_mbps": 217.78
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.51,
-   "decompress_mbps": 229.74
+   "compress_mbps": 8.48,
+   "decompress_mbps": 221.21
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.78,
-   "decompress_mbps": 229.93
+   "compress_mbps": 7.8,
+   "decompress_mbps": 221.65
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 0.92,
-   "decompress_mbps": 232.17
+   "decompress_mbps": 221.79
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 66.82,
-   "decompress_mbps": 237.08
+   "compress_mbps": 66.14,
+   "decompress_mbps": 231.86
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 61.07,
-   "decompress_mbps": 248.56
+   "compress_mbps": 61.08,
+   "decompress_mbps": 245.22
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 56.23,
-   "decompress_mbps": 261.12
+   "compress_mbps": 55.96,
+   "decompress_mbps": 254.19
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 47.29,
-   "decompress_mbps": 271.97
+   "compress_mbps": 46.52,
+   "decompress_mbps": 266.61
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.92,
-   "decompress_mbps": 281.67
+   "compress_mbps": 45.19,
+   "decompress_mbps": 276.43
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.84,
-   "decompress_mbps": 290.38
+   "compress_mbps": 42.22,
+   "decompress_mbps": 283.94
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.17,
-   "decompress_mbps": 271.25
+   "compress_mbps": 13.23,
+   "decompress_mbps": 268.06
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.7,
-   "decompress_mbps": 273.44
+   "compress_mbps": 12.8,
+   "decompress_mbps": 281.74
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5169629,
    "ratio": 0.2393,
-   "compress_mbps": 1.32,
-   "decompress_mbps": 292.12
+   "compress_mbps": 1.31,
+   "decompress_mbps": 279.98
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.26,
-   "decompress_mbps": 112.57
+   "compress_mbps": 32.17,
+   "decompress_mbps": 106.59
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 31.39,
-   "decompress_mbps": 115.91
+   "compress_mbps": 30.71,
+   "decompress_mbps": 109.26
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 29.86,
-   "decompress_mbps": 120.52
+   "compress_mbps": 29.53,
+   "decompress_mbps": 113.13
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.37,
-   "decompress_mbps": 124.38
+   "compress_mbps": 25.27,
+   "decompress_mbps": 116.67
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.86,
-   "decompress_mbps": 125.87
+   "compress_mbps": 24.89,
+   "decompress_mbps": 118.35
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 128.28
+   "compress_mbps": 24.07,
+   "decompress_mbps": 119.99
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.22,
-   "decompress_mbps": 129.05
+   "compress_mbps": 6.23,
+   "decompress_mbps": 121.85
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.19,
-   "decompress_mbps": 128.69
+   "compress_mbps": 6.25,
+   "decompress_mbps": 117.22
   },
   {
    "compressor": "native",
@@ -4775,7 +4775,7 @@
    "out_size": 5261135,
    "ratio": 0.7255,
    "compress_mbps": 1.56,
-   "decompress_mbps": 129.92
+   "decompress_mbps": 121.92
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 50.48,
-   "decompress_mbps": 166.33
+   "compress_mbps": 50.06,
+   "decompress_mbps": 164.88
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 46.38,
-   "decompress_mbps": 179.47
+   "compress_mbps": 46.02,
+   "decompress_mbps": 179.19
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 43.66,
-   "decompress_mbps": 192.51
+   "compress_mbps": 43.37,
+   "decompress_mbps": 192.16
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 36.04,
-   "decompress_mbps": 201.68
+   "compress_mbps": 35.73,
+   "decompress_mbps": 199.56
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.56,
-   "decompress_mbps": 209.1
+   "compress_mbps": 34.48,
+   "decompress_mbps": 207.06
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.49,
-   "decompress_mbps": 214.99
+   "compress_mbps": 31.16,
+   "decompress_mbps": 213.79
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.6,
-   "decompress_mbps": 214.38
+   "compress_mbps": 11.68,
+   "decompress_mbps": 213.69
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 214.7
+   "compress_mbps": 11.45,
+   "decompress_mbps": 215.35
   },
   {
    "compressor": "native",
@@ -4865,7 +4865,7 @@
    "out_size": 11638957,
    "ratio": 0.2807,
    "compress_mbps": 1.22,
-   "decompress_mbps": 214.25
+   "decompress_mbps": 215.17
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 69.53
+   "compress_mbps": 32.1,
+   "decompress_mbps": 93.36
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.6,
-   "decompress_mbps": 75.1
+   "compress_mbps": 32.55,
+   "decompress_mbps": 93.88
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 32.47,
-   "decompress_mbps": 79.31
+   "compress_mbps": 32.4,
+   "decompress_mbps": 95.79
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.64,
-   "decompress_mbps": 78.07
+   "compress_mbps": 30.51,
+   "decompress_mbps": 93.48
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.8,
-   "decompress_mbps": 78.86
+   "compress_mbps": 30.64,
+   "decompress_mbps": 95.56
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.65,
-   "decompress_mbps": 80.46
+   "compress_mbps": 31.19,
+   "decompress_mbps": 96.31
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.67,
-   "decompress_mbps": 81.53
+   "compress_mbps": 4.61,
+   "decompress_mbps": 97.72
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.69,
-   "decompress_mbps": 82.42
+   "compress_mbps": 4.63,
+   "decompress_mbps": 97.8
   },
   {
    "compressor": "native",
@@ -4955,7 +4955,7 @@
    "out_size": 5825680,
    "ratio": 0.6875,
    "compress_mbps": 1.67,
-   "decompress_mbps": 82.03
+   "decompress_mbps": 97.16
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 96.61,
-   "decompress_mbps": 319.69
+   "compress_mbps": 95.9,
+   "decompress_mbps": 325.58
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 87.11,
-   "decompress_mbps": 354.03
+   "compress_mbps": 87.1,
+   "decompress_mbps": 349.2
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 77.53,
-   "decompress_mbps": 394.02
+   "compress_mbps": 78.09,
+   "decompress_mbps": 402.85
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 64.47,
-   "decompress_mbps": 385.23
+   "compress_mbps": 64.42,
+   "decompress_mbps": 380.48
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.35,
-   "decompress_mbps": 427.02
+   "compress_mbps": 62.3,
+   "decompress_mbps": 432.52
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 57.84,
-   "decompress_mbps": 460.74
+   "compress_mbps": 58.08,
+   "decompress_mbps": 458.55
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.59,
-   "decompress_mbps": 475.93
+   "compress_mbps": 21.81,
+   "decompress_mbps": 453.97
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.37,
-   "decompress_mbps": 487.3
+   "compress_mbps": 20.36,
+   "decompress_mbps": 472.34
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 0.98,
-   "decompress_mbps": 481.02
+   "decompress_mbps": 515.21
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR widens the fast Huffman root decode table from `fastBits = 9` to `11` (libdeflate's `LITLEN_TABLEBITS`), so fewer codewords spill to the slow/subtable path. The canonical O(2^bits) table build from Phase 4 (https://github.com/kim-em/lean-zip/issues/2671) keeps the wider 2048-entry table cheap to construct, so this is now the cheap, sensible width. `peekFast` reads 3 bytes instead of 2 (an 11-bit window after a ≤7-bit bit-offset spans bits 0..17, which three bytes always cover), and the `0x1FF`/`2^9`/`512` constants threaded through `Zip/Native/Inflate.lean` and the proof files become `0x7FF`/`2^11`/`2048`. The `peekFast_testBit` and `peekFast_testBit_eof` bit-correspondence proofs gain a third byte case (`pos` / `pos+1` / `pos+2`), `peek_eq`/`peek_eq_refilled` require the buffer to hold 11 bits rather than 9, and `decodeSym_corr`/`buildTable_codeLen_le` bound table code lengths by `fastBits = 11`. The `termination_by … * 9 + cnt` refill measures keep their literal `9` (one byte refilled adds 8 bits, unrelated to the table width).

It also generalizes `go_corr` over abstract `litTable distTable : DecodeTable` (with per-index `lenAt … ≤ 11` hypotheses, exactly as `goFusedP_eq` and `goFused_eq_go` already are), instantiating with `buildTable` + `buildTable_codeLen_le` at its single call site. At the wider table the old concrete-table statement made the kernel reduce the 2048-entry `Array.ofFn` while checking the loop induction — a ~35 GB proof term that OOMs CI's 16 GB runner; abstracting the table drops the check to ~9s / 1.25 GB with no statement weakening (the concrete result is recovered by instantiation).

There is no new `sorry` and no `@[implemented_by]` trust gap; the full `lake build` and the differential conformance tests (`decodeWithTable` vs tree walk, canonical-fill vs tree build, native vs FFI fuzz) all pass, with the test depth sweeps updated to straddle the new boundary at 11.

Closes #2672.

🤖 Prepared with Claude Code