### PR TITLE
perf(deflate): local @[extern] word-sized ByteArray readers, wired into hash3

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -36,6 +36,7 @@ import Zip.Spec.DynamicTreesCorrect
 import Zip.Spec.DynamicTreesComplete
 import Zip.Spec.InflateCorrect
 import Zip.Spec.InflateComplete
+import Zip.Native.Wide
 import Zip.Native.Adler32
 import Zip.Native.Crc32
 import Zip.Native.Inflate

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1,5 +1,6 @@
 import Zip.Native.BitWriter
 import Zip.Native.Inflate
+import Zip.Native.Wide
 import Std.Tactic.BVDecide
 
 /-!
@@ -458,11 +459,28 @@ where
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact
     -- same index, so `hash3_eq` stays `rfl` and the `< hashSize` bound holds.
-    let a := (data[pos]'(by omega)).toUInt32
-    let b := (data[pos + 1]'(by omega)).toUInt32
-    let c := (data[pos + 2]'(by omega)).toUInt32
-    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
-    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    -- When the four hash bytes are in bounds and the buffer is `USize`-
+    -- addressable, read them as one wide load (`ugetUInt32LE`, #2706); its model
+    -- is exactly the `a ||| b<<<8 ||| c<<<16 ||| d<<<24` recombination, so the
+    -- hash value is identical and all three `hash3` variants stay defeq.
+    let word :=
+      if h4 : pos + 4 ≤ data.size then
+        if hsz : data.size.toUSize.toNat = data.size then
+          ByteArray.ugetUInt32LE data pos.toUSize (by
+            have hds : data.size < USize.size := by
+              rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _
+            rw [toUSize_toNat_of_lt (show pos < USize.size by omega)]; omega)
+        else
+          let a := (data[pos]'(by omega)).toUInt32
+          let b := (data[pos + 1]'(by omega)).toUInt32
+          let c := (data[pos + 2]'(by omega)).toUInt32
+          let d := (data[pos + 3]'(by omega)).toUInt32
+          a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+      else
+        let a := (data[pos]'(by omega)).toUInt32
+        let b := (data[pos + 1]'(by omega)).toUInt32
+        let c := (data[pos + 2]'(by omega)).toUInt32
+        a ||| (b <<< 8) ||| (c <<< 16)
     (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
@@ -589,11 +607,28 @@ where
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact
     -- same index, so `hash3_eq` stays `rfl` and the `< hashSize` bound holds.
-    let a := (data[pos]'(by omega)).toUInt32
-    let b := (data[pos + 1]'(by omega)).toUInt32
-    let c := (data[pos + 2]'(by omega)).toUInt32
-    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
-    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    -- When the four hash bytes are in bounds and the buffer is `USize`-
+    -- addressable, read them as one wide load (`ugetUInt32LE`, #2706); its model
+    -- is exactly the `a ||| b<<<8 ||| c<<<16 ||| d<<<24` recombination, so the
+    -- hash value is identical and all three `hash3` variants stay defeq.
+    let word :=
+      if h4 : pos + 4 ≤ data.size then
+        if hsz : data.size.toUSize.toNat = data.size then
+          ByteArray.ugetUInt32LE data pos.toUSize (by
+            have hds : data.size < USize.size := by
+              rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _
+            rw [toUSize_toNat_of_lt (show pos < USize.size by omega)]; omega)
+        else
+          let a := (data[pos]'(by omega)).toUInt32
+          let b := (data[pos + 1]'(by omega)).toUInt32
+          let c := (data[pos + 2]'(by omega)).toUInt32
+          let d := (data[pos + 3]'(by omega)).toUInt32
+          a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+      else
+        let a := (data[pos]'(by omega)).toUInt32
+        let b := (data[pos + 1]'(by omega)).toUInt32
+        let c := (data[pos + 2]'(by omega)).toUInt32
+        a ||| (b <<< 8) ||| (c <<< 16)
     (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
@@ -1489,11 +1524,28 @@ where
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact
     -- same index, so `hash3_eq` stays `rfl` and the `< hashSize` bound holds.
-    let a := (data[pos]'(by omega)).toUInt32
-    let b := (data[pos + 1]'(by omega)).toUInt32
-    let c := (data[pos + 2]'(by omega)).toUInt32
-    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
-    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    -- When the four hash bytes are in bounds and the buffer is `USize`-
+    -- addressable, read them as one wide load (`ugetUInt32LE`, #2706); its model
+    -- is exactly the `a ||| b<<<8 ||| c<<<16 ||| d<<<24` recombination, so the
+    -- hash value is identical and all three `hash3` variants stay defeq.
+    let word :=
+      if h4 : pos + 4 ≤ data.size then
+        if hsz : data.size.toUSize.toNat = data.size then
+          ByteArray.ugetUInt32LE data pos.toUSize (by
+            have hds : data.size < USize.size := by
+              rw [← hsz]; exact USize.toNat_lt_two_pow_numBits _
+            rw [toUSize_toNat_of_lt (show pos < USize.size by omega)]; omega)
+        else
+          let a := (data[pos]'(by omega)).toUInt32
+          let b := (data[pos + 1]'(by omega)).toUInt32
+          let c := (data[pos + 2]'(by omega)).toUInt32
+          let d := (data[pos + 3]'(by omega)).toUInt32
+          a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+      else
+        let a := (data[pos]'(by omega)).toUInt32
+        let b := (data[pos + 1]'(by omega)).toUInt32
+        let c := (data[pos + 2]'(by omega)).toUInt32
+        a ||| (b <<< 8) ||| (c <<< 16)
     (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=

--- a/Zip/Native/Wide.lean
+++ b/Zip/Native/Wide.lean
@@ -1,0 +1,58 @@
+/-!
+  Word-sized little-endian `ByteArray` loads for the DEFLATE hot loops.
+
+  `ByteArray.ugetUInt32LE a off` and `ByteArray.ugetUInt64LE a off` read a 4- or
+  8-byte little-endian word starting at byte `off` of `a`. The reference body —
+  and the trusted specification of the `@[extern]` — is literally the
+  byte-recombination expression the hot paths assemble today:
+
+      a[off] ||| a[off+1] <<< 8 ||| a[off+2] <<< 16 ||| a[off+3] <<< 24     (u32)
+      a[off] ||| a[off+1] <<< 8 ||| ... ||| a[off+7] <<< 56                 (u64)
+
+  so swapping the inline byte assembly for one of these is definitional modulo
+  the offset's `Nat`/`USize` round-trip; `@[extern]` only changes the compiled
+  implementation (`c/bytearray_wide_ffi.c`) to a single wide load.
+
+  The offset is a `USize`, so a hot loop's index arithmetic stays unboxed (the
+  point of mirroring lean#14053's `uget*` readers rather than lean#8165's
+  `Nat`-indexed `getUIntN`). The in-bounds hypothesis `off.toNat + W/8 ≤ a.size`
+  is discharged by the caller's existing guards and means the C does no bounds
+  check.
+
+  This is a project-local stopgap mirroring the readers of lean#14053 (`wide
+  fixed-width load/store`). The C symbols are namespaced `lean_zip_*` so they do
+  not clash with core after the toolchain bump. Migration once lean#14053 lands:
+  delete this file and `c/bytearray_wide_ffi.c`, and use core's `uget*`
+  primitives (their reference bodies are identical, so callers and proofs are
+  unchanged).
+-/
+
+namespace ByteArray
+
+/-- Load the little-endian `UInt32` at byte offset `off`. The reference body
+    `a[off] ||| a[off+1] <<< 8 ||| a[off+2] <<< 16 ||| a[off+3] <<< 24` is the
+    trusted specification of the `@[extern]`; the C reads it in one wide load. -/
+@[extern "lean_zip_uget_u32le"]
+def ugetUInt32LE (a : @& ByteArray) (off : USize)
+    (h : off.toNat + 4 ≤ a.size := by get_elem_tactic) : UInt32 :=
+  (a[off.toNat]'(by omega)).toUInt32 |||
+  ((a[off.toNat + 1]'(by omega)).toUInt32 <<< 8) |||
+  ((a[off.toNat + 2]'(by omega)).toUInt32 <<< 16) |||
+  ((a[off.toNat + 3]'(by omega)).toUInt32 <<< 24)
+
+/-- Load the little-endian `UInt64` at byte offset `off`. The reference body
+    `a[off] ||| a[off+1] <<< 8 ||| ... ||| a[off+7] <<< 56` is the trusted
+    specification of the `@[extern]`; the C reads it in one wide load. -/
+@[extern "lean_zip_uget_u64le"]
+def ugetUInt64LE (a : @& ByteArray) (off : USize)
+    (h : off.toNat + 8 ≤ a.size := by get_elem_tactic) : UInt64 :=
+  (a[off.toNat]'(by omega)).toUInt64 |||
+  ((a[off.toNat + 1]'(by omega)).toUInt64 <<< 8) |||
+  ((a[off.toNat + 2]'(by omega)).toUInt64 <<< 16) |||
+  ((a[off.toNat + 3]'(by omega)).toUInt64 <<< 24) |||
+  ((a[off.toNat + 4]'(by omega)).toUInt64 <<< 32) |||
+  ((a[off.toNat + 5]'(by omega)).toUInt64 <<< 40) |||
+  ((a[off.toNat + 6]'(by omega)).toUInt64 <<< 48) |||
+  ((a[off.toNat + 7]'(by omega)).toUInt64 <<< 56)
+
+end ByteArray

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -7,6 +7,7 @@ import ZipTest.Libdeflate
 import ZipTest.Zopfli
 import ZipTest.Checksum
 import ZipTest.Binary
+import ZipTest.Wide
 import ZipTest.Tar
 import ZipTest.Archive
 import ZipTest.ZipFixtures
@@ -40,6 +41,7 @@ def main : IO Unit := do
   ZipTest.Zopfli.tests
   ZipTest.Checksum.tests
   ZipTest.Binary.tests
+  ZipTest.Wide.tests
   ZipTest.Tar.tests
   ZipTest.Archive.tests
   ZipTest.ZipFixtures.tests

--- a/ZipTest/Wide.lean
+++ b/ZipTest/Wide.lean
@@ -1,0 +1,76 @@
+import ZipTest.Helpers
+
+/-! Conformance tests for the word-sized `@[extern]` ByteArray readers
+    (`ByteArray.ugetUInt32LE` / `ugetUInt64LE`).
+
+    Each test compares the compiled `@[extern]` result (which runs the C in
+    `c/bytearray_wide_ffi.c`) against a pure-Lean reference recombination of the
+    same bytes — i.e. the `@[extern]`'s own reference body, but evaluated without
+    the extern so the comparison validates the C against the model. We sweep all
+    in-bounds offsets (including the `off + W/8 == size` boundary) over several
+    byte patterns. -/
+
+namespace ZipTest.Wide
+
+/-- Pure-Lean reference for the little-endian `UInt32` load (no `@[extern]`). -/
+def refU32LE (a : ByteArray) (off : Nat) : UInt32 :=
+  a[off]!.toUInt32 |||
+  (a[off + 1]!.toUInt32 <<< 8) |||
+  (a[off + 2]!.toUInt32 <<< 16) |||
+  (a[off + 3]!.toUInt32 <<< 24)
+
+/-- Pure-Lean reference for the little-endian `UInt64` load (no `@[extern]`). -/
+def refU64LE (a : ByteArray) (off : Nat) : UInt64 :=
+  a[off]!.toUInt64 |||
+  (a[off + 1]!.toUInt64 <<< 8) |||
+  (a[off + 2]!.toUInt64 <<< 16) |||
+  (a[off + 3]!.toUInt64 <<< 24) |||
+  (a[off + 4]!.toUInt64 <<< 32) |||
+  (a[off + 5]!.toUInt64 <<< 40) |||
+  (a[off + 6]!.toUInt64 <<< 48) |||
+  (a[off + 7]!.toUInt64 <<< 56)
+
+/-- Check every in-bounds 4-byte offset of `a`, extern vs reference. The `USize`
+    index is passed straight to the extern, so its bound `off.toNat + 4 ≤ size`
+    is exactly the dif-condition. -/
+partial def checkU32 (a : ByteArray) (off : USize := 0) : IO Unit := do
+  if h : off.toNat + 4 ≤ a.size then
+    let got := ByteArray.ugetUInt32LE a off h
+    let want := refU32LE a off.toNat
+    unless got == want do
+      throw (IO.userError s!"ugetUInt32LE mismatch at off {off.toNat}: got {got}, want {want}")
+    checkU32 a (off + 1)
+
+/-- Check every in-bounds 8-byte offset of `a`, extern vs reference. -/
+partial def checkU64 (a : ByteArray) (off : USize := 0) : IO Unit := do
+  if h : off.toNat + 8 ≤ a.size then
+    let got := ByteArray.ugetUInt64LE a off h
+    let want := refU64LE a off.toNat
+    unless got == want do
+      throw (IO.userError s!"ugetUInt64LE mismatch at off {off.toNat}: got {got}, want {want}")
+    checkU64 a (off + 1)
+
+/-- A spread of byte patterns: zeros, max bytes, ascending, descending, and a
+    high-bit-set pattern (to catch sign-extension bugs in the recombination). -/
+def patterns : List ByteArray :=
+  [ ByteArray.mk (Array.replicate 20 0),
+    ByteArray.mk (Array.replicate 20 0xFF),
+    ByteArray.mk (Array.range 20 |>.map (·.toUInt8)),
+    ByteArray.mk (Array.range 20 |>.map (fun i => (19 - i).toUInt8)),
+    ByteArray.mk (Array.range 20 |>.map (fun i => (0x80 ||| i).toUInt8)),
+    -- Exactly word-sized: hits only the `off + W/8 == size` boundary.
+    ByteArray.mk #[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE] ]
+
+def tests : IO Unit := do
+  for a in patterns do
+    checkU32 a
+    checkU64 a
+  -- A direct spot-check of a known little-endian value.
+  let a := ByteArray.mk #[0x78, 0x56, 0x34, 0x12, 0xF0, 0xDE, 0xBC, 0x9A]
+  unless ByteArray.ugetUInt32LE a 0 (by decide) == 0x12345678 do
+    throw (IO.userError "ugetUInt32LE spot-check failed")
+  unless ByteArray.ugetUInt64LE a 0 (by decide) == 0x9ABCDEF012345678 do
+    throw (IO.userError "ugetUInt64LE spot-check failed")
+  IO.println "Wide reader conformance tests: OK"
+
+end ZipTest.Wide

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe6cf8553af)">
+   <g clip-path="url(#pba00708880)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3YwYpeZx3H8ZnJJIQwBBUaayhFBEsX3Yt4DW68EK/Au+gVFARXbou0y+56CdFKKSSmOmSaOJlMJ2/e0537wvfhb14+nyv4HQ4853ue4/3zv2xHvF2uL6cXrHP9YnrBEtvrm+kJyxzffzA9YY3bd6cXrHNyMr1gjdfX0wvWOT7Md7ZdPJmesMxhvjEAgEECCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdvr10fn0hiVe76+nJyzzi5/8anrCMmfbu9MTljh++Wx6wjJfvHo0PWGJ9+48mJ6wzG5/Mz1hics3h3vu3+x30xOW+M3996cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGLHL77/6zY9YoVXu8vpCcu8s783PWGd3c30gjUuz6cXrPPzD6YXLHG5XU1PWOZQz8d3trPpCcs8OXo2PWGJh+ffTU9Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxE7PLs6nNyxxdnpnesI610+nFyyzXT6fnrDGfj+9YJnje/+enrDEIZ8hZ6f3pyescefu9IJlHr66mZ6wxHb1r+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCInW7nT6c38GPt99ML4H+2x/+cnrDGif/Pt46zkf8jThAAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCInf7xP99Mb1ji4vrN9IRlvnzyYnrCMp/+4XfTE5Z4994vpycs89Enf56esMTvf/2z6QnLfHVxPT2BH+lvn/1jesISVx//aXrCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIHa823++TY9Y4c1+Nz1hmZPjw+3iW9dX0xPWuHU6vWCdl8+mFyyx/+nD6QnLbNt+esIStw74zuD1dpjftNu7w3yuoyM3WAAAOYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABA7PdmmJ6xxcnJnesI63z6aXrDM9t+L6Qlr7HbTC5bZPvzt9IQlTg74//PN0X56who3V9MLlrl9oM+2Pf779IRlDvcEAQAYIrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGI/AArxjQDjWREnAAAAAElFTkSuQmCC" id="image7d3597acfb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFklEQVR4nO3YwYpkZx2H4eqemiEMzaBCYhxEJKC4cC8h15BNLiRXkLvwCgTBlVsRXbrLJcQYRMgYYjuTNJ2Zsrumjjv3gffjb4rnuYLf4RRfvee7OH39u23Hd8vhdnrBOoeb6QVLbPd30xOWuXjy1vSENR6+Mb1gncvL6QVr3B+mF6xzcZ7vbHvxbHrCMuf5xgAABgksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/u+76+kNS9yfDtMTlvnR996ZnrDM1fb29IQlLr55Pj1hmb+8+mR6whI/fvTW9IRljqe76QlL3L4+33P/7nScnrDEr578ZHrCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIHZx85/fb9MjVnh1vJ2esMybp8fTE9Y53k0vWOP2enrBOj/8+fSCJW63l9MTljnX8/HN7Wp6wjLPds+nJyzx9Pqr6QnLuMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7qxfX0hiWu9o+mJ6xz+GJ6wTLb7dfTE9Y4naYXLHPx+MvpCUuc8xlytX8yPWGNR29ML1jm6au76QlLbC//OT1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/Xb9xfQGvq3TaXoB/M/2+WfTE9a49P35neNs5P+IEwQAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+w//9Y/pDUu8OLyenrDMx89upics84cP3puesMTbj386PWGZX/7mt9MTlnj/Zz+YnrDM314cpifwLf3xT59OT1ji5a8/mp6wjBssAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiF0cT3/epkes8Pp0nJ6wzOXF+Xbxg8PL6QlrPNhPL1jnm+fTC5Y4ff/p9IRltu00PWGJB2d8Z3C/ned/2sPjeT7XbucGCwAgJ7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7y3NtrMv99IJlLr/8bHrCMtvNv6cnrHE8Ti9YZvvFu9MTljjbs3G3291v5/l7fPD6PJ9rt9vtHh5upicssX3+1+kJy5zvCQIAMERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE/gs6f40ESdQ8iwAAAABJRU5ErkJggg==" id="image06de6af14f" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2db671a643" d="M 0 0 
+       <path id="m2c59db69c0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2db671a643" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2db671a643" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2db671a643" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2db671a643" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2db671a643" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2db671a643" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2db671a643" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2db671a643" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2db671a643" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2db671a643" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2db671a643" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c59db69c0" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1b3d659323" d="M 0 0 
+       <path id="m7bb63aa238" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1b3d659323" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7bb63aa238" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,14 +1303,14 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -5 -->
+    <!-- -2 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +1 -->
+    <!-- +5 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1330,7 +1330,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1459,29 +1459,30 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- +0 -->
+    <!-- +2 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +8 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -19 -->
+    <!-- -15 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -37 -->
+    <!-- -35 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1516,28 +1517,18 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -94 -->
+    <!-- -93 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1573,6 +1564,18 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2178,18 +2181,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageda1964a597" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0827375d79" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mff320983ef" d="M 0 0 
+       <path id="m82d211b1bb" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2215,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2229,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2256,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2269,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2282,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mff320983ef" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d211b1bb" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.069922 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,16 +3011,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3059,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe6cf8553af">
+  <clipPath id="pba00708880">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md206b66972" d="M 0 0 
+       <path id="m4f9472e02b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md206b66972" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md206b66972" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md206b66972" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md206b66972" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md206b66972" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#md206b66972" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md206b66972" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f9472e02b" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m090e8389e8" d="M 0 0 
+       <path id="m58b4a08d7a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m090e8389e8" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58b4a08d7a" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m090e8389e8" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58b4a08d7a" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m090e8389e8" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58b4a08d7a" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m626b406dd0" d="M 0 0 
+       <path id="mbd7a4918cb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m626b406dd0" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbd7a4918cb" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 175.979305) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 175.425138) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 332.559993) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 332.195521) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5fdb82c26c" d="M -2.5 2.5 
+     <path id="mb3bb7baf19" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m5fdb82c26c" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5fdb82c26c" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#mb3bb7baf19" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3bb7baf19" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0c660f825c" d="M 0 -2.5 
+     <path id="m765a529ac4" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m0c660f825c" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0c660f825c" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m765a529ac4" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m765a529ac4" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m992a7b9d54" d="M -0 3.535534 
+     <path id="m85655077c6" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m992a7b9d54" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m992a7b9d54" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m85655077c6" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85655077c6" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m14686152ee" d="M -0 2.5 
+     <path id="mf8c681c4fd" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m14686152ee" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#mf8c681c4fd" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2504069242" d="M -0.833333 2.5 
+     <path id="md439aaf8c9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m2504069242" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2504069242" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#md439aaf8c9" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md439aaf8c9" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc082f36f60" d="M -1.25 2.5 
+     <path id="m5e2fa3c16c" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#mc082f36f60" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc082f36f60" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m5e2fa3c16c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e2fa3c16c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6b54ebc4f4" d="M 0 -2.5 
+     <path id="m527339a017" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m6b54ebc4f4" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6b54ebc4f4" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m527339a017" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m527339a017" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2829408430" d="M 0 -2.5 
+     <path id="m785de4480c" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m2829408430" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2829408430" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m785de4480c" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m785de4480c" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m6b4a8e226e" d="M 0 3.5 
+      <path id="m4edfee5a4f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6b4a8e226e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4edfee5a4f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5fdb82c26c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb3bb7baf19" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0c660f825c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m765a529ac4" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m992a7b9d54" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m85655077c6" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m14686152ee" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf8c681c4fd" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2504069242" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md439aaf8c9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc082f36f60" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5e2fa3c16c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6b54ebc4f4" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m527339a017" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2829408430" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m785de4480c" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 180.979305 
-L 214.084819 183.575473 
-L 206.266533 186.149747 
-L 187.75787 192.883 
-L 186.58897 193.731187 
-L 184.505355 196.279314 
-L 164.72409 207.32024 
-L 150.950891 251.673923 
-L 98.348822 337.559993 
-" clip-path="url(#pf3d8ccba19)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pf3d8ccba19)">
-     <use xlink:href="#m6b4a8e226e" x="226.647908" y="180.979305" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="214.084819" y="183.575473" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="206.266533" y="186.149747" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="187.75787" y="192.883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="186.58897" y="193.731187" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="184.505355" y="196.279314" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="164.72409" y="207.32024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="150.950891" y="251.673923" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6b4a8e226e" x="98.348822" y="337.559993" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 180.425138 
+L 214.084819 183.225764 
+L 206.266533 185.77183 
+L 187.75787 192.086031 
+L 186.58897 193.229871 
+L 184.505355 195.352955 
+L 164.72409 206.648586 
+L 150.950891 251.636138 
+L 98.348822 337.195521 
+" clip-path="url(#p6dd96c69d4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p6dd96c69d4)">
+     <use xlink:href="#m4edfee5a4f" x="226.647908" y="180.425138" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="214.084819" y="183.225764" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="206.266533" y="185.77183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="187.75787" y="192.086031" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="186.58897" y="193.229871" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="184.505355" y="195.352955" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="164.72409" y="206.648586" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="150.950891" y="251.636138" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4edfee5a4f" x="98.348822" y="337.195521" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2918,34 +2918,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3005,29 +3000,44 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -3068,16 +3078,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3116,109 +3126,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf3d8ccba19">
+  <clipPath id="p6dd96c69d4">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p8f2d491a25)">
+   <g clip-path="url(#p9d39b12e57)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagee195264f06" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imaged0e98306ab" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mdcb0d9b02a" d="M 0 0 
+       <path id="mfcf9c551d2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mdcb0d9b02a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcf9c551d2" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mc4c8ba76bc" d="M 0 0 
+       <path id="m6d6f465b1b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc4c8ba76bc" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6d6f465b1b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image485ccb2414" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imageea9563f261" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m0cb0edd9f5" d="M 0 0 
+       <path id="m8072ac8269" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0cb0edd9f5" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8072ac8269" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.069922 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2951,16 +2951,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8f2d491a25">
+  <clipPath id="p9d39b12e57">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="386.202469pt" viewBox="0 0 570.260156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.872656 386.202469 
-L 570.872656 0 
+L 570.260156 386.202469 
+L 570.260156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.561328 104.1264 
-L 292.186328 104.1264 
-L 292.186328 74.7432 
-L 187.561328 74.7432 
+    <path d="M 187.255078 104.1264 
+L 291.880078 104.1264 
+L 291.880078 74.7432 
+L 187.255078 74.7432 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.186328 104.1264 
-L 396.811328 104.1264 
-L 396.811328 74.7432 
-L 292.186328 74.7432 
+    <path d="M 291.880078 104.1264 
+L 396.505078 104.1264 
+L 396.505078 74.7432 
+L 291.880078 74.7432 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.811328 104.1264 
-L 501.436328 104.1264 
-L 501.436328 74.7432 
-L 396.811328 74.7432 
+    <path d="M 396.505078 104.1264 
+L 501.130078 104.1264 
+L 501.130078 74.7432 
+L 396.505078 74.7432 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.561328 133.5096 
-L 292.186328 133.5096 
-L 292.186328 104.1264 
-L 187.561328 104.1264 
+    <path d="M 187.255078 133.5096 
+L 291.880078 133.5096 
+L 291.880078 104.1264 
+L 187.255078 104.1264 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.186328 133.5096 
-L 396.811328 133.5096 
-L 396.811328 104.1264 
-L 292.186328 104.1264 
+    <path d="M 291.880078 133.5096 
+L 396.505078 133.5096 
+L 396.505078 104.1264 
+L 291.880078 104.1264 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.811328 133.5096 
-L 501.436328 133.5096 
-L 501.436328 104.1264 
-L 396.811328 104.1264 
+    <path d="M 396.505078 133.5096 
+L 501.130078 133.5096 
+L 501.130078 104.1264 
+L 396.505078 104.1264 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.561328 162.8928 
-L 292.186328 162.8928 
-L 292.186328 133.5096 
-L 187.561328 133.5096 
+    <path d="M 187.255078 162.8928 
+L 291.880078 162.8928 
+L 291.880078 133.5096 
+L 187.255078 133.5096 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.186328 162.8928 
-L 396.811328 162.8928 
-L 396.811328 133.5096 
-L 292.186328 133.5096 
+    <path d="M 291.880078 162.8928 
+L 396.505078 162.8928 
+L 396.505078 133.5096 
+L 291.880078 133.5096 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.811328 162.8928 
-L 501.436328 162.8928 
-L 501.436328 133.5096 
-L 396.811328 133.5096 
+    <path d="M 396.505078 162.8928 
+L 501.130078 162.8928 
+L 501.130078 133.5096 
+L 396.505078 133.5096 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.561328 192.276 
-L 292.186328 192.276 
-L 292.186328 162.8928 
-L 187.561328 162.8928 
+    <path d="M 187.255078 192.276 
+L 291.880078 192.276 
+L 291.880078 162.8928 
+L 187.255078 162.8928 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.186328 192.276 
-L 396.811328 192.276 
-L 396.811328 162.8928 
-L 292.186328 162.8928 
+    <path d="M 291.880078 192.276 
+L 396.505078 192.276 
+L 396.505078 162.8928 
+L 291.880078 162.8928 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.811328 192.276 
-L 501.436328 192.276 
-L 501.436328 162.8928 
-L 396.811328 162.8928 
+    <path d="M 396.505078 192.276 
+L 501.130078 192.276 
+L 501.130078 162.8928 
+L 396.505078 162.8928 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.561328 221.6592 
-L 292.186328 221.6592 
-L 292.186328 192.276 
-L 187.561328 192.276 
+    <path d="M 187.255078 221.6592 
+L 291.880078 221.6592 
+L 291.880078 192.276 
+L 187.255078 192.276 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.186328 221.6592 
-L 396.811328 221.6592 
-L 396.811328 192.276 
-L 292.186328 192.276 
+    <path d="M 291.880078 221.6592 
+L 396.505078 221.6592 
+L 396.505078 192.276 
+L 291.880078 192.276 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.811328 221.6592 
-L 501.436328 221.6592 
-L 501.436328 192.276 
-L 396.811328 192.276 
+    <path d="M 396.505078 221.6592 
+L 501.130078 221.6592 
+L 501.130078 192.276 
+L 396.505078 192.276 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.561328 251.0424 
-L 292.186328 251.0424 
-L 292.186328 221.6592 
-L 187.561328 221.6592 
+    <path d="M 187.255078 251.0424 
+L 291.880078 251.0424 
+L 291.880078 221.6592 
+L 187.255078 221.6592 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.186328 251.0424 
-L 396.811328 251.0424 
-L 396.811328 221.6592 
-L 292.186328 221.6592 
+    <path d="M 291.880078 251.0424 
+L 396.505078 251.0424 
+L 396.505078 221.6592 
+L 291.880078 221.6592 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.811328 251.0424 
-L 501.436328 251.0424 
-L 501.436328 221.6592 
-L 396.811328 221.6592 
+    <path d="M 396.505078 251.0424 
+L 501.130078 251.0424 
+L 501.130078 221.6592 
+L 396.505078 221.6592 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.561328 280.4256 
-L 292.186328 280.4256 
-L 292.186328 251.0424 
-L 187.561328 251.0424 
+    <path d="M 187.255078 280.4256 
+L 291.880078 280.4256 
+L 291.880078 251.0424 
+L 187.255078 251.0424 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.186328 280.4256 
-L 396.811328 280.4256 
-L 396.811328 251.0424 
-L 292.186328 251.0424 
+    <path d="M 291.880078 280.4256 
+L 396.505078 280.4256 
+L 396.505078 251.0424 
+L 291.880078 251.0424 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.811328 280.4256 
-L 501.436328 280.4256 
-L 501.436328 251.0424 
-L 396.811328 251.0424 
+    <path d="M 396.505078 280.4256 
+L 501.130078 280.4256 
+L 501.130078 251.0424 
+L 396.505078 251.0424 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.561328 309.8088 
-L 292.186328 309.8088 
-L 292.186328 280.4256 
-L 187.561328 280.4256 
+    <path d="M 187.255078 309.8088 
+L 291.880078 309.8088 
+L 291.880078 280.4256 
+L 187.255078 280.4256 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.186328 309.8088 
-L 396.811328 309.8088 
-L 396.811328 280.4256 
-L 292.186328 280.4256 
+    <path d="M 291.880078 309.8088 
+L 396.505078 309.8088 
+L 396.505078 280.4256 
+L 291.880078 280.4256 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.811328 309.8088 
-L 501.436328 309.8088 
-L 501.436328 280.4256 
-L 396.811328 280.4256 
+    <path d="M 396.505078 309.8088 
+L 501.130078 309.8088 
+L 501.130078 280.4256 
+L 396.505078 280.4256 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.561328 339.192 
-L 292.186328 339.192 
-L 292.186328 309.8088 
-L 187.561328 309.8088 
+    <path d="M 187.255078 339.192 
+L 291.880078 339.192 
+L 291.880078 309.8088 
+L 187.255078 309.8088 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.186328 339.192 
-L 396.811328 339.192 
-L 396.811328 309.8088 
-L 292.186328 309.8088 
+    <path d="M 291.880078 339.192 
+L 396.505078 339.192 
+L 396.505078 309.8088 
+L 291.880078 309.8088 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.811328 339.192 
-L 501.436328 339.192 
-L 501.436328 309.8088 
-L 396.811328 309.8088 
+    <path d="M 396.505078 339.192 
+L 501.130078 339.192 
+L 501.130078 309.8088 
+L 396.505078 309.8088 
 z
-" clip-path="url(#pde47dca50c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pde93d899cb)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.242344 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.526563 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.098672 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.450391 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.180078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.557578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.818203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.387578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.081328 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.693828 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.387578 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.850078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.543828 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.195703 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.889453 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(227.221953 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.915703 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 24 -->
-    <g transform="translate(338.932578 238.5583) scale(0.08 -0.08)">
+    <!-- 25 -->
+    <g transform="translate(338.626328 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1722,29 +1722,6 @@ Q 3866 4013 3866 3353
 Q 3866 2972 3669 2642 
 Q 3472 2313 2841 1759 
 L 1844 884 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 135 -->
-    <g transform="translate(440.774453 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
@@ -1773,6 +1750,29 @@ L 678 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 135 -->
+    <g transform="translate(440.468203 238.5583) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
@@ -1780,7 +1780,7 @@ z
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.310703 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.004453 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1909,7 +1909,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.422578 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1919,14 +1919,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.408828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.488828 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1934,7 +1934,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.817578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.511328 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1990,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2000,21 +2000,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.408828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(444.033828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.727578 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.225703 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2025,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2035,13 +2035,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.647578 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.817578 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2057,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.945078 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.638828 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2270,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2409,16 +2409,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2457,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pde47dca50c">
-   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pde93d899cb">
+   <rect x="82.630078" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p6d4ad60b38)">
+   <g clip-path="url(#paba5eeb14e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7ElEQVR4nO3Yv46ldR3H8T0zh1lclrjCsgRNNjZqJQnRioY7sPAyLG3pLalp7b0BKo2VCSHQYSdBClkicWXZzM6ZOeMVWG1+7+/sk9frCj4nz5/f+zm747//eH1ryw7n0wt4HsfL6QVr7U6mF6x1eTG9YK0796YXrPXsyfSCtU7PphfwPLZ+f57dmV6w1MZPPwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/J4YvpDUvtT06nJyx1vL6enrDUg1cfTE9Y6ov//nN6wlob/8T9+cv3picsdbh9Nj1hqU8ffT49Yam37/9sesJSz86O0xOW2u2eTk9YauPHAwAAN40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtH7760+kNS927/WB6wlLfnH81PWGpHz/d9jfS3dd/OT1hqdPdfnrCUsdbx+kJS71x6/70hKUu719MT1jqzTsPpycsdThu+/q9crHt98u2T3cAAG4cAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGq/2227Qb87fDs9YakfnN6dnrDU1euvTU9Y6l+PP5uesNSTi/PpCUv96ke/np6w1MXp9IK1vj98Nz2B5/CfZ4+mJ6x1+8H0gqW2XZ8AANw4AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTu6q+/v54esdTxOL0A/r8T34AvNO+XF9vWn7+t35+u3wtt41cPAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDav/nx36c3LHWy33ZjP/r8m+kJS334u3emJyz1h799PT1hqfce/nB6wlJ/+ss/pics9f5vfzE9YakP/vzl9ISlfvPOW9MTlvry8bPpCUu9+5NXpicste06AwDgxhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnd4eqj6+kRK51eXk5PWOtkP71grcvz6QVrnd2ZXrDWbuPfuNfH6QVrHTx/L7SrbZ9/h922n7+XNt4vGz8dAAC4aQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fSA5fZn0wuWOu6mF6x18vjb6QlLXZ29PD1hqdOr4/SEtS7Ppxesddj273uyu5iesNTd622ffy+dbDxhLp5OL1jKP6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqf8BtMV8or4v3j8AAAAASUVORK5CYII=" id="imaged84df627b8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6UlEQVR4nO3Yv46UVQCH4Z3dYcEFIgouURNio1aaEK1svAMLL8PS1t7S2tbeG7DSWJkYox12ErVQiEb+SJadZdYrsCLnPcuX57mC3+TMN+f9ZrX964vTnSXbHM1ewNPYnsxeMNZqd/aCsU6OZy8Y6+DK7AVjPX44e8FYe/uzF/A0lv793D+YvWCohd9+AACcNQIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU+ofN7dkbhlrv7s2eMNT29HT2hKEOLx/OnjDU7fu/zZ4w1sJfcd+4cGX2hKE25/dnTxjqxzu3Zk8Y6u1rr8+eMNTj/e3sCUOtVo9mTxhq4dcDAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1vXH5t9oahrpw/nD1hqLtHv8+eMNQrj5b9jnTp6luzJwy1t1rPnjDUdmc7e8JQL+1cmz1hqJNrx7MnDHX94MbsCUNttss+v4vHy/59WfbtDgDAmSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIrVerZTfog83fsycM9dzepdkThnpy9cXZE4b6495PsycM9fD4aPaEod554d3ZE4Y63pu9YKx/Nw9mT+Ap/PP4zuwJY50/nL1gqGXXJwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtXry7cens0cMtd3OXgD/b9c74DPN78uzbenP39K/n87vmbbw0wMA4KwRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNbXv/959oahdtfLbuw7t+7OnjDU5x/dnD1hqE+/+3P2hKHev/H87AlDffnNL7MnDPXJh2/OnjDUZ1//OnvCUB/cfHn2hKF+vfd49oSh3nv14uwJQy27zgAAOHMEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqtXny1ensESPtnZzMnjDW7nr2grFOjmYvGGv/YPaCsVYLf8c93c5eMNbG8/dMe7Ls+2+zWvbzd27h/bLw2wEAgLNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFpvT7ezNwy1d+7C7AlDbXeWfX67D+7PnjDU8bn17AlD7e/sz54w1snx7AVjbY5mLxjq4WrZ53fpdNnP37m9ZX++pT9//gEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASP0Hj/B+tAZX5MgAAAAASUVORK5CYII=" id="imagee61ae01d2e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb556431569" d="M 0 0 
+       <path id="maabe5dafe5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb556431569" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb556431569" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb556431569" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb556431569" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb556431569" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb556431569" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb556431569" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb556431569" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb556431569" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb556431569" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb556431569" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb556431569" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maabe5dafe5" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m4c4990e986" d="M 0 0 
+       <path id="ma68ceca081" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4c4990e986" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma68ceca081" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +7 -->
+    <!-- +9 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,24 +1156,101 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -3 -->
+    <!-- -1 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +5 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -32 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1207,21 +1284,109 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +11 -->
+    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -3 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- +3 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -36 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- -22 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +21 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -12 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -6 -->
+    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1255,162 +1420,15 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +7 -->
-    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -6 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -16 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -24 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +21 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -14 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -9 -->
-    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
    <g id="text_32">
-    <!-- -26 -->
+    <!-- -22 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1438,33 +1456,6 @@ z
    <g id="text_36">
     <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -1549,29 +1540,6 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -1703,6 +1671,18 @@ z
    <g id="text_57">
     <!-- -97 -->
     <g transform="translate(110.506785 180.060583) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -1831,6 +1811,27 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2191,18 +2192,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagefed9d55034" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image116e611409" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m7bfce8209a" d="M 0 0 
+       <path id="md56c1be321" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2226,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2240,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2254,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2267,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2280,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2293,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m7bfce8209a" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md56c1be321" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2909,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2998,16 +2999,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3046,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6d4ad60b38">
+  <clipPath id="paba5eeb14e">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m485336968b" d="M 0 0 
+       <path id="m561f75cbe2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m485336968b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m485336968b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m485336968b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m485336968b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m485336968b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m485336968b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m485336968b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m561f75cbe2" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mba5809fc79" d="M 0 0 
+       <path id="me3bd050a3a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba5809fc79" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3bd050a3a" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mba5809fc79" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3bd050a3a" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mba5809fc79" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3bd050a3a" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m5ef38610bb" d="M 0 0 
+       <path id="mb2db5da6bc" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m5ef38610bb" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2db5da6bc" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 147.040773) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 145.576429) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 353.189223) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.938723) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m4f18ada8fb" d="M -2.5 2.5 
+     <path id="m48c8f579c2" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#m4f18ada8fb" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4f18ada8fb" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m48c8f579c2" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48c8f579c2" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdd31c36b15" d="M 0 -2.5 
+     <path id="mea6873c17a" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#mdd31c36b15" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd31c36b15" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#mea6873c17a" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea6873c17a" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="maba898eaa9" d="M -0 3.535534 
+     <path id="m3e5e767953" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#maba898eaa9" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maba898eaa9" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m3e5e767953" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3e5e767953" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc801200b69" d="M -0 2.5 
+     <path id="m546d2021a7" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#mc801200b69" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m546d2021a7" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m77c26462ff" d="M -0.833333 2.5 
+     <path id="m62ae00e128" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#m77c26462ff" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77c26462ff" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m62ae00e128" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62ae00e128" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9970d9aa4a" d="M -1.25 2.5 
+     <path id="m2f0ae877d7" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#m9970d9aa4a" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9970d9aa4a" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m2f0ae877d7" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2f0ae877d7" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m894c37414b" d="M 0 -2.5 
+     <path id="mc901a649b9" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#m894c37414b" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m894c37414b" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#mc901a649b9" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc901a649b9" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0546d412f7" d="M 0 -2.5 
+     <path id="m98f798a040" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#m0546d412f7" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0546d412f7" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#m98f798a040" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m98f798a040" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mad4437745d" d="M 0 3.5 
+      <path id="ma6a3a4edff" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mad4437745d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma6a3a4edff" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4f18ada8fb" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m48c8f579c2" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdd31c36b15" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mea6873c17a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#maba898eaa9" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3e5e767953" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc801200b69" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m546d2021a7" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m77c26462ff" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m62ae00e128" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9970d9aa4a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2f0ae877d7" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m894c37414b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc901a649b9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0546d412f7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m98f798a040" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 152.040773 
-L 236.23654 156.753859 
-L 222.073314 161.151695 
-L 202.315941 171.812598 
-L 199.905291 173.745032 
-L 195.893147 177.438551 
-L 187.210062 190.887619 
-L 157.246106 245.840376 
-L 95.319203 358.189223 
-" clip-path="url(#p0ce7cf9a72)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p0ce7cf9a72)">
-     <use xlink:href="#mad4437745d" x="257.531237" y="152.040773" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="236.23654" y="156.753859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="222.073314" y="161.151695" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="202.315941" y="171.812598" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="199.905291" y="173.745032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="195.893147" y="177.438551" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="187.210062" y="190.887619" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="157.246106" y="245.840376" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mad4437745d" x="95.319203" y="358.189223" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 150.576429 
+L 236.23654 155.036866 
+L 222.073314 159.620701 
+L 202.315941 169.960738 
+L 199.905291 171.681238 
+L 195.893147 175.837091 
+L 187.210062 189.502689 
+L 157.246106 245.334601 
+L 95.319203 357.938723 
+" clip-path="url(#p34e41c843f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p34e41c843f)">
+     <use xlink:href="#ma6a3a4edff" x="257.531237" y="150.576429" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="236.23654" y="155.036866" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="222.073314" y="159.620701" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="202.315941" y="169.960738" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="199.905291" y="171.681238" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="195.893147" y="175.837091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="187.210062" y="189.502689" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="157.246106" y="245.334601" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma6a3a4edff" x="95.319203" y="357.938723" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2830,34 +2830,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2917,29 +2912,44 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -2980,16 +2990,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3028,109 +3038,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0ce7cf9a72">
+  <clipPath id="p34e41c843f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p850d2cfbae)">
+   <g clip-path="url(#p1ad6c79531)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image8fb4e58666" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imagef0f71ecd78" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m43bdcbb60d" d="M 0 0 
+       <path id="m8eb1f203a8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m43bdcbb60d" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m43bdcbb60d" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8eb1f203a8" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m86b7f5fe33" d="M 0 0 
+       <path id="m3e444a876f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m86b7f5fe33" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3e444a876f" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image7f61a5d5c2" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image6897e34816" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mb4c8c0d9ca" d="M 0 0 
+       <path id="m3a5f9100ef" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb4c8c0d9ca" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a5f9100ef" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb4c8c0d9ca" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a5f9100ef" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb4c8c0d9ca" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a5f9100ef" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb4c8c0d9ca" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a5f9100ef" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb4c8c0d9ca" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a5f9100ef" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,16 +2870,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p850d2cfbae">
+  <clipPath id="p1ad6c79531">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="386.202469pt" viewBox="0 0 570.260156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.872656 386.202469 
-L 570.872656 0 
+L 570.260156 386.202469 
+L 570.260156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.561328 104.1264 
-L 292.186328 104.1264 
-L 292.186328 74.7432 
-L 187.561328 74.7432 
+    <path d="M 187.255078 104.1264 
+L 291.880078 104.1264 
+L 291.880078 74.7432 
+L 187.255078 74.7432 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.186328 104.1264 
-L 396.811328 104.1264 
-L 396.811328 74.7432 
-L 292.186328 74.7432 
+    <path d="M 291.880078 104.1264 
+L 396.505078 104.1264 
+L 396.505078 74.7432 
+L 291.880078 74.7432 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.811328 104.1264 
-L 501.436328 104.1264 
-L 501.436328 74.7432 
-L 396.811328 74.7432 
+    <path d="M 396.505078 104.1264 
+L 501.130078 104.1264 
+L 501.130078 74.7432 
+L 396.505078 74.7432 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.561328 133.5096 
-L 292.186328 133.5096 
-L 292.186328 104.1264 
-L 187.561328 104.1264 
+    <path d="M 187.255078 133.5096 
+L 291.880078 133.5096 
+L 291.880078 104.1264 
+L 187.255078 104.1264 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.186328 133.5096 
-L 396.811328 133.5096 
-L 396.811328 104.1264 
-L 292.186328 104.1264 
+    <path d="M 291.880078 133.5096 
+L 396.505078 133.5096 
+L 396.505078 104.1264 
+L 291.880078 104.1264 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.811328 133.5096 
-L 501.436328 133.5096 
-L 501.436328 104.1264 
-L 396.811328 104.1264 
+    <path d="M 396.505078 133.5096 
+L 501.130078 133.5096 
+L 501.130078 104.1264 
+L 396.505078 104.1264 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.561328 162.8928 
-L 292.186328 162.8928 
-L 292.186328 133.5096 
-L 187.561328 133.5096 
+    <path d="M 187.255078 162.8928 
+L 291.880078 162.8928 
+L 291.880078 133.5096 
+L 187.255078 133.5096 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.186328 162.8928 
-L 396.811328 162.8928 
-L 396.811328 133.5096 
-L 292.186328 133.5096 
+    <path d="M 291.880078 162.8928 
+L 396.505078 162.8928 
+L 396.505078 133.5096 
+L 291.880078 133.5096 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.811328 162.8928 
-L 501.436328 162.8928 
-L 501.436328 133.5096 
-L 396.811328 133.5096 
+    <path d="M 396.505078 162.8928 
+L 501.130078 162.8928 
+L 501.130078 133.5096 
+L 396.505078 133.5096 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.561328 192.276 
-L 292.186328 192.276 
-L 292.186328 162.8928 
-L 187.561328 162.8928 
+    <path d="M 187.255078 192.276 
+L 291.880078 192.276 
+L 291.880078 162.8928 
+L 187.255078 162.8928 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.186328 192.276 
-L 396.811328 192.276 
-L 396.811328 162.8928 
-L 292.186328 162.8928 
+    <path d="M 291.880078 192.276 
+L 396.505078 192.276 
+L 396.505078 162.8928 
+L 291.880078 162.8928 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.811328 192.276 
-L 501.436328 192.276 
-L 501.436328 162.8928 
-L 396.811328 162.8928 
+    <path d="M 396.505078 192.276 
+L 501.130078 192.276 
+L 501.130078 162.8928 
+L 396.505078 162.8928 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.561328 221.6592 
-L 292.186328 221.6592 
-L 292.186328 192.276 
-L 187.561328 192.276 
+    <path d="M 187.255078 221.6592 
+L 291.880078 221.6592 
+L 291.880078 192.276 
+L 187.255078 192.276 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.186328 221.6592 
-L 396.811328 221.6592 
-L 396.811328 192.276 
-L 292.186328 192.276 
+    <path d="M 291.880078 221.6592 
+L 396.505078 221.6592 
+L 396.505078 192.276 
+L 291.880078 192.276 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.811328 221.6592 
-L 501.436328 221.6592 
-L 501.436328 192.276 
-L 396.811328 192.276 
+    <path d="M 396.505078 221.6592 
+L 501.130078 221.6592 
+L 501.130078 192.276 
+L 396.505078 192.276 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.561328 251.0424 
-L 292.186328 251.0424 
-L 292.186328 221.6592 
-L 187.561328 221.6592 
+    <path d="M 187.255078 251.0424 
+L 291.880078 251.0424 
+L 291.880078 221.6592 
+L 187.255078 221.6592 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.186328 251.0424 
-L 396.811328 251.0424 
-L 396.811328 221.6592 
-L 292.186328 221.6592 
+    <path d="M 291.880078 251.0424 
+L 396.505078 251.0424 
+L 396.505078 221.6592 
+L 291.880078 221.6592 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.811328 251.0424 
-L 501.436328 251.0424 
-L 501.436328 221.6592 
-L 396.811328 221.6592 
+    <path d="M 396.505078 251.0424 
+L 501.130078 251.0424 
+L 501.130078 221.6592 
+L 396.505078 221.6592 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.561328 280.4256 
-L 292.186328 280.4256 
-L 292.186328 251.0424 
-L 187.561328 251.0424 
+    <path d="M 187.255078 280.4256 
+L 291.880078 280.4256 
+L 291.880078 251.0424 
+L 187.255078 251.0424 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.186328 280.4256 
-L 396.811328 280.4256 
-L 396.811328 251.0424 
-L 292.186328 251.0424 
+    <path d="M 291.880078 280.4256 
+L 396.505078 280.4256 
+L 396.505078 251.0424 
+L 291.880078 251.0424 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.811328 280.4256 
-L 501.436328 280.4256 
-L 501.436328 251.0424 
-L 396.811328 251.0424 
+    <path d="M 396.505078 280.4256 
+L 501.130078 280.4256 
+L 501.130078 251.0424 
+L 396.505078 251.0424 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.561328 309.8088 
-L 292.186328 309.8088 
-L 292.186328 280.4256 
-L 187.561328 280.4256 
+    <path d="M 187.255078 309.8088 
+L 291.880078 309.8088 
+L 291.880078 280.4256 
+L 187.255078 280.4256 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.186328 309.8088 
-L 396.811328 309.8088 
-L 396.811328 280.4256 
-L 292.186328 280.4256 
+    <path d="M 291.880078 309.8088 
+L 396.505078 309.8088 
+L 396.505078 280.4256 
+L 291.880078 280.4256 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.811328 309.8088 
-L 501.436328 309.8088 
-L 501.436328 280.4256 
-L 396.811328 280.4256 
+    <path d="M 396.505078 309.8088 
+L 501.130078 309.8088 
+L 501.130078 280.4256 
+L 396.505078 280.4256 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.561328 339.192 
-L 292.186328 339.192 
-L 292.186328 309.8088 
-L 187.561328 309.8088 
+    <path d="M 187.255078 339.192 
+L 291.880078 339.192 
+L 291.880078 309.8088 
+L 187.255078 309.8088 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.186328 339.192 
-L 396.811328 339.192 
-L 396.811328 309.8088 
-L 292.186328 309.8088 
+    <path d="M 291.880078 339.192 
+L 396.505078 339.192 
+L 396.505078 309.8088 
+L 291.880078 309.8088 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.811328 339.192 
-L 501.436328 339.192 
-L 501.436328 309.8088 
-L 396.811328 309.8088 
+    <path d="M 396.505078 339.192 
+L 501.130078 339.192 
+L 501.130078 309.8088 
+L 396.505078 309.8088 
 z
-" clip-path="url(#pb05a882f76)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf3e06eeb1e)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.242344 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.526563 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.098672 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.450391 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.180078 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.557578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.818203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.817578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.511328 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.850078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.543828 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.387578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.081328 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.693828 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.387578 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.422578 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.408828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(441.488828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.195703 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.889453 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(227.221953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.915703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1853,36 +1853,42 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 34 -->
-    <g transform="translate(338.932578 267.9415) scale(0.08 -0.08)">
+    <!-- 35 -->
+    <g transform="translate(338.626328 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 177 -->
-    <g transform="translate(440.774453 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.468203 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1916,7 +1922,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.310703 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.004453 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1981,7 +1987,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.422578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1991,21 +1997,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.408828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(444.033828 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.727578 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.225703 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2016,7 +2022,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2026,13 +2032,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.647578 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.817578 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2048,7 +2054,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.038047 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.731797 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2192,7 +2198,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-23T14:19:32Z  ·  Linux chungus x86_64  ·  commit b59eed59  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-24T02:43:35Z  ·  Linux chungus x86_64  ·  commit 47de79ca  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2331,16 +2337,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2379,110 +2385,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
     <use xlink:href="#DejaVuSans-65" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3322.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3449.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3387.744141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb05a882f76">
-   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pf3e06eeb1e">
+   <rect x="82.630078" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-23T14:19:32Z",
+  "date": "2026-06-24T02:43:35Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "b59eed59",
+  "git_commit": "47de79ca",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,7 +14,7 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 39.96,
+   "compress_mbps": 41.02,
    "decompress_mbps": 109.29
   },
   {
@@ -24,7 +24,7 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 36.65,
+   "compress_mbps": 37.78,
    "decompress_mbps": 120.88
   },
   {
@@ -34,7 +34,7 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.01,
+   "compress_mbps": 34.9,
    "decompress_mbps": 131.49
   },
   {
@@ -44,7 +44,7 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 26.91,
+   "compress_mbps": 27.82,
    "decompress_mbps": 135.96
   },
   {
@@ -54,7 +54,7 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.07,
+   "compress_mbps": 27.06,
    "decompress_mbps": 142.94
   },
   {
@@ -64,7 +64,7 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.19,
+   "compress_mbps": 25.08,
    "decompress_mbps": 146.64
   },
   {
@@ -74,7 +74,7 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 19.69,
+   "compress_mbps": 20.38,
    "decompress_mbps": 148.87
   },
   {
@@ -84,7 +84,7 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.12,
+   "compress_mbps": 9.14,
    "decompress_mbps": 149.01
   },
   {
@@ -94,7 +94,7 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.24,
+   "compress_mbps": 1.23,
    "decompress_mbps": 148.01
   },
   {
@@ -104,7 +104,7 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.29,
+   "compress_mbps": 38.91,
    "decompress_mbps": 102.66
   },
   {
@@ -114,7 +114,7 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.26,
+   "compress_mbps": 35.8,
    "decompress_mbps": 110.16
   },
   {
@@ -124,7 +124,7 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.02,
+   "compress_mbps": 33.45,
    "decompress_mbps": 119.07
   },
   {
@@ -134,7 +134,7 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.05,
+   "compress_mbps": 25.89,
    "decompress_mbps": 124.46
   },
   {
@@ -144,7 +144,7 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.64,
+   "compress_mbps": 25.24,
    "decompress_mbps": 129.6
   },
   {
@@ -154,7 +154,7 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.12,
+   "compress_mbps": 23.98,
    "decompress_mbps": 133.96
   },
   {
@@ -164,7 +164,7 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.03,
+   "compress_mbps": 21.56,
    "decompress_mbps": 134.41
   },
   {
@@ -174,7 +174,7 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.87,
+   "compress_mbps": 8.92,
    "decompress_mbps": 134.69
   },
   {
@@ -184,7 +184,7 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.35,
+   "compress_mbps": 1.36,
    "decompress_mbps": 131.66
   },
   {
@@ -194,7 +194,7 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 32.74,
+   "compress_mbps": 33.46,
    "decompress_mbps": 123.24
   },
   {
@@ -204,7 +204,7 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.83,
+   "compress_mbps": 32.62,
    "decompress_mbps": 127.64
   },
   {
@@ -214,7 +214,7 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.01,
+   "compress_mbps": 31.47,
    "decompress_mbps": 130.3
   },
   {
@@ -224,7 +224,7 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 29.87,
+   "compress_mbps": 29.99,
    "decompress_mbps": 135.84
   },
   {
@@ -234,7 +234,7 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.27,
+   "compress_mbps": 29.63,
    "decompress_mbps": 141.35
   },
   {
@@ -244,7 +244,7 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.64,
+   "compress_mbps": 28.89,
    "decompress_mbps": 141.4
   },
   {
@@ -254,7 +254,7 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.15,
+   "compress_mbps": 25.47,
    "decompress_mbps": 143.93
   },
   {
@@ -264,7 +264,7 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.69,
+   "compress_mbps": 9.67,
    "decompress_mbps": 143.1
   },
   {
@@ -274,7 +274,7 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.61,
+   "compress_mbps": 1.59,
    "decompress_mbps": 143.67
   },
   {
@@ -284,7 +284,7 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.39,
+   "compress_mbps": 22.95,
    "decompress_mbps": 98.85
   },
   {
@@ -294,7 +294,7 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.95,
+   "compress_mbps": 22.38,
    "decompress_mbps": 101.29
   },
   {
@@ -304,7 +304,7 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 21.99,
+   "compress_mbps": 22.11,
    "decompress_mbps": 98.0
   },
   {
@@ -314,7 +314,7 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.51,
+   "compress_mbps": 21.4,
    "decompress_mbps": 107.38
   },
   {
@@ -324,7 +324,7 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.3,
+   "compress_mbps": 21.06,
    "decompress_mbps": 108.85
   },
   {
@@ -334,7 +334,7 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 20.92,
+   "compress_mbps": 20.86,
    "decompress_mbps": 109.97
   },
   {
@@ -344,7 +344,7 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.12,
+   "compress_mbps": 19.09,
    "decompress_mbps": 110.15
   },
   {
@@ -354,7 +354,7 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.12,
+   "compress_mbps": 6.97,
    "decompress_mbps": 110.32
   },
   {
@@ -364,7 +364,7 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.53,
+   "compress_mbps": 1.52,
    "decompress_mbps": 110.32
   },
   {
@@ -374,7 +374,7 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.89,
+   "compress_mbps": 11.48,
    "decompress_mbps": 55.72
   },
   {
@@ -384,7 +384,7 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.77,
+   "compress_mbps": 11.34,
    "decompress_mbps": 56.19
   },
   {
@@ -394,7 +394,7 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.66,
+   "compress_mbps": 11.33,
    "decompress_mbps": 56.43
   },
   {
@@ -404,7 +404,7 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.48,
+   "compress_mbps": 11.22,
    "decompress_mbps": 57.38
   },
   {
@@ -414,7 +414,7 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.5,
+   "compress_mbps": 10.74,
    "decompress_mbps": 57.8
   },
   {
@@ -424,7 +424,7 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.48,
+   "compress_mbps": 11.28,
    "decompress_mbps": 58.11
   },
   {
@@ -434,7 +434,7 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.22,
+   "compress_mbps": 11.03,
    "decompress_mbps": 57.91
   },
   {
@@ -444,7 +444,7 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.91,
+   "compress_mbps": 3.83,
    "decompress_mbps": 57.87
   },
   {
@@ -454,7 +454,7 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.24,
+   "compress_mbps": 1.23,
    "decompress_mbps": 58.47
   },
   {
@@ -464,7 +464,7 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 64.79,
+   "compress_mbps": 66.32,
    "decompress_mbps": 201.96
   },
   {
@@ -474,7 +474,7 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 60.86,
+   "compress_mbps": 60.39,
    "decompress_mbps": 217.53
   },
   {
@@ -484,7 +484,7 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 59.75,
+   "compress_mbps": 59.27,
    "decompress_mbps": 226.8
   },
   {
@@ -494,7 +494,7 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 56.43,
+   "compress_mbps": 56.96,
    "decompress_mbps": 234.14
   },
   {
@@ -504,7 +504,7 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 55.44,
+   "compress_mbps": 55.82,
    "decompress_mbps": 228.45
   },
   {
@@ -514,7 +514,7 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 52.05,
+   "compress_mbps": 52.28,
    "decompress_mbps": 235.41
   },
   {
@@ -524,7 +524,7 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 19.96,
+   "compress_mbps": 20.17,
    "decompress_mbps": 237.05
   },
   {
@@ -534,7 +534,7 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.26,
+   "compress_mbps": 7.23,
    "decompress_mbps": 241.61
   },
   {
@@ -544,7 +544,7 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 0.89,
+   "compress_mbps": 0.92,
    "decompress_mbps": 242.37
   },
   {
@@ -554,7 +554,7 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.25,
+   "compress_mbps": 45.54,
    "decompress_mbps": 117.03
   },
   {
@@ -564,7 +564,7 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.47,
+   "compress_mbps": 41.37,
    "decompress_mbps": 126.41
   },
   {
@@ -574,7 +574,7 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 37.22,
+   "compress_mbps": 37.88,
    "decompress_mbps": 138.94
   },
   {
@@ -584,7 +584,7 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 28.86,
+   "compress_mbps": 30.15,
    "decompress_mbps": 144.1
   },
   {
@@ -594,7 +594,7 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.69,
+   "compress_mbps": 29.25,
    "decompress_mbps": 151.64
   },
   {
@@ -604,7 +604,7 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.65,
+   "compress_mbps": 27.17,
    "decompress_mbps": 155.09
   },
   {
@@ -614,7 +614,7 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.15,
+   "compress_mbps": 22.54,
    "decompress_mbps": 155.64
   },
   {
@@ -624,7 +624,7 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.87,
+   "compress_mbps": 9.99,
    "decompress_mbps": 156.03
   },
   {
@@ -644,7 +644,7 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 38.71,
+   "compress_mbps": 39.35,
    "decompress_mbps": 97.42
   },
   {
@@ -654,7 +654,7 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 35.3,
+   "compress_mbps": 36.05,
    "decompress_mbps": 106.05
   },
   {
@@ -664,7 +664,7 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 32.43,
+   "compress_mbps": 32.66,
    "decompress_mbps": 116.08
   },
   {
@@ -674,7 +674,7 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.64,
+   "compress_mbps": 24.03,
    "decompress_mbps": 120.48
   },
   {
@@ -684,7 +684,7 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.76,
+   "compress_mbps": 23.09,
    "decompress_mbps": 127.28
   },
   {
@@ -694,7 +694,7 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 21.07,
+   "compress_mbps": 21.44,
    "decompress_mbps": 130.79
   },
   {
@@ -704,7 +704,7 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.15,
+   "compress_mbps": 18.48,
    "decompress_mbps": 131.27
   },
   {
@@ -734,7 +734,7 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 124.9,
+   "compress_mbps": 126.79,
    "decompress_mbps": 342.2
   },
   {
@@ -744,7 +744,7 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 109.37,
+   "compress_mbps": 112.24,
    "decompress_mbps": 358.45
   },
   {
@@ -754,7 +754,7 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 93.18,
+   "compress_mbps": 95.95,
    "decompress_mbps": 380.91
   },
   {
@@ -764,7 +764,7 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 73.76,
+   "compress_mbps": 77.26,
    "decompress_mbps": 351.29
   },
   {
@@ -774,7 +774,7 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 70.72,
+   "compress_mbps": 74.01,
    "decompress_mbps": 373.63
   },
   {
@@ -784,7 +784,7 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 63.11,
+   "compress_mbps": 66.28,
    "decompress_mbps": 405.54
   },
   {
@@ -794,7 +794,7 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 37.06,
+   "compress_mbps": 37.81,
    "decompress_mbps": 428.85
   },
   {
@@ -804,7 +804,7 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.73,
+   "compress_mbps": 16.85,
    "decompress_mbps": 457.54
   },
   {
@@ -814,7 +814,7 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.91,
+   "compress_mbps": 0.94,
    "decompress_mbps": 467.88
   },
   {
@@ -824,7 +824,7 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.66,
+   "compress_mbps": 26.63,
    "decompress_mbps": 112.48
   },
   {
@@ -834,7 +834,7 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.88,
+   "compress_mbps": 25.94,
    "decompress_mbps": 115.14
   },
   {
@@ -844,7 +844,7 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.39,
+   "compress_mbps": 25.13,
    "decompress_mbps": 116.46
   },
   {
@@ -854,7 +854,7 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 22.86,
+   "compress_mbps": 23.16,
    "decompress_mbps": 121.98
   },
   {
@@ -864,7 +864,7 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.57,
+   "compress_mbps": 23.03,
    "decompress_mbps": 129.07
   },
   {
@@ -874,7 +874,7 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.04,
+   "compress_mbps": 21.74,
    "decompress_mbps": 129.05
   },
   {
@@ -884,7 +884,7 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.28,
+   "compress_mbps": 17.59,
    "decompress_mbps": 132.23
   },
   {
@@ -894,7 +894,7 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.34,
+   "compress_mbps": 5.36,
    "decompress_mbps": 130.24
   },
   {
@@ -904,7 +904,7 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.16,
+   "compress_mbps": 1.19,
    "decompress_mbps": 135.45
   },
   {
@@ -914,7 +914,7 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 13.08,
+   "compress_mbps": 13.21,
    "decompress_mbps": 57.23
   },
   {
@@ -924,7 +924,7 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 13.1,
+   "compress_mbps": 13.26,
    "decompress_mbps": 57.78
   },
   {
@@ -934,7 +934,7 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.95,
+   "compress_mbps": 13.25,
    "decompress_mbps": 57.4
   },
   {
@@ -944,7 +944,7 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.82,
+   "compress_mbps": 13.0,
    "decompress_mbps": 59.11
   },
   {
@@ -954,7 +954,7 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.77,
+   "compress_mbps": 12.98,
    "decompress_mbps": 59.31
   },
   {
@@ -964,7 +964,7 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.6,
+   "compress_mbps": 13.0,
    "decompress_mbps": 59.5
   },
   {
@@ -974,7 +974,7 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.63,
+   "compress_mbps": 12.87,
    "decompress_mbps": 59.34
   },
   {
@@ -984,7 +984,7 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.15,
+   "compress_mbps": 4.26,
    "decompress_mbps": 59.51
   },
   {
@@ -994,7 +994,7 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 1.39,
+   "compress_mbps": 1.42,
    "decompress_mbps": 59.33
   },
   {
@@ -3974,7 +3974,7 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 40.41,
+   "compress_mbps": 41.51,
    "decompress_mbps": 101.16
   },
   {
@@ -3984,7 +3984,7 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 35.97,
+   "compress_mbps": 37.67,
    "decompress_mbps": 109.65
   },
   {
@@ -3994,7 +3994,7 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.38,
+   "compress_mbps": 34.33,
    "decompress_mbps": 120.2
   },
   {
@@ -4004,7 +4004,7 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.33,
+   "compress_mbps": 25.93,
    "decompress_mbps": 122.69
   },
   {
@@ -4014,7 +4014,7 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.99,
+   "compress_mbps": 25.33,
    "decompress_mbps": 131.55
   },
   {
@@ -4024,7 +4024,7 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 22.71,
+   "compress_mbps": 23.13,
    "decompress_mbps": 135.72
   },
   {
@@ -4034,7 +4034,7 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 19.15,
+   "compress_mbps": 19.67,
    "decompress_mbps": 135.0
   },
   {
@@ -4044,7 +4044,7 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.91,
+   "compress_mbps": 9.02,
    "decompress_mbps": 139.28
   },
   {
@@ -4064,7 +4064,7 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 53.3,
+   "compress_mbps": 53.87,
    "decompress_mbps": 132.62
   },
   {
@@ -4074,7 +4074,7 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 49.3,
+   "compress_mbps": 50.27,
    "decompress_mbps": 139.57
   },
   {
@@ -4084,7 +4084,7 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 46.17,
+   "compress_mbps": 47.19,
    "decompress_mbps": 142.51
   },
   {
@@ -4094,7 +4094,7 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.18,
+   "compress_mbps": 39.44,
    "decompress_mbps": 151.09
   },
   {
@@ -4104,7 +4104,7 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.74,
+   "compress_mbps": 37.66,
    "decompress_mbps": 160.64
   },
   {
@@ -4114,7 +4114,7 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.43,
+   "compress_mbps": 33.14,
    "decompress_mbps": 166.03
   },
   {
@@ -4124,7 +4124,7 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 21.61,
+   "compress_mbps": 22.02,
    "decompress_mbps": 161.46
   },
   {
@@ -4134,7 +4134,7 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.79,
+   "compress_mbps": 6.8,
    "decompress_mbps": 166.03
   },
   {
@@ -4144,7 +4144,7 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.14,
+   "compress_mbps": 1.15,
    "decompress_mbps": 165.2
   },
   {
@@ -4154,7 +4154,7 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 53.63,
+   "compress_mbps": 54.88,
    "decompress_mbps": 120.47
   },
   {
@@ -4164,7 +4164,7 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 48.79,
+   "compress_mbps": 49.94,
    "decompress_mbps": 126.11
   },
   {
@@ -4174,7 +4174,7 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 43.25,
+   "compress_mbps": 44.3,
    "decompress_mbps": 134.51
   },
   {
@@ -4184,7 +4184,7 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.22,
+   "compress_mbps": 31.87,
    "decompress_mbps": 130.11
   },
   {
@@ -4194,7 +4194,7 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.72,
+   "compress_mbps": 30.36,
    "decompress_mbps": 136.54
   },
   {
@@ -4204,7 +4204,7 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.25,
+   "compress_mbps": 27.62,
    "decompress_mbps": 141.79
   },
   {
@@ -4214,7 +4214,7 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 20.67,
+   "compress_mbps": 21.06,
    "decompress_mbps": 143.06
   },
   {
@@ -4224,7 +4224,7 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.1,
+   "compress_mbps": 8.24,
    "decompress_mbps": 150.57
   },
   {
@@ -4234,7 +4234,7 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 0.96,
+   "compress_mbps": 0.97,
    "decompress_mbps": 145.12
   },
   {
@@ -4244,7 +4244,7 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 130.22,
+   "compress_mbps": 135.71,
    "decompress_mbps": 350.47
   },
   {
@@ -4254,7 +4254,7 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 110.63,
+   "compress_mbps": 114.94,
    "decompress_mbps": 398.18
   },
   {
@@ -4264,7 +4264,7 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 91.37,
+   "compress_mbps": 99.1,
    "decompress_mbps": 445.44
   },
   {
@@ -4274,7 +4274,7 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 80.6,
+   "compress_mbps": 86.39,
    "decompress_mbps": 455.47
   },
   {
@@ -4284,7 +4284,7 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 78.48,
+   "compress_mbps": 83.81,
    "decompress_mbps": 528.19
   },
   {
@@ -4294,7 +4294,7 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 72.01,
+   "compress_mbps": 76.65,
    "decompress_mbps": 569.44
   },
   {
@@ -4304,7 +4304,7 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 41.61,
+   "compress_mbps": 43.28,
    "decompress_mbps": 576.01
   },
   {
@@ -4314,7 +4314,7 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.35,
+   "compress_mbps": 22.92,
    "decompress_mbps": 589.15
   },
   {
@@ -4324,7 +4324,7 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.75,
+   "compress_mbps": 0.76,
    "decompress_mbps": 552.7
   },
   {
@@ -4334,7 +4334,7 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 39.04,
+   "compress_mbps": 39.26,
    "decompress_mbps": 91.36
   },
   {
@@ -4344,7 +4344,7 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 37.53,
+   "compress_mbps": 37.71,
    "decompress_mbps": 93.76
   },
   {
@@ -4354,7 +4354,7 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 35.96,
+   "compress_mbps": 37.18,
    "decompress_mbps": 96.13
   },
   {
@@ -4364,7 +4364,7 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.95,
+   "compress_mbps": 31.0,
    "decompress_mbps": 104.54
   },
   {
@@ -4374,7 +4374,7 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 29.65,
+   "compress_mbps": 30.38,
    "decompress_mbps": 106.83
   },
   {
@@ -4384,7 +4384,7 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 28.14,
+   "compress_mbps": 29.07,
    "decompress_mbps": 110.68
   },
   {
@@ -4394,7 +4394,7 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 25.05,
+   "compress_mbps": 25.91,
    "decompress_mbps": 111.01
   },
   {
@@ -4404,7 +4404,7 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.77,
+   "compress_mbps": 6.88,
    "decompress_mbps": 113.15
   },
   {
@@ -4414,7 +4414,7 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.44,
+   "compress_mbps": 1.46,
    "decompress_mbps": 111.01
   },
   {
@@ -4424,7 +4424,7 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 54.66,
+   "compress_mbps": 56.7,
    "decompress_mbps": 151.18
   },
   {
@@ -4434,7 +4434,7 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 52.65,
+   "compress_mbps": 54.12,
    "decompress_mbps": 156.94
   },
   {
@@ -4444,7 +4444,7 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 50.47,
+   "compress_mbps": 52.17,
    "decompress_mbps": 159.11
   },
   {
@@ -4454,7 +4454,7 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 46.3,
+   "compress_mbps": 48.03,
    "decompress_mbps": 173.47
   },
   {
@@ -4464,7 +4464,7 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 44.9,
+   "compress_mbps": 47.87,
    "decompress_mbps": 178.76
   },
   {
@@ -4474,7 +4474,7 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 46.35,
+   "compress_mbps": 47.64,
    "decompress_mbps": 188.39
   },
   {
@@ -4484,7 +4484,7 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 43.09,
+   "compress_mbps": 44.76,
    "decompress_mbps": 191.45
   },
   {
@@ -4494,7 +4494,7 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.12,
+   "compress_mbps": 12.2,
    "decompress_mbps": 192.74
   },
   {
@@ -4504,7 +4504,7 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.74,
+   "compress_mbps": 1.76,
    "decompress_mbps": 195.31
   },
   {
@@ -4514,7 +4514,7 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 46.71,
+   "compress_mbps": 48.45,
    "decompress_mbps": 116.34
   },
   {
@@ -4524,7 +4524,7 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 40.29,
+   "compress_mbps": 43.49,
    "decompress_mbps": 138.48
   },
   {
@@ -4534,7 +4534,7 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 36.29,
+   "compress_mbps": 36.66,
    "decompress_mbps": 149.98
   },
   {
@@ -4544,7 +4544,7 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 25.86,
+   "compress_mbps": 26.84,
    "decompress_mbps": 153.07
   },
   {
@@ -4554,7 +4554,7 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 23.4,
+   "compress_mbps": 24.79,
    "decompress_mbps": 159.4
   },
   {
@@ -4564,7 +4564,7 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 19.24,
+   "compress_mbps": 20.44,
    "decompress_mbps": 160.97
   },
   {
@@ -4574,7 +4574,7 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 12.97,
+   "compress_mbps": 13.17,
    "decompress_mbps": 184.83
   },
   {
@@ -4584,7 +4584,7 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.62,
+   "compress_mbps": 7.66,
    "decompress_mbps": 190.4
   },
   {
@@ -4604,7 +4604,7 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 69.85,
+   "compress_mbps": 70.61,
    "decompress_mbps": 196.01
   },
   {
@@ -4614,7 +4614,7 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 62.59,
+   "compress_mbps": 64.54,
    "decompress_mbps": 207.87
   },
   {
@@ -4624,7 +4624,7 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 56.67,
+   "compress_mbps": 58.17,
    "decompress_mbps": 217.97
   },
   {
@@ -4634,7 +4634,7 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.99,
+   "compress_mbps": 48.78,
    "decompress_mbps": 227.98
   },
   {
@@ -4644,7 +4644,7 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.33,
+   "compress_mbps": 47.11,
    "decompress_mbps": 239.69
   },
   {
@@ -4654,7 +4654,7 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.97,
+   "compress_mbps": 43.95,
    "decompress_mbps": 244.9
   },
   {
@@ -4664,7 +4664,7 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 31.89,
+   "compress_mbps": 32.94,
    "decompress_mbps": 248.18
   },
   {
@@ -4674,7 +4674,7 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.59,
+   "compress_mbps": 12.87,
    "decompress_mbps": 234.53
   },
   {
@@ -4694,7 +4694,7 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.99,
+   "compress_mbps": 34.4,
    "decompress_mbps": 93.59
   },
   {
@@ -4704,7 +4704,7 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 32.06,
+   "compress_mbps": 32.5,
    "decompress_mbps": 94.92
   },
   {
@@ -4714,7 +4714,7 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 30.84,
+   "compress_mbps": 30.89,
    "decompress_mbps": 99.62
   },
   {
@@ -4724,7 +4724,7 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.96,
+   "compress_mbps": 26.09,
    "decompress_mbps": 102.03
   },
   {
@@ -4734,7 +4734,7 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.9,
+   "compress_mbps": 25.62,
    "decompress_mbps": 105.51
   },
   {
@@ -4744,7 +4744,7 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.77,
+   "compress_mbps": 24.82,
    "decompress_mbps": 106.98
   },
   {
@@ -4754,7 +4754,7 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 23.53,
+   "compress_mbps": 23.57,
    "decompress_mbps": 108.68
   },
   {
@@ -4774,7 +4774,7 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.57,
+   "compress_mbps": 1.58,
    "decompress_mbps": 107.87
   },
   {
@@ -4784,7 +4784,7 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 52.05,
+   "compress_mbps": 53.63,
    "decompress_mbps": 132.97
   },
   {
@@ -4794,7 +4794,7 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 47.2,
+   "compress_mbps": 49.21,
    "decompress_mbps": 146.69
   },
   {
@@ -4804,7 +4804,7 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 43.85,
+   "compress_mbps": 45.14,
    "decompress_mbps": 157.81
   },
   {
@@ -4814,7 +4814,7 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.51,
+   "compress_mbps": 37.08,
    "decompress_mbps": 165.21
   },
   {
@@ -4824,7 +4824,7 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.0,
+   "compress_mbps": 35.52,
    "decompress_mbps": 174.97
   },
   {
@@ -4834,7 +4834,7 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.38,
+   "compress_mbps": 32.18,
    "decompress_mbps": 179.78
   },
   {
@@ -4844,7 +4844,7 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.1,
+   "compress_mbps": 24.72,
    "decompress_mbps": 181.27
   },
   {
@@ -4854,7 +4854,7 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.4,
+   "compress_mbps": 11.39,
    "decompress_mbps": 181.15
   },
   {
@@ -4864,7 +4864,7 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.2,
+   "compress_mbps": 1.19,
    "decompress_mbps": 180.83
   },
   {
@@ -4874,7 +4874,7 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 34.04,
+   "compress_mbps": 34.87,
    "decompress_mbps": 76.72
   },
   {
@@ -4884,7 +4884,7 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 33.79,
+   "compress_mbps": 34.44,
    "decompress_mbps": 77.76
   },
   {
@@ -4894,7 +4894,7 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 33.85,
+   "compress_mbps": 34.9,
    "decompress_mbps": 79.21
   },
   {
@@ -4904,7 +4904,7 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 31.8,
+   "compress_mbps": 32.63,
    "decompress_mbps": 80.27
   },
   {
@@ -4914,7 +4914,7 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 31.73,
+   "compress_mbps": 32.63,
    "decompress_mbps": 82.06
   },
   {
@@ -4924,7 +4924,7 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 31.97,
+   "compress_mbps": 32.83,
    "decompress_mbps": 82.84
   },
   {
@@ -4934,7 +4934,7 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 32.12,
+   "compress_mbps": 32.82,
    "decompress_mbps": 82.69
   },
   {
@@ -4944,7 +4944,7 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.75,
+   "compress_mbps": 4.73,
    "decompress_mbps": 83.53
   },
   {
@@ -4964,7 +4964,7 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 104.28,
+   "compress_mbps": 108.25,
    "decompress_mbps": 270.26
   },
   {
@@ -4974,7 +4974,7 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 92.05,
+   "compress_mbps": 95.78,
    "decompress_mbps": 295.6
   },
   {
@@ -4984,7 +4984,7 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 81.36,
+   "compress_mbps": 83.04,
    "decompress_mbps": 332.81
   },
   {
@@ -4994,7 +4994,7 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 66.24,
+   "compress_mbps": 69.29,
    "decompress_mbps": 333.05
   },
   {
@@ -5004,7 +5004,7 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 63.86,
+   "compress_mbps": 66.97,
    "decompress_mbps": 375.41
   },
   {
@@ -5014,7 +5014,7 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 59.06,
+   "compress_mbps": 61.62,
    "decompress_mbps": 403.54
   },
   {
@@ -5024,7 +5024,7 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 40.05,
+   "compress_mbps": 41.49,
    "decompress_mbps": 410.98
   },
   {
@@ -5034,7 +5034,7 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.32,
+   "compress_mbps": 20.55,
    "decompress_mbps": 414.35
   },
   {

--- a/c/bytearray_wide_ffi.c
+++ b/c/bytearray_wide_ffi.c
@@ -1,0 +1,53 @@
+/*
+ * Word-sized little-endian ByteArray loads for the DEFLATE hot loops.
+ *
+ * `lean_zip_uget_u32le(a, off)` and `lean_zip_uget_u64le(a, off)` read a
+ * 4-/8-byte little-endian word starting at byte `off` of `a`, returning an
+ * unboxed scalar. Their Lean reference bodies are the byte-recombination
+ * expressions
+ *
+ *     a[off] | a[off+1]<<8 | a[off+2]<<16 | a[off+3]<<24                (u32)
+ *     a[off] | a[off+1]<<8 | ... | a[off+7]<<56                        (u64)
+ *
+ * (see `ugetUInt32LE` / `ugetUInt64LE` in `Zip/Native/Wide.lean`), and this C
+ * must agree with those bodies. The recombination is written out byte-by-byte
+ * so it is host-endian-independent — little-endian *by construction* — and free
+ * of unaligned-access UB; on a little-endian target the optimizer folds each to
+ * a single (possibly unaligned) load.
+ *
+ * The Lean side carries the in-bounds proof (`off + W/8 ≤ a.size`), so C does
+ * no bounds check: the caller has already proven the `W/8` bytes at `off` are
+ * within the array. `a` is borrowed (`b_lean_obj_arg`); the offset is a
+ * `size_t` (Lean `USize`), kept unboxed so a hot loop's index arithmetic never
+ * boxes.
+ *
+ * This is a project-local stopgap mirroring the readers of lean#14053 (`wide
+ * fixed-width load/store`); the symbols are namespaced `lean_zip_*` so they do
+ * not clash with core after the toolchain bump. When lean#14053 lands this file
+ * and its lakefile target are deleted and core's `uget*` primitives are used
+ * (the reference bodies are identical, so callers and proofs are unchanged).
+ */
+
+#include <lean/lean.h>
+#include <stdint.h>
+
+/*
+ * lean_zip_uget_u32le : ByteArray → USize → UInt32
+ *   (a borrowed, off an unboxed size_t; returns an unboxed uint32_t)
+ */
+LEAN_EXPORT uint32_t lean_zip_uget_u32le(b_lean_obj_arg a, size_t off) {
+    const uint8_t *p = lean_sarray_cptr(a) + off;
+    return (uint32_t)p[0]         | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+/*
+ * lean_zip_uget_u64le : ByteArray → USize → UInt64
+ *   (a borrowed, off an unboxed size_t; returns an unboxed uint64_t)
+ */
+LEAN_EXPORT uint64_t lean_zip_uget_u64le(b_lean_obj_arg a, size_t off) {
+    const uint8_t *p = lean_sarray_cptr(a) + off;
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (8 * i);
+    return v;
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -214,6 +214,24 @@ extern_lib libcopy_within_ffi pkg := do
   let name := nameToStaticLib "copy_within_ffi"
   buildStaticLib (pkg.staticLibDir / name) #[ffiO]
 
+-- Word-sized little-endian ByteArray readers (project-local stopgap for
+-- lean#14053); no external library, always compiled.
+input_file bytearray_wide_ffi.c where
+  path := "c" / "bytearray_wide_ffi.c"
+  text := true
+
+target bytearray_wide_ffi.o pkg : FilePath := do
+  let srcJob ← bytearray_wide_ffi.c.fetch
+  let oFile := pkg.buildDir / "c" / "bytearray_wide_ffi.o"
+  let weakArgs := #["-I", (← getLeanIncludeDir).toString]
+  let hardArgs := if Platform.isWindows then #[] else #["-fPIC"]
+  buildO oFile srcJob weakArgs hardArgs "cc"
+
+extern_lib libbytearray_wide_ffi pkg := do
+  let ffiO ← bytearray_wide_ffi.o.fetch
+  let name := nameToStaticLib "bytearray_wide_ffi"
+  buildStaticLib (pkg.staticLibDir / name) #[ffiO]
+
 -- miniz_oxide FFI (Track D comparator)
 input_file miniz_oxide_ffi.c where
   path := "c" / "miniz_oxide_ffi.c"


### PR DESCRIPTION
This PR adds project-local `@[extern]` word-sized little-endian ByteArray readers — `ByteArray.ugetUInt32LE` / `ugetUInt64LE` (`Zip/Native/Wide.lean` + `c/bytearray_wide_ffi.c`, always compiled like `copyWithin`) — mirroring the readers of [lean4#14053](https://github.com/leanprover/lean4/pull/14053) (`wide fixed-width load/store`): a USize-indexed byte-recombination whose Lean model is the inline byte assembly the hot loops use today, so swapping it in is definitional modulo the offset's Nat/USize round-trip and `@[extern]` only changes the compiled implementation to one wide load. It wires `ugetUInt32LE` into the three `lz77*.hash3` matcher variants (the four-byte hash word), keeping the byte-recombination as the near-EOF / non-USize-addressable fallback, and adds a conformance test that sweeps every in-bounds offset over several byte patterns, comparing the `@[extern]` result against a pure-Lean recombination (validating the C against the model).

Because the three `hash3` bodies stay textually identical the `hash3_eq` bridge is still `rfl`, and the body still ends in `_ % hashSize` so the `< hashSize` bound is unchanged; the whole Spec suite holds and matcher output stays byte-identical. This supersedes the "blocked on lean4#14053" framing of [#2629](https://github.com/kim-em/lean-zip/issues/2629) by proving the reader value in-repo now.

In-situ controlled interleaved measurement (paired AFTER/BEFORE, one core, Canterbury, median-of-5 per run) shows the hash3 wide load is a small but real compress speedup: about +1% geomean overall, +1.3–1.6% on L1–L6 where hashing is hottest, flat at L7–L9 (match-finding dominated). The 95% CI excludes 1.0, so it clears machine noise. Full before/after overlay graphs to follow as a comment.

Scope is the readers plus the hash3 site only. The `refill` wide load ([#2630](https://github.com/kim-em/lean-zip/issues/2630)) is deliberately deferred: the production decoder's per-byte refill is woven into the `goFusedPU`/`goTreeFree` decode-equivalence chain under the `BufCorr` invariant, and a general-`cnt` wide load loads a variable number of bytes `k` (a literal 8-byte load gives `cnt+64 > 64`, breaking `BufCorr`), so landing it with proofs intact needs a masked variable-width equivalence lemma threaded through that chain — a real proof refactor, exactly the dilution pitfall #2630 flags. The BitWriter wide-store ([#2631](https://github.com/kim-em/lean-zip/issues/2631)) stays deferred. If the readers prove their worth this is direct evidence for upstreaming lean4#14053, or for moving the accessors into lean-zip-common.

Closes the reader half of #2629.

🤖 Prepared with Claude Code