### PR TITLE
perf(compress): promote level 7 to the top single-block point, de-collapsing L7/L8

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1259,9 +1259,9 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
   -- Every region looked incompressible.
   return true
 
-/-- Unified raw DEFLATE compression dispatch. Level 0 = stored; level ≥ 1 runs the
+/-- Unified raw DEFLATE compression dispatch. Level 0 = stored; levels 1–7 run the
     single-block cost-model dispatch (`deflateRawBase`). At the max-compression
-    tiers (level ≥ 7) two block-split streams are also tried, and the smallest of
+    tiers (level ≥ 8) two block-split streams are also tried, and the smallest of
     all candidates is emitted:
       * self-contained split — per-chunk Huffman trees, fresh window per chunk
         (wins on locally-varying statistics, e.g. structured binary);
@@ -1287,6 +1287,19 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     single-block so it pays no extra compress time. All branches are
     roundtrip-verified.
 
+    The split entry sits at level ≥ 8 (was ≥ 7): the single-block → split transition is
+    a hard ~2.5–3× compress-speed cliff (a second whole-file encode plus the partition
+    sizing), and levels 7 and 8 both paid it, landing coincident (they differed only in
+    chain depth, which saturates). Promoting level 7 to the *strongest single-block*
+    point (full lazy lookahead, chain depth 256) de-collapses the pair: level 7 fills the
+    empty band between level 6 and the split tier — on Canterbury outside the prior hull,
+    on Silesia a distinct Pareto-efficient point on it — while level 8 still emits the
+    split ratio level 7 used to carry (same candidate, deeper chain; empirically
+    equal-or-better on the measured corpora). The matcher knobs cannot separate the two
+    split levels (chain depth and the lazy gate are quality-for-speed tradeoffs that
+    trace one frontier); pushing the frontier itself out is the work of #2696 (chain
+    self-throttle) and #2638 (near-optimal parse). See #2698.
+
     Before any of that, an `incompressiblePrescan` reads a bounded sample (≤128 KiB,
     short-circuited on the first compressible region) and, on unambiguously
     incompressible input, dispatches straight to `deflateStoredPure` — skipping the
@@ -1297,7 +1310,7 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if incompressiblePrescan data then deflateStoredPure data
-  else if 7 ≤ level then
+  else if 8 ≤ level then
     -- One *packed* matcher pass shared by the base and shared-split candidates
     -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
     -- The base candidate consumes the packed words end-to-end (freqs *and*
@@ -1311,8 +1324,10 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
             (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))))
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
-      -- The self-contained split is demoted to level 9: it wins on exactly
-      -- one corpus file while paying a full per-chunk match pass.
+      -- Level 8: base vs cross-block split. The self-contained split is demoted to
+      -- level 9 (it wins on exactly one corpus file while paying a full per-chunk
+      -- match pass). Level 7 no longer enters here — it is the top single-block
+      -- point (see the dispatch docstring), so the split tier starts at level 8.
       pickSmaller (deflateRawBaseP data ptokens)
         (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))
   else deflateRawBase data level

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -25,7 +25,7 @@ The three contracts the dynamic encoder consumes, lifted to the level-dispatched
 `lzMatch` by casing on `4 ≤ level` and applying the lazy (`lz77ChainLazyIter_*`) or
 greedy (`lz77ChainIter_*`) version. Both arms are line-for-line parallel because
 the two matchers share contract signatures. Consumed here and in `DeflateRoundtrip`,
-so the `7 ≤ level`/`4 ≤ level` split lives in exactly one place. -/
+so the `8 ≤ level`/`4 ≤ level` split lives in exactly one place. -/
 
 theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
     ∀ t ∈ (lzMatch data level).toList,
@@ -1478,7 +1478,7 @@ theorem emitSharedBlocksAtSized_eq (data : ByteArray) (toks : Array LZ77Token)
   emitSharedBlocksAtSized_eq_fuel data toks (toks.size - pos + 1) pos (by omega) cuts bw
 
 /-- The sized-tree shared-window candidate is byte-identical to the reference
-    arbitrated candidate: `deflateRaw`'s level ≥ 7 branches and the roundtrip
+    arbitrated candidate: `deflateRaw`'s level ≥ 8 branches and the roundtrip
     proofs see the old `deflateDynamicBlocksSharedAtTokens … chooseSplitsArbitrated`
     through this rewrite. -/
 theorem deflateDynamicBlocksSharedSized_eq (data : ByteArray) (toks : Array LZ77Token) :

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -13,7 +13,7 @@ Proves the unified roundtrip theorem for `deflateRaw`:
 `deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
 block; level ≥ 1 runs the single-block cost-model dispatch `deflateRawBase`
 (stored / fixed / dynamic, all sized from one hash-chain token pass, emitting
-only the smallest); and level ≥ 7 additionally compares two block-split streams
+only the smallest); and level ≥ 8 additionally compares two block-split streams
 (self-contained #2524 and cross-block shared-window #2525) against that base via
 `pickSmaller`, so the split is a first-class candidate that can only ever win.
 
@@ -107,7 +107,7 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The incompressible pre-scan
     and the level-0 path both dispatch to `deflateStoredPure` directly; the
-    cost-model stored fallback is covered by `deflateRawBase`; the level-≥7
+    cost-model stored fallback is covered by `deflateRawBase`; the level-≥8
     block-split candidates are covered by the `pickSmaller` cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -501,8 +501,9 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
       throw (IO.userError "deflateDynamicBlocksShared(tokChunk=1)→inflate mismatch on text")
   | .error e => throw (IO.userError s!"deflateDynamicBlocksShared(tokChunk=1)→inflate failed: {e}")
 
-  -- deflateRaw at the max-compression tiers (≥ 7) now considers the shared-window
-  -- split via pickSmaller; verify roundtrip on text and large inputs.
+  -- deflateRaw at the max-compression tiers (≥ 8) considers the shared-window
+  -- split via pickSmaller; level 7 is the top single-block point (#2698). Verify
+  -- roundtrip across the single-block/split boundary on text and large inputs.
   for level in [7, 8, 9] do
     for (name, data) in [("text", textRepeat), ("256K-cyclic", largeCyclic),
                           ("256K-prng", mkPrngData 262144)] do

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p03f746c8d1)">
+   <g clip-path="url(#p838d365e5d)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image62f4d7b827" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3Yz4rkZxmG4aqemiEMzaBC/jiIiKC4cO8ix+DGA/EIPIscgSC4ciuiS3cegkYRIWPUZtqMnZlKd0393LkP3B+vKa7rCJ6i4K27vv35s19uO75ajnfTC9Y5vppesMT2cD89YZn9s/emJ6zx+J3pBetcXU0vWOPhOL1gnf1lfmfb7YvpCctc5jcGADBIYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxA5/3d1Mb1ji4XycnrDMN7/23ekJy1xvH0xPWGL/+cvpCcv8/s0fpycs8a0n701PWOZ0vp+esMTd28u9+/fn0/SEJX707NvTE5bxggUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/asvfrVNj1jhzeluesIy756fTk9Y53Q/vWCNu5vpBeu8//3pBUvcba+nJyxzqffx3e16esIyL3Yvpycs8fzm39MTlvGCBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHD9e3N9IYlrg9Ppiesc/x0esEy291n0xPWOJ+nFyyzf/rP6QlLXPINuT48m56wxpN3phcs8/zN/fSEJbbXf5+esIwXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2GG7+XR6A1/W+Ty9AP5n++Qv0xPWuPL/8yvHbeT/iAsCABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAscNP//W36Q1L3B7fTk9Y5g8vXk1PWObXP/lwesISHzz9zvSEZX74819MT1jix9/7xvSEZf58e5yewJf0m99+PD1hidcf/Wx6wjJesAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2P51/t02PWOHt+TQ9YZmr/eV28aPj6+kJazw6TC9Y5/OX0wuWOH/9+fSEZbbtPD1hiUcX/GbwsF3mb9rj02V+rt3OCxYAQE5gAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEDleX2lhXh+kFy1z94+PpCcts/7mdnrDG6TS9YJn9Dz6cnrDEhV7G3W63273dnacnrPFwnF6wzOMv7qYnLLF98qfpCctc8g0BABghsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYv8F7OOLBWFgl6gAAAAASUVORK5CYII=" id="image7e8475812a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc39a303a88" d="M 0 0 
+       <path id="m7f40b94546" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc39a303a88" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc39a303a88" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc39a303a88" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc39a303a88" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc39a303a88" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc39a303a88" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc39a303a88" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc39a303a88" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc39a303a88" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc39a303a88" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc39a303a88" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f40b94546" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m18ea45ddb2" d="M 0 0 
+       <path id="m8676634208" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m18ea45ddb2" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8676634208" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,10 +1303,44 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -2 -->
+    <!-- -3 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
@@ -1353,27 +1387,15 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -57 -->
+    <!-- -59 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -86 -->
+    <!-- -87 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1415,40 +1437,20 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1460,17 +1462,17 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +4 -->
+    <!-- +3 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +0 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    <!-- -1 -->
+    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1489,45 +1491,11 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -34 -->
+    <!-- -35 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1579,6 +1547,38 @@ z
    <g id="text_36">
     <!-- -46 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -2176,18 +2176,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagee74bbab115" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imaged100640a49" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m3d5e1fd20e" d="M 0 0 
+       <path id="m83794615d6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2210,7 +2210,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2224,7 +2224,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2238,7 +2238,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2251,7 +2251,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2264,7 +2264,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2277,7 +2277,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3d5e1fd20e" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83794615d6" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2938,8 +2938,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.602031 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.914609 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,13 +3008,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3054,109 +3054,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p03f746c8d1">
+  <clipPath id="p838d365e5d">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m782c29d017" d="M 0 0 
+       <path id="m4aaac3336b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m782c29d017" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m782c29d017" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m782c29d017" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m782c29d017" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m782c29d017" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m782c29d017" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m782c29d017" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4aaac3336b" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="me34ec03627" d="M 0 0 
+       <path id="m0b5e483765" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me34ec03627" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b5e483765" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me34ec03627" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b5e483765" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me34ec03627" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b5e483765" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mfe593433f9" d="M 0 0 
+       <path id="m0ae8dfa914" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mfe593433f9" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0ae8dfa914" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 175.73438) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 177.208708) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.588195) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.761753) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="macebe1ea10" d="M -2.5 2.5 
+     <path id="m5203371dcc" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#macebe1ea10" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macebe1ea10" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m5203371dcc" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5203371dcc" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me88c4505eb" d="M 0 -2.5 
+     <path id="m9e69aa5aaf" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#me88c4505eb" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me88c4505eb" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m9e69aa5aaf" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e69aa5aaf" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb5915ee6a2" d="M -0 3.535534 
+     <path id="m8203786d64" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#mb5915ee6a2" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5915ee6a2" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m8203786d64" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8203786d64" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m19a309dad1" d="M -0 2.5 
+     <path id="m10735345de" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#m19a309dad1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m10735345de" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7ba39aaaeb" d="M -0.833333 2.5 
+     <path id="m8db9afadc9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#m7ba39aaaeb" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba39aaaeb" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m8db9afadc9" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8db9afadc9" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2556081116" d="M -1.25 2.5 
+     <path id="m766cf7fd14" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#m2556081116" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2556081116" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m766cf7fd14" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766cf7fd14" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m39ae7be1ca" d="M 0 -2.5 
+     <path id="m0188b25838" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#m39ae7be1ca" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m39ae7be1ca" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m0188b25838" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0188b25838" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md01514762f" d="M 0 -2.5 
+     <path id="m1d01166496" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#md01514762f" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md01514762f" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m1d01166496" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1d01166496" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mdd1f6a7d53" d="M 0 3.5 
+      <path id="m4f538ef748" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mdd1f6a7d53" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4f538ef748" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#macebe1ea10" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5203371dcc" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me88c4505eb" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9e69aa5aaf" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb5915ee6a2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8203786d64" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m19a309dad1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m10735345de" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7ba39aaaeb" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8db9afadc9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2556081116" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m766cf7fd14" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m39ae7be1ca" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0188b25838" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md01514762f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1d01166496" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 180.73438 
-L 214.084819 183.250886 
-L 206.266533 185.673939 
-L 187.75787 192.379104 
-L 186.58897 193.213736 
-L 184.505355 195.524133 
-L 152.30308 249.736351 
-L 150.950891 251.596788 
-L 98.348822 336.588195 
-" clip-path="url(#pbff0619bfc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pbff0619bfc)">
-     <use xlink:href="#mdd1f6a7d53" x="226.647908" y="180.73438" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="214.084819" y="183.250886" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="206.266533" y="185.673939" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="187.75787" y="192.379104" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="186.58897" y="193.213736" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="184.505355" y="195.524133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="152.30308" y="249.736351" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="150.950891" y="251.596788" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mdd1f6a7d53" x="98.348822" y="336.588195" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 182.208708 
+L 214.084819 184.564148 
+L 206.266533 186.912306 
+L 187.75787 193.309738 
+L 186.58897 194.170336 
+L 184.505355 196.340125 
+L 164.72409 206.708502 
+L 150.950891 251.341004 
+L 98.348822 336.761753 
+" clip-path="url(#p6b7b4f624d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p6b7b4f624d)">
+     <use xlink:href="#m4f538ef748" x="226.647908" y="182.208708" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="214.084819" y="184.564148" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="206.266533" y="186.912306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="187.75787" y="193.309738" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="186.58897" y="194.170336" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="184.505355" y="196.340125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="164.72409" y="206.708502" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="150.950891" y="251.341004" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f538ef748" x="98.348822" y="336.761753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.602031 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.914609 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,16 +2903,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2926,31 +2916,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
@@ -3080,13 +3045,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3126,109 +3091,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbff0619bfc">
+  <clipPath id="p6b7b4f624d">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pdab969c640)">
+   <g clip-path="url(#pc14ab020b0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image91be587baa" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image829a9a8d49" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4d7a848396" d="M 0 0 
+       <path id="m9b52118254" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4d7a848396" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4d7a848396" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4d7a848396" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4d7a848396" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4d7a848396" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4d7a848396" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4d7a848396" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4d7a848396" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4d7a848396" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4d7a848396" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4d7a848396" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9b52118254" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mbb878da07b" d="M 0 0 
+       <path id="m3bba1d0b2e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbb878da07b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bba1d0b2e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec15cbfbacc" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image299fae7f33" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mf606acd570" d="M 0 0 
+       <path id="m3a4d18cb7a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf606acd570" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a4d18cb7a" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.602031 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.914609 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdab969c640">
+  <clipPath id="pc14ab020b0">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.195938pt" height="386.202469pt" viewBox="0 0 569.195938 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.570781pt" height="386.202469pt" viewBox="0 0 570.570781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.195938 386.202469 
-L 569.195938 0 
+L 570.570781 386.202469 
+L 570.570781 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.722969 104.1264 
-L 291.347969 104.1264 
-L 291.347969 74.7432 
-L 186.722969 74.7432 
+    <path d="M 187.410391 104.1264 
+L 292.035391 104.1264 
+L 292.035391 74.7432 
+L 187.410391 74.7432 
 z
-" clip-path="url(#p7588332338)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.347969 104.1264 
-L 395.972969 104.1264 
-L 395.972969 74.7432 
-L 291.347969 74.7432 
+    <path d="M 292.035391 104.1264 
+L 396.660391 104.1264 
+L 396.660391 74.7432 
+L 292.035391 74.7432 
 z
-" clip-path="url(#p7588332338)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.972969 104.1264 
-L 500.597969 104.1264 
-L 500.597969 74.7432 
-L 395.972969 74.7432 
+    <path d="M 396.660391 104.1264 
+L 501.285391 104.1264 
+L 501.285391 74.7432 
+L 396.660391 74.7432 
 z
-" clip-path="url(#p7588332338)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.722969 133.5096 
-L 291.347969 133.5096 
-L 291.347969 104.1264 
-L 186.722969 104.1264 
+    <path d="M 187.410391 133.5096 
+L 292.035391 133.5096 
+L 292.035391 104.1264 
+L 187.410391 104.1264 
 z
-" clip-path="url(#p7588332338)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.347969 133.5096 
-L 395.972969 133.5096 
-L 395.972969 104.1264 
-L 291.347969 104.1264 
+    <path d="M 292.035391 133.5096 
+L 396.660391 133.5096 
+L 396.660391 104.1264 
+L 292.035391 104.1264 
 z
-" clip-path="url(#p7588332338)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.972969 133.5096 
-L 500.597969 133.5096 
-L 500.597969 104.1264 
-L 395.972969 104.1264 
+    <path d="M 396.660391 133.5096 
+L 501.285391 133.5096 
+L 501.285391 104.1264 
+L 396.660391 104.1264 
 z
-" clip-path="url(#p7588332338)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.722969 162.8928 
-L 291.347969 162.8928 
-L 291.347969 133.5096 
-L 186.722969 133.5096 
+    <path d="M 187.410391 162.8928 
+L 292.035391 162.8928 
+L 292.035391 133.5096 
+L 187.410391 133.5096 
 z
-" clip-path="url(#p7588332338)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.347969 162.8928 
-L 395.972969 162.8928 
-L 395.972969 133.5096 
-L 291.347969 133.5096 
+    <path d="M 292.035391 162.8928 
+L 396.660391 162.8928 
+L 396.660391 133.5096 
+L 292.035391 133.5096 
 z
-" clip-path="url(#p7588332338)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.972969 162.8928 
-L 500.597969 162.8928 
-L 500.597969 133.5096 
-L 395.972969 133.5096 
+    <path d="M 396.660391 162.8928 
+L 501.285391 162.8928 
+L 501.285391 133.5096 
+L 396.660391 133.5096 
 z
-" clip-path="url(#p7588332338)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.722969 192.276 
-L 291.347969 192.276 
-L 291.347969 162.8928 
-L 186.722969 162.8928 
+    <path d="M 187.410391 192.276 
+L 292.035391 192.276 
+L 292.035391 162.8928 
+L 187.410391 162.8928 
 z
-" clip-path="url(#p7588332338)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.347969 192.276 
-L 395.972969 192.276 
-L 395.972969 162.8928 
-L 291.347969 162.8928 
+    <path d="M 292.035391 192.276 
+L 396.660391 192.276 
+L 396.660391 162.8928 
+L 292.035391 162.8928 
 z
-" clip-path="url(#p7588332338)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.972969 192.276 
-L 500.597969 192.276 
-L 500.597969 162.8928 
-L 395.972969 162.8928 
+    <path d="M 396.660391 192.276 
+L 501.285391 192.276 
+L 501.285391 162.8928 
+L 396.660391 162.8928 
 z
-" clip-path="url(#p7588332338)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.722969 221.6592 
-L 291.347969 221.6592 
-L 291.347969 192.276 
-L 186.722969 192.276 
+    <path d="M 187.410391 221.6592 
+L 292.035391 221.6592 
+L 292.035391 192.276 
+L 187.410391 192.276 
 z
-" clip-path="url(#p7588332338)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.347969 221.6592 
-L 395.972969 221.6592 
-L 395.972969 192.276 
-L 291.347969 192.276 
+    <path d="M 292.035391 221.6592 
+L 396.660391 221.6592 
+L 396.660391 192.276 
+L 292.035391 192.276 
 z
-" clip-path="url(#p7588332338)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.972969 221.6592 
-L 500.597969 221.6592 
-L 500.597969 192.276 
-L 395.972969 192.276 
+    <path d="M 396.660391 221.6592 
+L 501.285391 221.6592 
+L 501.285391 192.276 
+L 396.660391 192.276 
 z
-" clip-path="url(#p7588332338)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.722969 251.0424 
-L 291.347969 251.0424 
-L 291.347969 221.6592 
-L 186.722969 221.6592 
+    <path d="M 187.410391 251.0424 
+L 292.035391 251.0424 
+L 292.035391 221.6592 
+L 187.410391 221.6592 
 z
-" clip-path="url(#p7588332338)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.347969 251.0424 
-L 395.972969 251.0424 
-L 395.972969 221.6592 
-L 291.347969 221.6592 
+    <path d="M 292.035391 251.0424 
+L 396.660391 251.0424 
+L 396.660391 221.6592 
+L 292.035391 221.6592 
 z
-" clip-path="url(#p7588332338)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.972969 251.0424 
-L 500.597969 251.0424 
-L 500.597969 221.6592 
-L 395.972969 221.6592 
+    <path d="M 396.660391 251.0424 
+L 501.285391 251.0424 
+L 501.285391 221.6592 
+L 396.660391 221.6592 
 z
-" clip-path="url(#p7588332338)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.722969 280.4256 
-L 291.347969 280.4256 
-L 291.347969 251.0424 
-L 186.722969 251.0424 
+    <path d="M 187.410391 280.4256 
+L 292.035391 280.4256 
+L 292.035391 251.0424 
+L 187.410391 251.0424 
 z
-" clip-path="url(#p7588332338)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.347969 280.4256 
-L 395.972969 280.4256 
-L 395.972969 251.0424 
-L 291.347969 251.0424 
+    <path d="M 292.035391 280.4256 
+L 396.660391 280.4256 
+L 396.660391 251.0424 
+L 292.035391 251.0424 
 z
-" clip-path="url(#p7588332338)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.972969 280.4256 
-L 500.597969 280.4256 
-L 500.597969 251.0424 
-L 395.972969 251.0424 
+    <path d="M 396.660391 280.4256 
+L 501.285391 280.4256 
+L 501.285391 251.0424 
+L 396.660391 251.0424 
 z
-" clip-path="url(#p7588332338)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.722969 309.8088 
-L 291.347969 309.8088 
-L 291.347969 280.4256 
-L 186.722969 280.4256 
+    <path d="M 187.410391 309.8088 
+L 292.035391 309.8088 
+L 292.035391 280.4256 
+L 187.410391 280.4256 
 z
-" clip-path="url(#p7588332338)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.347969 309.8088 
-L 395.972969 309.8088 
-L 395.972969 280.4256 
-L 291.347969 280.4256 
+    <path d="M 292.035391 309.8088 
+L 396.660391 309.8088 
+L 396.660391 280.4256 
+L 292.035391 280.4256 
 z
-" clip-path="url(#p7588332338)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.972969 309.8088 
-L 500.597969 309.8088 
-L 500.597969 280.4256 
-L 395.972969 280.4256 
+    <path d="M 396.660391 309.8088 
+L 501.285391 309.8088 
+L 501.285391 280.4256 
+L 396.660391 280.4256 
 z
-" clip-path="url(#p7588332338)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.722969 339.192 
-L 291.347969 339.192 
-L 291.347969 309.8088 
-L 186.722969 309.8088 
+    <path d="M 187.410391 339.192 
+L 292.035391 339.192 
+L 292.035391 309.8088 
+L 187.410391 309.8088 
 z
-" clip-path="url(#p7588332338)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.347969 339.192 
-L 395.972969 339.192 
-L 395.972969 309.8088 
-L 291.347969 309.8088 
+    <path d="M 292.035391 339.192 
+L 396.660391 339.192 
+L 396.660391 309.8088 
+L 292.035391 309.8088 
 z
-" clip-path="url(#p7588332338)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.972969 339.192 
-L 500.597969 339.192 
-L 500.597969 309.8088 
-L 395.972969 309.8088 
+    <path d="M 396.660391 339.192 
+L 501.285391 339.192 
+L 501.285391 309.8088 
+L 396.660391 309.8088 
 z
-" clip-path="url(#p7588332338)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p133f605f83)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.710234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.397656 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.994453 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.681875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.566563 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.253984 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.918281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.605703 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.647969 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.335391 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.584219 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.025469 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.712891 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.650469 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.286094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.973516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.584219 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.570469 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.650469 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.549219 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.236641 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.584219 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.570469 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.650469 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.855469 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.542891 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.584219 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.570469 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.650469 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.011719 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.699141 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.584219 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.570469 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.650469 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.357344 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(98.044766 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.383594 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.071016 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 25 -->
-    <g transform="translate(338.094219 238.5583) scale(0.08 -0.08)">
+    <!-- 24 -->
+    <g transform="translate(338.781641 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,39 +1724,14 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 210 -->
-    <g transform="translate(439.936094 238.5583) scale(0.08 -0.08)">
+    <!-- 138 -->
+    <g transform="translate(440.623516 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1772,15 +1747,54 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.472344 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.159766 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1909,7 +1923,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.584219 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1919,14 +1933,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.570469 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.650469 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1934,7 +1948,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.979219 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.666641 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1990,7 +2004,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.584219 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2000,21 +2014,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.570469 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.195469 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.882891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.693594 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.381016 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2039,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.584219 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2035,13 +2049,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.115469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.802891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.285469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.972891 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2071,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.106719 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.794141 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2270,7 +2284,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2411,13 +2425,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2457,110 +2471,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7588332338">
-   <rect x="82.097969" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p133f605f83">
+   <rect x="82.785391" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p5c8987e0d0)">
+   <g clip-path="url(#pddd43911e6)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3YsY5cZx2HYc/ueJ04jnCIcQRIVppARaQoVDTcAQWXkTItfcrUaem5ASoQFRJC0CVdopCCOCLCxFjend1ZroDK+t7/+uh5ruAnfXPO957ZHf/12+tbW3Z4Pr2AF3G8nF6w1u5kesFalxfTC9a6e396wVrnT6cXrHV6Nr2AF7H13+fZ3ekFS2389gMA4KYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPZ/PXwxvWGp/cnp9ISljtfX0xOWevj6w+kJS33xn39MT1hr45+4P3nl/vSEpQ53zqYnLPW3x59OT1jq3QfvTE9Y6vzsOD1hqd3u2fSEpTZ+PQAAcNMIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/tHrb09vWOr+nYfTE5b65vlX0xOW+tGzbX8j3XvzZ9MTljrd7acnLHW8dZyesNQPbj2YnrDU5YOL6QlLvXX30fSEpQ7HbZ/faxfbfr9s+3YHAODGEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT2u922G/S7w7fTE5Z69fTe9ISlrt78/vSEpf755O/TE5Z6evF8esJS77/x8+kJS12cTi9Y67+H76Yn8AL+ff54esJadx5OL1hq2/UJAMCNI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtrv704fX0iKWOx+kF8P+d+AZ8qXm/vNy2/vxt/ffp/F5qGz89AABuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBq/9ZfPpvesNTJftuN/fjTb6YnLPXJB+9NT1jqoz9/PT1hqV8++t70hKV+98fPpycs9Ztf/3R6wlIf/+HL6QlL/eq9H05PWOrLJ+fTE5b6xY9fm56w1LbrDACAG0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR2h6vfX0+PWOn08nJ6wlon++kFa10+n16w1tnd6QVr7Tb+jXt9nF6w1sHz91K72vb9d9ht+/m7vfF+2fjtAADATSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7Y/Xx+kNS53efmV6wlLHW9s+v5Mn305PWOpw+2x6wlK3r6YX8EIunk0vWOrp7mJ6wlL3rjf+ftlt/D+086fTC5ba+OkBAHDTCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A7FxfaJxqypDAAAAAElFTkSuQmCC" id="image7a49c59d79" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8klEQVR4nO3Yv46cZx2G4Z3dyTqxE2ES4wiQLBqgSqQIKpqcQYocRsq09Cmpaek5ASoQFRJC0IWOKFAQR4kwcSzvzu4sR0Blvfdv/em6juAZfX/e+5vd8avf3Jxs2eH59AJexPFqesFau9PpBWtdXU4vWOvu/ekFa108nV6w1tn59AJexNbvz/O70wuW2vjpBwDAbSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7f9y+Gx6w1L707PpCUsdb26mJyz18I2H0xOW+uy//5yesNbGP3F/8ur96QlLHe6cT09Y6q+PP52esNS7D348PWGpi/Pj9ISldrtn0xOW2vjxAADAbSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7R2/8aHrDUvfvPJyesNSXz/81PWGpHzzb9jfS62+9Mz1hqbPdfnrCUseT4/SEpb538mB6wlJXDy6nJyz19t1H0xOWOhy3ff3uXW77/bLt0x0AgFtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNrvdttu0G8OX09PWOq1s9enJyx1/dab0xOW+veTv01PWOrp5fPpCUv97Ls/n56w1OXZ9IK1vj18Mz2BF/Cfi8fTE9a683B6wVLbrk8AAG4dAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp3/cePb6ZHLHU8Ti+A/+/UN+BLzfvl5bb152/r96fr91Lb+NUDAOC2EaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT2b//579Mbljrdb7uxH3/65fSEpX790XvTE5b65E9fTE9Y6v1H35mesNRv//CP6QlL/fLDn05PWOpXv/98esJSH7z3/ekJS33+5GJ6wlK/+OG96QlLbbvOAAC4dQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp3uP7dzfSIlc6urqYnrHW6n16w1tXz6QVrnd+dXrDWbuPfuDfH6QVrHTx/L7XrbZ9/h922n79XNt4vGz8dAAC4bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fHmOL1hqbP9+fSEpY676QVrnT75enrCUtfnr05PWOrs6mp6wlobf3+eXD6bXrDUt6fbvj/vXW/7P6ZXdtv+fScXT6cXLLXxqwcAwG0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASP0Pp11/miwvfLUAAAAASUVORK5CYII=" id="image65635bb869" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m551d824f3c" d="M 0 0 
+       <path id="m3a1bededf6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m551d824f3c" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m551d824f3c" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m551d824f3c" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m551d824f3c" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m551d824f3c" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m551d824f3c" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m551d824f3c" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m551d824f3c" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m551d824f3c" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m551d824f3c" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m551d824f3c" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m551d824f3c" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a1bededf6" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m53e872370b" d="M 0 0 
+       <path id="m6506391b7d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m53e872370b" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6506391b7d" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1192,65 +1192,8 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -1 -->
+    <!-- -3 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +5 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -37 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1284,6 +1227,22 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +3 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -37 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1301,138 +1260,8 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +9 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -7 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -10 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -24 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +20 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -14 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -12 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -27 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
     <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1465,6 +1294,176 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -9 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -11 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -25 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +17 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -15 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -12 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -28 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1571,6 +1570,29 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -1589,47 +1611,6 @@ z
    <g id="text_49">
     <!-- +238 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
@@ -1830,6 +1811,27 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2190,18 +2192,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image004b5339a7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagecfe7b92f84" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mf8b4ba39de" d="M 0 0 
+       <path id="ma168334642" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2224,7 +2226,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2238,7 +2240,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2252,7 +2254,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2265,7 +2267,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2278,7 +2280,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2291,7 +2293,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mf8b4ba39de" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma168334642" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2907,8 +2909,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.602031 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.914609 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,13 +3001,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3045,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5c8987e0d0">
+  <clipPath id="pddd43911e6">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md380c36b0b" d="M 0 0 
+       <path id="ma1611e4564" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md380c36b0b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md380c36b0b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md380c36b0b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md380c36b0b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md380c36b0b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md380c36b0b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md380c36b0b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma1611e4564" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m89eaedd9bc" d="M 0 0 
+       <path id="m4529f4ee4d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m89eaedd9bc" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4529f4ee4d" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m89eaedd9bc" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4529f4ee4d" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m89eaedd9bc" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4529f4ee4d" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m32e603528a" d="M 0 0 
+       <path id="md3326a8468" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m32e603528a" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md3326a8468" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 148.829561) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 149.75071) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 351.969673) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 351.951426) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8611444e29" d="M -2.5 2.5 
+     <path id="m6547566ad6" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#m8611444e29" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8611444e29" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m6547566ad6" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6547566ad6" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="macd88cc7cf" d="M 0 -2.5 
+     <path id="m37b216e607" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#macd88cc7cf" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macd88cc7cf" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m37b216e607" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37b216e607" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6e9d56e086" d="M -0 3.535534 
+     <path id="m062c37e5b0" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#m6e9d56e086" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6e9d56e086" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m062c37e5b0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m062c37e5b0" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb852b05eae" d="M -0 2.5 
+     <path id="m61838d320d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#mb852b05eae" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m61838d320d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc3c31cc7fe" d="M -0.833333 2.5 
+     <path id="m764e517f19" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#mc3c31cc7fe" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc3c31cc7fe" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m764e517f19" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m764e517f19" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbdb458e9ab" d="M -1.25 2.5 
+     <path id="m1ad902c799" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#mbdb458e9ab" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbdb458e9ab" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m1ad902c799" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ad902c799" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdaf19b87d9" d="M 0 -2.5 
+     <path id="m9e065cf935" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#mdaf19b87d9" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdaf19b87d9" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m9e065cf935" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065cf935" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5b67339dbc" d="M 0 -2.5 
+     <path id="m5b2259fd6f" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#m5b67339dbc" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b67339dbc" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#m5b2259fd6f" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b2259fd6f" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m6999aa7053" d="M 0 3.5 
+      <path id="ma3ff7e435e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6999aa7053" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma3ff7e435e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8611444e29" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6547566ad6" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#macd88cc7cf" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m37b216e607" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6e9d56e086" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m062c37e5b0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb852b05eae" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m61838d320d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc3c31cc7fe" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m764e517f19" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbdb458e9ab" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1ad902c799" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdaf19b87d9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m9e065cf935" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5b67339dbc" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5b2259fd6f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 153.829561 
-L 236.23654 158.632653 
-L 222.073314 161.934999 
-L 202.315941 171.732161 
-L 199.905291 173.34456 
-L 195.893147 177.155404 
-L 157.982343 243.769719 
-L 157.246106 245.846518 
-L 95.319203 356.969673 
-" clip-path="url(#pdb99435edc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pdb99435edc)">
-     <use xlink:href="#m6999aa7053" x="257.531237" y="153.829561" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="236.23654" y="158.632653" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="222.073314" y="161.934999" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="202.315941" y="171.732161" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="199.905291" y="173.34456" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="195.893147" y="177.155404" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="157.982343" y="243.769719" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="157.246106" y="245.846518" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6999aa7053" x="95.319203" y="356.969673" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 154.75071 
+L 236.23654 159.369829 
+L 222.073314 162.627932 
+L 202.315941 172.397262 
+L 199.905291 173.882766 
+L 195.893147 177.895787 
+L 187.210062 190.818145 
+L 157.246106 245.581439 
+L 95.319203 356.951426 
+" clip-path="url(#pf1020a5a92)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pf1020a5a92)">
+     <use xlink:href="#ma3ff7e435e" x="257.531237" y="154.75071" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="236.23654" y="159.369829" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="222.073314" y="162.627932" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="202.315941" y="172.397262" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="199.905291" y="173.882766" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="195.893147" y="177.895787" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="187.210062" y="190.818145" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="157.246106" y="245.581439" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma3ff7e435e" x="95.319203" y="356.951426" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.602031 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.914609 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2815,16 +2815,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2838,31 +2828,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
@@ -2992,13 +2957,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3038,109 +3003,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdb99435edc">
+  <clipPath id="pf1020a5a92">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m97d0b4f946" d="M 0 0 
+       <path id="m2c421145f7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m97d0b4f946" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m97d0b4f946" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m97d0b4f946" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m97d0b4f946" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m97d0b4f946" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m97d0b4f946" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m97d0b4f946" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c421145f7" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf3f1b11f48" d="M 0 0 
+       <path id="mb2aac56085" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf3f1b11f48" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2aac56085" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf3f1b11f48" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2aac56085" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf3f1b11f48" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2aac56085" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m88fd6354aa" d="M 0 0 
+       <path id="m292b5407e7" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m88fd6354aa" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m292b5407e7" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pf552c65474)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p337752e4bc)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mf66cfe0a7c" d="M -2.5 2.5 
+     <path id="md7b299f61b" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#mf66cfe0a7c" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf66cfe0a7c" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#md7b299f61b" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md7b299f61b" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="me562bc662c" d="M 0 -2.5 
+     <path id="m58dcbd45cd" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#me562bc662c" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me562bc662c" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#m58dcbd45cd" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58dcbd45cd" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m7c071c07c1" d="M -0 3.535534 
+     <path id="m519ad74efb" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#m7c071c07c1" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7c071c07c1" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#m519ad74efb" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m519ad74efb" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="me59f593fc3" d="M -0.833333 2.5 
+     <path id="m88f4a40085" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#me59f593fc3" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me59f593fc3" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#m88f4a40085" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f4a40085" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="med60ed5207" d="M -1.25 2.5 
+     <path id="m07b53bcedf" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#med60ed5207" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med60ed5207" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#m07b53bcedf" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m07b53bcedf" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="md51ee0f308" d="M 0 -2.5 
+     <path id="mcb62d37c38" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#md51ee0f308" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md51ee0f308" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#mcb62d37c38" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcb62d37c38" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mbbf3c31d09" d="M 0 -2.5 
+     <path id="mdf0b536386" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#mbbf3c31d09" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbbf3c31d09" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#mdf0b536386" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf0b536386" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m7817f38df8" d="M 0 3.5 
+      <path id="m9901a5fe56" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m7817f38df8" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9901a5fe56" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mf66cfe0a7c" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md7b299f61b" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#me562bc662c" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m58dcbd45cd" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m7c071c07c1" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m519ad74efb" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#me59f593fc3" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m88f4a40085" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#med60ed5207" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m07b53bcedf" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#md51ee0f308" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mcb62d37c38" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mbbf3c31d09" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdf0b536386" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pf552c65474)">
-     <use xlink:href="#m7817f38df8" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7817f38df8" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p337752e4bc)">
+     <use xlink:href="#m9901a5fe56" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9901a5fe56" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pf552c65474">
+  <clipPath id="p337752e4bc">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m7ca1ec3e19" d="M 0 0 
+       <path id="m2580dea275" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7ca1ec3e19" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2580dea275" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7ca1ec3e19" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2580dea275" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mbff69253be" d="M 0 0 
+       <path id="m76fc7e1c71" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbff69253be" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mbff69253be" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mbff69253be" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mbff69253be" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbff69253be" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbff69253be" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbff69253be" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mbff69253be" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mbff69253be" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbff69253be" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbff69253be" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbff69253be" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbff69253be" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbff69253be" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbff69253be" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbff69253be" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbff69253be" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbff69253be" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbff69253be" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbff69253be" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m76fc7e1c71" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m71b40b5d47" d="M 0 0 
+       <path id="ma7b69a9113" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m71b40b5d47" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7b69a9113" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#pac45ce7b43)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p372f73b57e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m74bcb92aca" d="M 0 3 
+     <path id="m7a207e71ce" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m74bcb92aca" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m7a207e71ce" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m520b327e4c" d="M 0 3 
+     <path id="m45e01b07d2" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m520b327e4c" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m45e01b07d2" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m1debc1d1fd" d="M 0 3 
+     <path id="m0b65869d73" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m1debc1d1fd" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m0b65869d73" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m4b33247b22" d="M 0 5 
+     <path id="m3fecff45d1" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m4b33247b22" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m3fecff45d1" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m353d1adc84" d="M 0 3 
+     <path id="m0b96e57bc8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m353d1adc84" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m0b96e57bc8" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m617508d2da" d="M 0 3 
+     <path id="m29aa102069" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m617508d2da" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m29aa102069" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m63925b9b97" d="M 0 3 
+     <path id="m4db43c2357" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m63925b9b97" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#m4db43c2357" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m33508f8c5e" d="M 0 3 
+     <path id="mf524b7dbdb" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pac45ce7b43)">
-     <use xlink:href="#m33508f8c5e" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p372f73b57e)">
+     <use xlink:href="#mf524b7dbdb" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pac45ce7b43">
+  <clipPath id="p372f73b57e">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfa57a87214)">
+   <g clip-path="url(#p1f08b08f2b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image243bdd357a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image2d34df707c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m78388fc46f" d="M 0 0 
+       <path id="m2d8a95d6db" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m78388fc46f" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m78388fc46f" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m78388fc46f" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m78388fc46f" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m78388fc46f" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m78388fc46f" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m78388fc46f" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m78388fc46f" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m78388fc46f" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m78388fc46f" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m78388fc46f" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m78388fc46f" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d8a95d6db" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mdb79adeba1" d="M 0 0 
+       <path id="m962fb3a8ce" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdb79adeba1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m962fb3a8ce" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image3345076032" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagef601240aa5" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m04d1158dcd" d="M 0 0 
+       <path id="m780d60d74d" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m04d1158dcd" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m780d60d74d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m04d1158dcd" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m780d60d74d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m04d1158dcd" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m780d60d74d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m04d1158dcd" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m780d60d74d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m04d1158dcd" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m780d60d74d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.602031 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.914609 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2872,13 +2872,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfa57a87214">
+  <clipPath id="p1f08b08f2b">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.195938pt" height="386.202469pt" viewBox="0 0 569.195938 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.570781pt" height="386.202469pt" viewBox="0 0 570.570781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.195938 386.202469 
-L 569.195938 0 
+L 570.570781 386.202469 
+L 570.570781 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.722969 104.1264 
-L 291.347969 104.1264 
-L 291.347969 74.7432 
-L 186.722969 74.7432 
+    <path d="M 187.410391 104.1264 
+L 292.035391 104.1264 
+L 292.035391 74.7432 
+L 187.410391 74.7432 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.347969 104.1264 
-L 395.972969 104.1264 
-L 395.972969 74.7432 
-L 291.347969 74.7432 
+    <path d="M 292.035391 104.1264 
+L 396.660391 104.1264 
+L 396.660391 74.7432 
+L 292.035391 74.7432 
 z
-" clip-path="url(#p580cd47104)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.972969 104.1264 
-L 500.597969 104.1264 
-L 500.597969 74.7432 
-L 395.972969 74.7432 
+    <path d="M 396.660391 104.1264 
+L 501.285391 104.1264 
+L 501.285391 74.7432 
+L 396.660391 74.7432 
 z
-" clip-path="url(#p580cd47104)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.722969 133.5096 
-L 291.347969 133.5096 
-L 291.347969 104.1264 
-L 186.722969 104.1264 
+    <path d="M 187.410391 133.5096 
+L 292.035391 133.5096 
+L 292.035391 104.1264 
+L 187.410391 104.1264 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.347969 133.5096 
-L 395.972969 133.5096 
-L 395.972969 104.1264 
-L 291.347969 104.1264 
+    <path d="M 292.035391 133.5096 
+L 396.660391 133.5096 
+L 396.660391 104.1264 
+L 292.035391 104.1264 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.972969 133.5096 
-L 500.597969 133.5096 
-L 500.597969 104.1264 
-L 395.972969 104.1264 
+    <path d="M 396.660391 133.5096 
+L 501.285391 133.5096 
+L 501.285391 104.1264 
+L 396.660391 104.1264 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.722969 162.8928 
-L 291.347969 162.8928 
-L 291.347969 133.5096 
-L 186.722969 133.5096 
+    <path d="M 187.410391 162.8928 
+L 292.035391 162.8928 
+L 292.035391 133.5096 
+L 187.410391 133.5096 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.347969 162.8928 
-L 395.972969 162.8928 
-L 395.972969 133.5096 
-L 291.347969 133.5096 
+    <path d="M 292.035391 162.8928 
+L 396.660391 162.8928 
+L 396.660391 133.5096 
+L 292.035391 133.5096 
 z
-" clip-path="url(#p580cd47104)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.972969 162.8928 
-L 500.597969 162.8928 
-L 500.597969 133.5096 
-L 395.972969 133.5096 
+    <path d="M 396.660391 162.8928 
+L 501.285391 162.8928 
+L 501.285391 133.5096 
+L 396.660391 133.5096 
 z
-" clip-path="url(#p580cd47104)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.722969 192.276 
-L 291.347969 192.276 
-L 291.347969 162.8928 
-L 186.722969 162.8928 
+    <path d="M 187.410391 192.276 
+L 292.035391 192.276 
+L 292.035391 162.8928 
+L 187.410391 162.8928 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.347969 192.276 
-L 395.972969 192.276 
-L 395.972969 162.8928 
-L 291.347969 162.8928 
+    <path d="M 292.035391 192.276 
+L 396.660391 192.276 
+L 396.660391 162.8928 
+L 292.035391 162.8928 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.972969 192.276 
-L 500.597969 192.276 
-L 500.597969 162.8928 
-L 395.972969 162.8928 
+    <path d="M 396.660391 192.276 
+L 501.285391 192.276 
+L 501.285391 162.8928 
+L 396.660391 162.8928 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.722969 221.6592 
-L 291.347969 221.6592 
-L 291.347969 192.276 
-L 186.722969 192.276 
+    <path d="M 187.410391 221.6592 
+L 292.035391 221.6592 
+L 292.035391 192.276 
+L 187.410391 192.276 
 z
-" clip-path="url(#p580cd47104)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.347969 221.6592 
-L 395.972969 221.6592 
-L 395.972969 192.276 
-L 291.347969 192.276 
+    <path d="M 292.035391 221.6592 
+L 396.660391 221.6592 
+L 396.660391 192.276 
+L 292.035391 192.276 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.972969 221.6592 
-L 500.597969 221.6592 
-L 500.597969 192.276 
-L 395.972969 192.276 
+    <path d="M 396.660391 221.6592 
+L 501.285391 221.6592 
+L 501.285391 192.276 
+L 396.660391 192.276 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.722969 251.0424 
-L 291.347969 251.0424 
-L 291.347969 221.6592 
-L 186.722969 221.6592 
+    <path d="M 187.410391 251.0424 
+L 292.035391 251.0424 
+L 292.035391 221.6592 
+L 187.410391 221.6592 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.347969 251.0424 
-L 395.972969 251.0424 
-L 395.972969 221.6592 
-L 291.347969 221.6592 
+    <path d="M 292.035391 251.0424 
+L 396.660391 251.0424 
+L 396.660391 221.6592 
+L 292.035391 221.6592 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.972969 251.0424 
-L 500.597969 251.0424 
-L 500.597969 221.6592 
-L 395.972969 221.6592 
+    <path d="M 396.660391 251.0424 
+L 501.285391 251.0424 
+L 501.285391 221.6592 
+L 396.660391 221.6592 
 z
-" clip-path="url(#p580cd47104)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.722969 280.4256 
-L 291.347969 280.4256 
-L 291.347969 251.0424 
-L 186.722969 251.0424 
+    <path d="M 187.410391 280.4256 
+L 292.035391 280.4256 
+L 292.035391 251.0424 
+L 187.410391 251.0424 
 z
-" clip-path="url(#p580cd47104)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.347969 280.4256 
-L 395.972969 280.4256 
-L 395.972969 251.0424 
-L 291.347969 251.0424 
+    <path d="M 292.035391 280.4256 
+L 396.660391 280.4256 
+L 396.660391 251.0424 
+L 292.035391 251.0424 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.972969 280.4256 
-L 500.597969 280.4256 
-L 500.597969 251.0424 
-L 395.972969 251.0424 
+    <path d="M 396.660391 280.4256 
+L 501.285391 280.4256 
+L 501.285391 251.0424 
+L 396.660391 251.0424 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.722969 309.8088 
-L 291.347969 309.8088 
-L 291.347969 280.4256 
-L 186.722969 280.4256 
+    <path d="M 187.410391 309.8088 
+L 292.035391 309.8088 
+L 292.035391 280.4256 
+L 187.410391 280.4256 
 z
-" clip-path="url(#p580cd47104)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.347969 309.8088 
-L 395.972969 309.8088 
-L 395.972969 280.4256 
-L 291.347969 280.4256 
+    <path d="M 292.035391 309.8088 
+L 396.660391 309.8088 
+L 396.660391 280.4256 
+L 292.035391 280.4256 
 z
-" clip-path="url(#p580cd47104)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.972969 309.8088 
-L 500.597969 309.8088 
-L 500.597969 280.4256 
-L 395.972969 280.4256 
+    <path d="M 396.660391 309.8088 
+L 501.285391 309.8088 
+L 501.285391 280.4256 
+L 396.660391 280.4256 
 z
-" clip-path="url(#p580cd47104)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.722969 339.192 
-L 291.347969 339.192 
-L 291.347969 309.8088 
-L 186.722969 309.8088 
+    <path d="M 187.410391 339.192 
+L 292.035391 339.192 
+L 292.035391 309.8088 
+L 187.410391 309.8088 
 z
-" clip-path="url(#p580cd47104)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.347969 339.192 
-L 395.972969 339.192 
-L 395.972969 309.8088 
-L 291.347969 309.8088 
+    <path d="M 292.035391 339.192 
+L 396.660391 339.192 
+L 396.660391 309.8088 
+L 292.035391 309.8088 
 z
-" clip-path="url(#p580cd47104)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.972969 339.192 
-L 500.597969 339.192 
-L 500.597969 309.8088 
-L 395.972969 309.8088 
+    <path d="M 396.660391 339.192 
+L 501.285391 339.192 
+L 501.285391 309.8088 
+L 396.660391 309.8088 
 z
-" clip-path="url(#p580cd47104)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p85f31aadcf)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.710234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.397656 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.994453 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.681875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.566563 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.253984 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.918281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.605703 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.647969 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.335391 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.584219 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.025469 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.712891 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.650469 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.286094 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.973516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.584219 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.570469 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.650469 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.979219 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.666641 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.584219 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.570469 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.650469 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.011719 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.699141 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.584219 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.570469 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.650469 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.549219 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.236641 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.584219 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.570469 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.650469 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.855469 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.542891 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.584219 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.570469 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.650469 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.337891 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.357344 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.044766 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(226.383594 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.071016 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 34 -->
-    <g transform="translate(338.094219 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.781641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1881,58 +1881,71 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 267 -->
-    <g transform="translate(439.936094 267.9415) scale(0.08 -0.08)">
+    <!-- 182 -->
+    <g transform="translate(440.623516 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.472344 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.159766 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1997,7 +2010,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.584219 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2007,21 +2020,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.570469 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.257891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.195469 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.882891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.693594 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.381016 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2032,7 +2045,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.584219 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.271641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2042,13 +2055,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.115469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.802891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.285469 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.972891 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2064,7 +2077,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.199688 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.887109 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2137,6 +2150,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2178,7 +2221,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T07:53:49Z  ·  Linux chungus x86_64  ·  commit 8099528f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-23T13:19:09Z  ·  Linux chungus x86_64  ·  commit dc308322  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2319,13 +2362,13 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2365,110 +2408,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.605469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.966797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.753906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.537109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3737.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.339844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.71875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3964.058594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.943359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4187.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.748047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.53125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4310.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.333984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.712891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.335938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4532.027344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.207031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.830078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.617188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.240234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.863281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.357422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.220703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.201172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.824219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.611328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.398438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.759766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.96875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.347656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.210938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.392578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.771484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.626953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5718.103516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.482422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.691406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.478516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.267578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5968.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.466797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.990234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.466797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.25 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.529297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.908203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.695312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.794922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.929688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6667.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.589844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.490234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.390625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.669922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.878906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.630859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.414062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.513672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.777344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.300781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7496.033203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.396484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.808594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.591797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.970703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.753906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.853516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7843.0625 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.845703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3126.708984 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3190.332031 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3540.234375 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3572.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.808594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.595703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3667.382812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3695.166016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.689453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.96875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3881.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.824219 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.6875 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.869141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4104.048828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.572266 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.685547 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4240.376953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4268.160156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.683594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.962891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4454.341797 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.65625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4706.246094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4865.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.986328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.849609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.830078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5154.240234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5186.027344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.814453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.601562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5281.388672 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.597656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.976562 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.839844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5484.021484 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5547.400391 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.876953 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5674.255859 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.732422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5801.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5840.320312 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5872.107422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.896484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.683594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6085.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.619141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6299.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.537109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6394.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6446.423828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.802734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6571.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.558594 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.658203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6750.037109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6811.21875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6850.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6884.119141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.90625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6957.019531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7018.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7085.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.472656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7178.259766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7206.042969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7258.142578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7353.40625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7454.138672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7555.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7652.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7680.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.599609 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7771.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.691406 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.474609 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p580cd47104">
-   <rect x="82.097969" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p85f31aadcf">
+   <rect x="82.785391" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-23T07:53:49Z",
+  "date": "2026-06-23T13:19:09Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "8099528f",
+  "git_commit": "dc308322",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.68,
-   "decompress_mbps": 194.74
+   "compress_mbps": 38.9,
+   "decompress_mbps": 111.25
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.64,
-   "decompress_mbps": 219.44
+   "compress_mbps": 36.87,
+   "decompress_mbps": 125.73
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.47,
-   "decompress_mbps": 241.21
+   "compress_mbps": 34.09,
+   "decompress_mbps": 136.14
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.58,
-   "decompress_mbps": 243.32
+   "compress_mbps": 27.44,
+   "decompress_mbps": 140.48
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.93,
-   "decompress_mbps": 245.9
+   "compress_mbps": 26.44,
+   "decompress_mbps": 147.71
   },
   {
    "compressor": "native",
@@ -64,18 +64,18 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.93,
-   "decompress_mbps": 253.33
+   "compress_mbps": 24.84,
+   "decompress_mbps": 152.45
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 7,
-   "out_size": 54140,
-   "ratio": 0.356,
-   "compress_mbps": 9.24,
-   "decompress_mbps": 253.36
+   "out_size": 54385,
+   "ratio": 0.3576,
+   "compress_mbps": 20.27,
+   "decompress_mbps": 152.94
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.11,
-   "decompress_mbps": 253.62
+   "compress_mbps": 9.24,
+   "decompress_mbps": 125.49
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.28,
-   "decompress_mbps": 253.11
+   "compress_mbps": 1.26,
+   "decompress_mbps": 153.39
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.73,
-   "decompress_mbps": 185.65
+   "compress_mbps": 37.11,
+   "decompress_mbps": 106.75
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 35.14,
-   "decompress_mbps": 201.02
+   "compress_mbps": 34.45,
+   "decompress_mbps": 114.53
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.92,
-   "decompress_mbps": 218.94
+   "compress_mbps": 32.28,
+   "decompress_mbps": 123.95
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.69,
-   "decompress_mbps": 224.68
+   "compress_mbps": 25.45,
+   "decompress_mbps": 128.51
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 226.43
+   "compress_mbps": 24.85,
+   "decompress_mbps": 134.69
   },
   {
    "compressor": "native",
@@ -154,18 +154,18 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.8,
-   "decompress_mbps": 223.81
+   "compress_mbps": 23.68,
+   "decompress_mbps": 137.77
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 7,
-   "out_size": 48634,
-   "ratio": 0.3885,
-   "compress_mbps": 8.73,
-   "decompress_mbps": 230.67
+   "out_size": 48874,
+   "ratio": 0.3904,
+   "compress_mbps": 21.44,
+   "decompress_mbps": 138.2
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.75,
-   "decompress_mbps": 230.78
+   "compress_mbps": 8.96,
+   "decompress_mbps": 138.66
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.35,
-   "decompress_mbps": 231.68
+   "compress_mbps": 1.36,
+   "decompress_mbps": 138.56
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 34.57,
-   "decompress_mbps": 221.47
+   "compress_mbps": 33.0,
+   "decompress_mbps": 125.26
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.38,
-   "decompress_mbps": 226.36
+   "compress_mbps": 32.02,
+   "decompress_mbps": 129.14
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.43,
-   "decompress_mbps": 232.56
+   "compress_mbps": 31.22,
+   "decompress_mbps": 131.77
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.74,
-   "decompress_mbps": 240.64
+   "compress_mbps": 29.57,
+   "decompress_mbps": 138.0
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.26,
-   "decompress_mbps": 248.16
+   "compress_mbps": 29.09,
+   "decompress_mbps": 142.97
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.49,
-   "decompress_mbps": 249.28
+   "compress_mbps": 28.32,
+   "decompress_mbps": 142.83
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.74,
-   "decompress_mbps": 251.6
+   "compress_mbps": 25.3,
+   "decompress_mbps": 145.0
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.72,
-   "decompress_mbps": 252.34
+   "compress_mbps": 9.6,
+   "decompress_mbps": 145.0
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 251.65
+   "compress_mbps": 1.62,
+   "decompress_mbps": 144.97
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.71,
-   "decompress_mbps": 150.59
+   "compress_mbps": 22.82,
+   "decompress_mbps": 99.84
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.19,
-   "decompress_mbps": 152.15
+   "compress_mbps": 22.39,
+   "decompress_mbps": 102.79
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.96,
-   "decompress_mbps": 155.81
+   "compress_mbps": 22.04,
+   "decompress_mbps": 106.03
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.97,
-   "decompress_mbps": 157.4
+   "compress_mbps": 21.0,
+   "decompress_mbps": 108.42
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.73,
-   "decompress_mbps": 158.87
+   "compress_mbps": 20.84,
+   "decompress_mbps": 110.33
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.42,
-   "decompress_mbps": 159.22
+   "compress_mbps": 20.57,
+   "decompress_mbps": 111.29
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.08,
-   "decompress_mbps": 159.08
+   "compress_mbps": 19.05,
+   "decompress_mbps": 111.58
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.08,
-   "decompress_mbps": 159.1
+   "compress_mbps": 7.02,
+   "decompress_mbps": 111.42
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.53,
-   "decompress_mbps": 159.14
+   "compress_mbps": 1.52,
+   "decompress_mbps": 111.77
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.85,
-   "decompress_mbps": 69.02
+   "compress_mbps": 11.25,
+   "decompress_mbps": 55.92
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.75,
-   "decompress_mbps": 69.65
+   "compress_mbps": 11.14,
+   "decompress_mbps": 56.94
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.79,
-   "decompress_mbps": 69.74
+   "compress_mbps": 11.11,
+   "decompress_mbps": 56.83
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.53,
-   "decompress_mbps": 70.43
+   "compress_mbps": 10.98,
+   "decompress_mbps": 57.79
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.65,
-   "decompress_mbps": 70.35
+   "compress_mbps": 10.99,
+   "decompress_mbps": 58.17
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.52,
-   "decompress_mbps": 70.65
+   "compress_mbps": 10.99,
+   "decompress_mbps": 58.3
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.86,
-   "decompress_mbps": 70.62
+   "compress_mbps": 10.77,
+   "decompress_mbps": 58.33
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.84,
-   "decompress_mbps": 70.57
+   "compress_mbps": 3.8,
+   "decompress_mbps": 58.26
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.23,
-   "decompress_mbps": 70.5
+   "compress_mbps": 1.21,
+   "decompress_mbps": 58.2
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 64.67,
-   "decompress_mbps": 341.86
+   "compress_mbps": 62.41,
+   "decompress_mbps": 207.76
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 61.0,
-   "decompress_mbps": 381.43
+   "compress_mbps": 59.33,
+   "decompress_mbps": 223.62
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 60.08,
-   "decompress_mbps": 404.23
+   "compress_mbps": 57.87,
+   "decompress_mbps": 232.77
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 427.03
+   "compress_mbps": 54.93,
+   "decompress_mbps": 241.47
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.85,
-   "decompress_mbps": 408.02
+   "compress_mbps": 54.34,
+   "decompress_mbps": 236.46
   },
   {
    "compressor": "native",
@@ -514,18 +514,18 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.96,
-   "decompress_mbps": 426.07
+   "compress_mbps": 51.35,
+   "decompress_mbps": 244.11
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 7,
-   "out_size": 200711,
-   "ratio": 0.1949,
-   "compress_mbps": 9.52,
-   "decompress_mbps": 427.97
+   "out_size": 214282,
+   "ratio": 0.2081,
+   "compress_mbps": 22.05,
+   "decompress_mbps": 245.3
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.6,
-   "decompress_mbps": 434.78
+   "compress_mbps": 7.77,
+   "decompress_mbps": 249.11
   },
   {
    "compressor": "native",
@@ -545,7 +545,7 @@
    "out_size": 178311,
    "ratio": 0.1732,
    "compress_mbps": 0.96,
-   "decompress_mbps": 435.13
+   "decompress_mbps": 249.7
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.64,
-   "decompress_mbps": 204.37
+   "compress_mbps": 43.1,
+   "decompress_mbps": 120.76
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.55,
-   "decompress_mbps": 220.75
+   "compress_mbps": 39.79,
+   "decompress_mbps": 130.23
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 37.57,
-   "decompress_mbps": 243.72
+   "compress_mbps": 36.82,
+   "decompress_mbps": 143.48
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 29.18,
-   "decompress_mbps": 249.47
+   "compress_mbps": 29.1,
+   "decompress_mbps": 148.51
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.6,
-   "decompress_mbps": 252.92
+   "compress_mbps": 28.39,
+   "decompress_mbps": 155.32
   },
   {
    "compressor": "native",
@@ -604,18 +604,18 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.58,
-   "decompress_mbps": 257.81
+   "compress_mbps": 26.28,
+   "decompress_mbps": 159.86
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 7,
-   "out_size": 144554,
-   "ratio": 0.3387,
-   "compress_mbps": 9.92,
-   "decompress_mbps": 258.43
+   "out_size": 145077,
+   "ratio": 0.34,
+   "compress_mbps": 22.09,
+   "decompress_mbps": 160.39
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.91,
-   "decompress_mbps": 258.85
+   "compress_mbps": 9.9,
+   "decompress_mbps": 159.94
   },
   {
    "compressor": "native",
@@ -635,7 +635,7 @@
    "out_size": 138661,
    "ratio": 0.3249,
    "compress_mbps": 1.31,
-   "decompress_mbps": 258.48
+   "decompress_mbps": 160.35
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 38.77,
-   "decompress_mbps": 174.82
+   "compress_mbps": 37.47,
+   "decompress_mbps": 101.13
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 35.67,
-   "decompress_mbps": 194.49
+   "compress_mbps": 34.25,
+   "decompress_mbps": 110.44
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 32.54,
-   "decompress_mbps": 213.73
+   "compress_mbps": 31.46,
+   "decompress_mbps": 120.57
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.48,
-   "decompress_mbps": 219.7
+   "compress_mbps": 23.22,
+   "decompress_mbps": 124.8
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.63,
-   "decompress_mbps": 219.05
+   "compress_mbps": 22.41,
+   "decompress_mbps": 131.18
   },
   {
    "compressor": "native",
@@ -694,18 +694,18 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 222.03
+   "compress_mbps": 20.84,
+   "decompress_mbps": 134.58
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 7,
-   "out_size": 194385,
-   "ratio": 0.4034,
-   "compress_mbps": 8.3,
-   "decompress_mbps": 223.07
+   "out_size": 194724,
+   "ratio": 0.4041,
+   "compress_mbps": 18.2,
+   "decompress_mbps": 134.99
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.28,
-   "decompress_mbps": 222.56
+   "compress_mbps": 8.44,
+   "decompress_mbps": 135.3
   },
   {
    "compressor": "native",
@@ -725,7 +725,7 @@
    "out_size": 186472,
    "ratio": 0.387,
    "compress_mbps": 1.26,
-   "decompress_mbps": 223.08
+   "decompress_mbps": 135.36
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 120.45,
-   "decompress_mbps": 482.54
+   "compress_mbps": 120.43,
+   "decompress_mbps": 342.78
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 107.68,
-   "decompress_mbps": 509.98
+   "compress_mbps": 106.8,
+   "decompress_mbps": 362.26
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 92.75,
-   "decompress_mbps": 555.15
+   "compress_mbps": 91.75,
+   "decompress_mbps": 384.35
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 73.98,
-   "decompress_mbps": 471.66
+   "compress_mbps": 73.3,
+   "decompress_mbps": 357.58
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 70.97,
-   "decompress_mbps": 497.79
+   "compress_mbps": 70.99,
+   "decompress_mbps": 380.82
   },
   {
    "compressor": "native",
@@ -785,17 +785,17 @@
    "out_size": 55441,
    "ratio": 0.108,
    "compress_mbps": 64.34,
-   "decompress_mbps": 544.47
+   "decompress_mbps": 410.21
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 53495,
-   "ratio": 0.1042,
-   "compress_mbps": 18.91,
-   "decompress_mbps": 584.55
+   "out_size": 53529,
+   "ratio": 0.1043,
+   "compress_mbps": 37.34,
+   "decompress_mbps": 430.9
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.82,
-   "decompress_mbps": 627.51
+   "compress_mbps": 16.99,
+   "decompress_mbps": 461.7
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.95,
-   "decompress_mbps": 640.39
+   "compress_mbps": 0.96,
+   "decompress_mbps": 468.81
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 188.88
+   "compress_mbps": 26.15,
+   "decompress_mbps": 114.0
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 193.34
+   "compress_mbps": 25.63,
+   "decompress_mbps": 116.68
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.0,
-   "decompress_mbps": 197.71
+   "compress_mbps": 25.18,
+   "decompress_mbps": 118.05
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.27,
-   "decompress_mbps": 202.61
+   "compress_mbps": 23.07,
+   "decompress_mbps": 123.62
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.95,
-   "decompress_mbps": 213.09
+   "compress_mbps": 22.78,
+   "decompress_mbps": 130.59
   },
   {
    "compressor": "native",
@@ -874,18 +874,18 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.79,
-   "decompress_mbps": 218.34
+   "compress_mbps": 21.74,
+   "decompress_mbps": 133.14
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 13035,
-   "ratio": 0.3409,
-   "compress_mbps": 5.76,
-   "decompress_mbps": 219.26
+   "out_size": 13344,
+   "ratio": 0.349,
+   "compress_mbps": 18.02,
+   "decompress_mbps": 134.26
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.4,
-   "decompress_mbps": 221.15
+   "compress_mbps": 5.44,
+   "decompress_mbps": 135.87
   },
   {
    "compressor": "native",
@@ -905,7 +905,7 @@
    "out_size": 12278,
    "ratio": 0.3211,
    "compress_mbps": 1.2,
-   "decompress_mbps": 224.56
+   "decompress_mbps": 137.32
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.99,
-   "decompress_mbps": 76.87
+   "compress_mbps": 12.7,
+   "decompress_mbps": 57.76
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 13.02,
-   "decompress_mbps": 76.5
+   "compress_mbps": 12.71,
+   "decompress_mbps": 58.19
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 13.0,
-   "decompress_mbps": 76.67
+   "compress_mbps": 12.7,
+   "decompress_mbps": 58.34
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.83,
-   "decompress_mbps": 77.43
+   "compress_mbps": 12.54,
+   "decompress_mbps": 59.61
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.83,
-   "decompress_mbps": 76.74
+   "compress_mbps": 12.54,
+   "decompress_mbps": 59.89
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.81,
-   "decompress_mbps": 77.35
+   "compress_mbps": 12.52,
+   "decompress_mbps": 59.79
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 77.19
+   "compress_mbps": 12.42,
+   "decompress_mbps": 59.79
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 77.21
+   "compress_mbps": 4.16,
+   "decompress_mbps": 59.77
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 1.4,
-   "decompress_mbps": 76.76
+   "compress_mbps": 1.39,
+   "decompress_mbps": 59.9
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 178.28
+   "compress_mbps": 37.73,
+   "decompress_mbps": 105.69
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 34.59,
-   "decompress_mbps": 198.15
+   "compress_mbps": 34.13,
+   "decompress_mbps": 114.75
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.84,
-   "decompress_mbps": 217.77
+   "compress_mbps": 33.43,
+   "decompress_mbps": 123.86
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.87,
-   "decompress_mbps": 217.88
+   "compress_mbps": 25.7,
+   "decompress_mbps": 128.8
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.21,
-   "decompress_mbps": 218.49
+   "compress_mbps": 24.87,
+   "decompress_mbps": 133.38
   },
   {
    "compressor": "native",
@@ -4024,18 +4024,18 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.21,
-   "decompress_mbps": 224.38
+   "compress_mbps": 23.11,
+   "decompress_mbps": 138.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3865234,
-   "ratio": 0.3792,
-   "compress_mbps": 8.81,
-   "decompress_mbps": 229.05
+   "out_size": 3866648,
+   "ratio": 0.3794,
+   "compress_mbps": 19.46,
+   "decompress_mbps": 138.92
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.92,
-   "decompress_mbps": 235.55
+   "compress_mbps": 8.82,
+   "decompress_mbps": 143.14
   },
   {
    "compressor": "native",
@@ -4055,7 +4055,7 @@
    "out_size": 3712344,
    "ratio": 0.3642,
    "compress_mbps": 1.27,
-   "decompress_mbps": 235.27
+   "decompress_mbps": 144.63
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 51.4,
-   "decompress_mbps": 192.25
+   "compress_mbps": 50.7,
+   "decompress_mbps": 135.71
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 48.51,
-   "decompress_mbps": 205.85
+   "compress_mbps": 47.39,
+   "decompress_mbps": 141.73
   },
   {
    "compressor": "native",
@@ -4085,7 +4085,7 @@
    "out_size": 20554782,
    "ratio": 0.4013,
    "compress_mbps": 45.51,
-   "decompress_mbps": 212.5
+   "decompress_mbps": 145.35
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.6,
-   "decompress_mbps": 217.84
+   "compress_mbps": 38.32,
+   "decompress_mbps": 154.06
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 37.11,
-   "decompress_mbps": 226.56
+   "compress_mbps": 36.73,
+   "decompress_mbps": 162.51
   },
   {
    "compressor": "native",
@@ -4114,18 +4114,18 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 33.11,
-   "decompress_mbps": 227.52
+   "compress_mbps": 32.44,
+   "decompress_mbps": 167.94
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 19177172,
-   "ratio": 0.3744,
-   "compress_mbps": 7.6,
-   "decompress_mbps": 223.24
+   "out_size": 20251341,
+   "ratio": 0.3954,
+   "compress_mbps": 22.5,
+   "decompress_mbps": 163.56
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.9,
-   "decompress_mbps": 232.38
+   "compress_mbps": 6.88,
+   "decompress_mbps": 167.87
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.19,
-   "decompress_mbps": 223.7
+   "compress_mbps": 1.18,
+   "decompress_mbps": 168.14
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 52.46,
-   "decompress_mbps": 211.01
+   "compress_mbps": 51.33,
+   "decompress_mbps": 123.22
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.98,
-   "decompress_mbps": 215.61
+   "compress_mbps": 47.52,
+   "decompress_mbps": 129.56
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 43.11,
-   "decompress_mbps": 229.5
+   "compress_mbps": 42.21,
+   "decompress_mbps": 138.53
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.65,
-   "decompress_mbps": 214.02
+   "compress_mbps": 31.27,
+   "decompress_mbps": 133.48
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.13,
-   "decompress_mbps": 210.76
+   "compress_mbps": 29.84,
+   "decompress_mbps": 139.49
   },
   {
    "compressor": "native",
@@ -4204,18 +4204,18 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.65,
-   "decompress_mbps": 216.24
+   "compress_mbps": 27.25,
+   "decompress_mbps": 144.4
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3609769,
-   "ratio": 0.362,
-   "compress_mbps": 8.35,
-   "decompress_mbps": 227.19
+   "out_size": 3704150,
+   "ratio": 0.3715,
+   "compress_mbps": 20.99,
+   "decompress_mbps": 145.29
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.19,
-   "decompress_mbps": 225.47
+   "compress_mbps": 8.21,
+   "decompress_mbps": 148.34
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 0.99,
-   "decompress_mbps": 234.85
+   "compress_mbps": 1.0,
+   "decompress_mbps": 154.47
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 122.01,
-   "decompress_mbps": 618.66
+   "compress_mbps": 116.43,
+   "decompress_mbps": 358.45
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 105.81,
-   "decompress_mbps": 686.24
+   "compress_mbps": 90.56,
+   "decompress_mbps": 412.55
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 89.97,
-   "decompress_mbps": 761.88
+   "compress_mbps": 86.89,
+   "decompress_mbps": 461.39
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 80.03,
-   "decompress_mbps": 760.08
+   "compress_mbps": 79.22,
+   "decompress_mbps": 466.08
   },
   {
    "compressor": "native",
@@ -4285,7 +4285,7 @@
    "out_size": 3225450,
    "ratio": 0.0961,
    "compress_mbps": 77.58,
-   "decompress_mbps": 851.07
+   "decompress_mbps": 537.54
   },
   {
    "compressor": "native",
@@ -4294,18 +4294,18 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 71.56,
-   "decompress_mbps": 910.75
+   "compress_mbps": 71.65,
+   "decompress_mbps": 574.33
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3123611,
+   "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 25.49,
-   "decompress_mbps": 908.1
+   "compress_mbps": 42.92,
+   "decompress_mbps": 592.52
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 906.96
+   "compress_mbps": 22.9,
+   "decompress_mbps": 597.78
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 2868751,
    "ratio": 0.0855,
    "compress_mbps": 0.78,
-   "decompress_mbps": 843.73
+   "decompress_mbps": 590.91
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 38.24,
-   "decompress_mbps": 133.79
+   "compress_mbps": 37.26,
+   "decompress_mbps": 93.37
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 36.84,
-   "decompress_mbps": 134.74
+   "compress_mbps": 35.68,
+   "decompress_mbps": 93.19
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 35.43,
-   "decompress_mbps": 140.65
+   "compress_mbps": 35.14,
+   "decompress_mbps": 98.45
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 30.09,
-   "decompress_mbps": 145.37
+   "compress_mbps": 29.76,
+   "decompress_mbps": 104.57
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 153.76
+   "compress_mbps": 29.32,
+   "decompress_mbps": 110.9
   },
   {
    "compressor": "native",
@@ -4384,18 +4384,18 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 28.62,
-   "decompress_mbps": 156.96
+   "compress_mbps": 27.9,
+   "decompress_mbps": 112.91
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3165678,
-   "ratio": 0.5146,
-   "compress_mbps": 6.98,
-   "decompress_mbps": 158.73
+   "out_size": 3232621,
+   "ratio": 0.5254,
+   "compress_mbps": 25.1,
+   "decompress_mbps": 110.53
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.79,
-   "decompress_mbps": 159.35
+   "compress_mbps": 6.85,
+   "decompress_mbps": 114.33
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.46,
-   "decompress_mbps": 160.38
+   "compress_mbps": 1.47,
+   "decompress_mbps": 107.15
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 53.99,
-   "decompress_mbps": 224.46
+   "compress_mbps": 53.32,
+   "decompress_mbps": 155.3
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 45.88,
-   "decompress_mbps": 232.2
+   "compress_mbps": 49.71,
+   "decompress_mbps": 159.87
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 50.0,
-   "decompress_mbps": 236.37
+   "compress_mbps": 48.75,
+   "decompress_mbps": 163.87
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 45.7,
-   "decompress_mbps": 249.35
+   "compress_mbps": 44.55,
+   "decompress_mbps": 175.54
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 45.75,
-   "decompress_mbps": 251.46
+   "compress_mbps": 44.52,
+   "decompress_mbps": 182.4
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 45.69,
-   "decompress_mbps": 260.36
+   "compress_mbps": 44.86,
+   "decompress_mbps": 190.01
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.97,
-   "decompress_mbps": 271.52
+   "compress_mbps": 41.99,
+   "decompress_mbps": 193.18
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.83,
-   "decompress_mbps": 271.97
+   "compress_mbps": 11.98,
+   "decompress_mbps": 198.57
   },
   {
    "compressor": "native",
@@ -4505,7 +4505,7 @@
    "out_size": 3647083,
    "ratio": 0.3616,
    "compress_mbps": 1.77,
-   "decompress_mbps": 268.53
+   "decompress_mbps": 200.92
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 46.46,
-   "decompress_mbps": 227.59
+   "compress_mbps": 47.44,
+   "decompress_mbps": 133.42
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 42.72,
-   "decompress_mbps": 240.17
+   "compress_mbps": 42.14,
+   "decompress_mbps": 145.95
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 36.99,
-   "decompress_mbps": 262.04
+   "compress_mbps": 36.26,
+   "decompress_mbps": 159.43
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.9,
-   "decompress_mbps": 266.43
+   "compress_mbps": 26.29,
+   "decompress_mbps": 167.33
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.83,
-   "decompress_mbps": 268.79
+   "compress_mbps": 24.64,
+   "decompress_mbps": 174.86
   },
   {
    "compressor": "native",
@@ -4564,18 +4564,18 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.65,
-   "decompress_mbps": 280.88
+   "compress_mbps": 20.23,
+   "decompress_mbps": 190.31
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1843401,
-   "ratio": 0.2782,
-   "compress_mbps": 8.39,
-   "decompress_mbps": 305.39
+   "out_size": 1868263,
+   "ratio": 0.2819,
+   "compress_mbps": 13.37,
+   "decompress_mbps": 189.16
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.75,
-   "decompress_mbps": 283.07
+   "compress_mbps": 7.7,
+   "decompress_mbps": 189.18
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 0.92,
-   "decompress_mbps": 296.77
+   "decompress_mbps": 188.26
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 67.26,
-   "decompress_mbps": 306.17
+   "compress_mbps": 65.98,
+   "decompress_mbps": 201.8
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 60.68,
-   "decompress_mbps": 321.79
+   "compress_mbps": 60.64,
+   "decompress_mbps": 213.36
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 56.04,
-   "decompress_mbps": 336.91
+   "compress_mbps": 55.05,
+   "decompress_mbps": 223.24
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 47.38,
-   "decompress_mbps": 348.67
+   "compress_mbps": 46.48,
+   "decompress_mbps": 232.63
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.9,
-   "decompress_mbps": 355.32
+   "compress_mbps": 45.46,
+   "decompress_mbps": 244.37
   },
   {
    "compressor": "native",
@@ -4654,18 +4654,18 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.93,
-   "decompress_mbps": 365.5
+   "compress_mbps": 42.21,
+   "decompress_mbps": 251.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5409010,
-   "ratio": 0.2503,
-   "compress_mbps": 13.16,
-   "decompress_mbps": 335.94
+   "out_size": 5829595,
+   "ratio": 0.2698,
+   "compress_mbps": 32.37,
+   "decompress_mbps": 252.54
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.67,
-   "decompress_mbps": 339.43
+   "compress_mbps": 12.8,
+   "decompress_mbps": 238.42
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.31,
-   "decompress_mbps": 370.87
+   "decompress_mbps": 253.99
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.61,
-   "decompress_mbps": 133.48
+   "compress_mbps": 31.96,
+   "decompress_mbps": 95.45
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 31.6,
-   "decompress_mbps": 134.64
+   "compress_mbps": 31.14,
+   "decompress_mbps": 96.2
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 30.07,
-   "decompress_mbps": 141.42
+   "compress_mbps": 29.78,
+   "decompress_mbps": 101.18
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.69,
-   "decompress_mbps": 141.42
+   "compress_mbps": 25.4,
+   "decompress_mbps": 103.22
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 142.64
+   "compress_mbps": 24.72,
+   "decompress_mbps": 107.38
   },
   {
    "compressor": "native",
@@ -4744,18 +4744,18 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.61,
-   "decompress_mbps": 140.86
+   "compress_mbps": 24.09,
+   "decompress_mbps": 108.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 7,
-   "out_size": 5429379,
-   "ratio": 0.7487,
-   "compress_mbps": 6.22,
-   "decompress_mbps": 142.07
+   "out_size": 5496371,
+   "ratio": 0.7579,
+   "compress_mbps": 23.28,
+   "decompress_mbps": 110.06
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.24,
-   "decompress_mbps": 143.55
+   "compress_mbps": 6.23,
+   "decompress_mbps": 105.6
   },
   {
    "compressor": "native",
@@ -4775,7 +4775,7 @@
    "out_size": 5261135,
    "ratio": 0.7255,
    "compress_mbps": 1.58,
-   "decompress_mbps": 142.54
+   "decompress_mbps": 108.77
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 51.08,
-   "decompress_mbps": 230.6
+   "compress_mbps": 50.07,
+   "decompress_mbps": 140.2
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 46.77,
-   "decompress_mbps": 249.66
+   "compress_mbps": 45.81,
+   "decompress_mbps": 151.55
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 44.02,
-   "decompress_mbps": 268.95
+   "compress_mbps": 43.13,
+   "decompress_mbps": 162.65
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 36.01,
-   "decompress_mbps": 275.7
+   "compress_mbps": 35.58,
+   "decompress_mbps": 169.31
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.49,
-   "decompress_mbps": 281.05
+   "compress_mbps": 34.35,
+   "decompress_mbps": 178.57
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.44,
-   "decompress_mbps": 288.8
+   "compress_mbps": 31.04,
+   "decompress_mbps": 184.16
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 291.04
+   "compress_mbps": 24.48,
+   "decompress_mbps": 185.99
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.25,
-   "decompress_mbps": 292.86
+   "compress_mbps": 11.31,
+   "decompress_mbps": 185.95
   },
   {
    "compressor": "native",
@@ -4865,7 +4865,7 @@
    "out_size": 11638957,
    "ratio": 0.2807,
    "compress_mbps": 1.23,
-   "decompress_mbps": 284.73
+   "decompress_mbps": 186.63
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 32.18,
-   "decompress_mbps": 126.16
+   "compress_mbps": 32.63,
+   "decompress_mbps": 79.24
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 30.96,
-   "decompress_mbps": 127.72
+   "compress_mbps": 32.71,
+   "decompress_mbps": 79.84
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 31.88,
-   "decompress_mbps": 122.2
+   "compress_mbps": 32.53,
+   "decompress_mbps": 81.79
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.47,
-   "decompress_mbps": 114.72
+   "compress_mbps": 30.76,
+   "decompress_mbps": 81.79
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.79,
-   "decompress_mbps": 118.97
+   "compress_mbps": 30.89,
+   "decompress_mbps": 84.09
   },
   {
    "compressor": "native",
@@ -4924,18 +4924,18 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.85,
-   "decompress_mbps": 115.36
+   "compress_mbps": 30.73,
+   "decompress_mbps": 84.68
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 7,
-   "out_size": 6278507,
-   "ratio": 0.7409,
-   "compress_mbps": 4.69,
-   "decompress_mbps": 124.1
+   "out_size": 6368717,
+   "ratio": 0.7515,
+   "compress_mbps": 28.34,
+   "decompress_mbps": 84.53
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.7,
-   "decompress_mbps": 123.61
+   "compress_mbps": 4.75,
+   "decompress_mbps": 85.41
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.7,
-   "decompress_mbps": 123.51
+   "compress_mbps": 1.71,
+   "decompress_mbps": 84.93
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 99.54,
-   "decompress_mbps": 425.59
+   "compress_mbps": 94.29,
+   "decompress_mbps": 276.12
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 86.66,
-   "decompress_mbps": 469.18
+   "compress_mbps": 85.38,
+   "decompress_mbps": 300.67
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 76.88,
-   "decompress_mbps": 572.27
+   "compress_mbps": 76.55,
+   "decompress_mbps": 334.55
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 64.87,
-   "decompress_mbps": 565.07
+   "compress_mbps": 63.66,
+   "decompress_mbps": 332.17
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.39,
-   "decompress_mbps": 617.44
+   "compress_mbps": 62.04,
+   "decompress_mbps": 371.09
   },
   {
    "compressor": "native",
@@ -5014,18 +5014,18 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 57.88,
-   "decompress_mbps": 665.35
+   "compress_mbps": 57.49,
+   "decompress_mbps": 398.43
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 675427,
-   "ratio": 0.1264,
-   "compress_mbps": 21.28,
-   "decompress_mbps": 603.94
+   "out_size": 702400,
+   "ratio": 0.1314,
+   "compress_mbps": 40.51,
+   "decompress_mbps": 404.39
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.1,
-   "decompress_mbps": 606.66
+   "compress_mbps": 20.3,
+   "decompress_mbps": 421.21
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 637424,
    "ratio": 0.1192,
-   "compress_mbps": 0.98,
-   "decompress_mbps": 678.57
+   "compress_mbps": 0.97,
+   "decompress_mbps": 458.83
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR moves the block-split candidate entry in `deflateRaw` from `level ≥ 7` to `level ≥ 8`, promoting level 7 to the strongest single-block point. It resolves the L7/L8 half of [perf(explore): spread the per-level ladder — L4-6 and L7-8 collapse on the compress Pareto](https://github.com/kim-em/lean-zip/issues/2698): the two levels were nearly coincident on the speed/ratio Pareto (Silesia 9.99 vs 9.64 MB/s at ratio .3230 vs .3228).

The exploration found the L6→L7 cliff is architectural, not a matcher-knob effect: at `level ≥ 7` the encoder computes a second candidate (the cross-block split via `deflateDynamicBlocksSharedSized`) and keeps the smaller, a hard ~2.5-3× compress-speed cliff (a second whole-file encode plus the partition sizing). Levels 7 and 8 both paid it and differed only in chain depth, which saturates — hence the collapse. Promoting level 7 to single-block (full lazy lookahead, chain depth 256) lands it in the empty band between level 6 and the split tier; level 8 still emits the split ratio level 7 used to carry (same candidate, deeper chain). L7 and L8 are now distinct operating points.

The roundtrip proofs case on the dispatch `if` and apply level-agnostic lemmas, so the threshold change needs no proof edits; the matcher correctness contracts are untouched.

What the exploration established and why the scope is this one change:

- On **Canterbury** the new L7 point lands outside the prior convex hull (8.4 → 20.8 MB/s at the same-or-better ratio) — a genuine frontier expansion, because the small files make the split's ratio win small and the gap was wide.
- On **Silesia** the new L7 is a distinct Pareto-efficient point that sits *on* the existing frontier (the split's large Silesia ratio win is fairly priced, so the gap-filler lands on the curve, not beyond it). It de-collapses L7/L8 and adds a usable ~24 MB/s operating point where before the ladder jumped straight from level 6 to the split tier — but it does not push the Silesia curve outward.
- The per-level matcher knobs the issue suggested as separators (chain depth, the lazy `good_match` gate, a `nice_match` early-out) were measured to be quality-for-speed tradeoffs that trace a single frontier: they redistribute levels along it but cannot push it outward, and graduating `good_match` across L4-6 landed those levels slightly *inside* the Silesia frontier. Pushing the frontier itself out is the work of the sibling issues #2696 (chain self-throttle — speed at ~equal ratio) and #2638 (near-optimal parse — better ratio at the top), so the L4-6 de-bunch and the top-end gains are deferred there.

🤖 Prepared with Claude Code