### PR TITLE
perf(explore): direct-index scanBounds — skip length codes that cannot qualify

### DIFF
--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -356,27 +356,44 @@ private theorem seedTailCosts_size (cost : Array Nat) (r perByte j : Nat) :
 termination_by 259 - j
 decreasing_by omega
 
+/-- `lengthBoundaryStart[v]` is the smallest length-code slot `s` with
+    `lengthBase[s] > v` (equivalently, the count of length bases `≤ v`),
+    `29` if none. `Inflate.lengthBase` is sorted ascending, so this is the
+    first slot a covered interval `(v, len)` can include — `scanBounds`
+    starts its scan here instead of from slot 0, skipping the boundaries that
+    cannot qualify. Indexed by the previous candidate length, `0..258`. -/
+def lengthBoundaryStart : Array Nat :=
+  Array.ofFn (n := 259) fun v =>
+    (Inflate.lengthBase.filter fun b => decide (b.toNat ≤ v.val)).size
+
 /-- Evaluate one candidate at the length-code lower boundaries inside
     `(prevLen, len)` (its covered interval, exclusive of `len` which the
     caller already evaluated): truncating a match to a boundary can buy a
     cheaper length code or a better continuation. `(bestC, bestL, bestD)`
-    is the running arg-min. -/
-def scanBounds (lenCost distCost cost : Array Nat) (i dist prevLen len s : Nat)
+    is the running arg-min.
+
+    The caller starts `s` at `lengthBoundaryStart[prevLen]`, the first slot
+    with `lengthBase[s] > prevLen`, so the lower bound `prevLen < b` already
+    holds for every slot scanned (`lengthBase` ascending). Only the upper
+    bound `b < len` is tested, and once it fails the scan stops — all later
+    slots have an even larger base. Same boundaries, same order, same
+    arg-min as a full `0..28` scan with the `prevLen < b ∧ b < len`
+    predicate, just without the iterations that cannot qualify. -/
+def scanBounds (lenCost distCost cost : Array Nat) (i dist len s : Nat)
     (bestC bestL bestD : Nat) : Nat × Nat × Nat :=
   if h : s < Inflate.lengthBase.size then
     let b := Inflate.lengthBase[s].toNat
-    if prevLen < b ∧ b < len then
+    if b < len then
       -- These three reads stay panic-checked: the indices (`b` a length-base
       -- value, `dist` a cached distance, `i + b` a cost-array offset) are
       -- heuristic cache/table values whose bounds would require cache-content
       -- invariants the design deliberately keeps out of the proof boundary.
       let c := lenCost[b]! + distCost[dist]! + cost[i + b]!
       if c < bestC then
-        scanBounds lenCost distCost cost i dist prevLen len (s + 1) c b dist
+        scanBounds lenCost distCost cost i dist len (s + 1) c b dist
       else
-        scanBounds lenCost distCost cost i dist prevLen len (s + 1) bestC bestL bestD
-    else
-      scanBounds lenCost distCost cost i dist prevLen len (s + 1) bestC bestL bestD
+        scanBounds lenCost distCost cost i dist len (s + 1) bestC bestL bestD
+    else (bestC, bestL, bestD)
   else (bestC, bestL, bestD)
 termination_by Inflate.lengthBase.size - s
 decreasing_by all_goals omega
@@ -402,8 +419,13 @@ def scanCands (cacheLens cacheDists lenCost distCost cost : Array Nat)
       let cFull := lenCost[len]! + distCost[dist]! + cost[i + len]!
       let (bestC, bestL, bestD) :=
         if cFull < bestC then (cFull, len, dist) else (bestC, bestL, bestD)
+      -- `lengthBoundaryStart[prevLen]!` stays panic-checked like the cache
+      -- reads above: `prevLen` is `0` or a prior cached `len`, both `≤ 258`
+      -- (matches are capped at the DEFLATE maximum), so it indexes the
+      -- 259-entry table in range — the same bound `lenCost[len]!` already
+      -- assumes for the current `len`.
       let (bestC, bestL, bestD) :=
-        scanBounds lenCost distCost cost i dist prevLen len 0 bestC bestL bestD
+        scanBounds lenCost distCost cost i dist len (lengthBoundaryStart[prevLen]!) bestC bestL bestD
       scanCands cacheLens cacheDists lenCost distCost cost slotBase i slots
         (k + 1) len bestC bestL bestD
   else (bestC, bestL, bestD)

--- a/ZipTest/OptimalParse.lean
+++ b/ZipTest/OptimalParse.lean
@@ -116,6 +116,20 @@ def tests : IO Unit := do
   assert! distCost[5]! == 6        -- code 4 (5 bits) + 1 extra
   assert! distCost[32768]! == 18   -- code 29 (5 bits) + 13 extra
 
+  -- Direct-index boundary table (#2641): `scanBounds` starts its length-code
+  -- scan at `lengthBoundaryStart[prevLen]` and drops the `prevLen < b` test,
+  -- which is byte-identical only because `lengthBase` is sorted ascending.
+  -- Pin both invariants so a future reordering of `lengthBase` cannot
+  -- silently break the parse: `lengthBase` strictly ascending, and each table
+  -- entry equal to an independent "first slot whose base exceeds v" scan.
+  let lb := Zip.Native.Inflate.lengthBase
+  for s in [1:lb.size] do
+    assert! lb[s - 1]! < lb[s]!
+  assert! lengthBoundaryStart.size == 259
+  for v in [0:259] do
+    let firstGt := (lb.findIdx? (fun b => decide (v < b.toNat))).getD lb.size
+    assert! lengthBoundaryStart[v]! == firstGt
+
   -- Fitted tables: an unseen symbol costs the zero-frequency fallback, a
   -- frequent one costs its real (short) code, never 0 anywhere.
   let toks := #[LZ77Token.literal 97, .literal 97, .literal 97, .literal 98]

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe373deb7c6)">
+   <g clip-path="url(#p52ac0cfe24)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3YQYrkZx2H8eqemiEMzaBCYhxERIhuss/CM7jxIJ4gt8gJhEBWbkNIlu48QqIhCBlDbGfM0JmpdNfU3537wPPyS4rP5wTfouBXT70Xp28+2Hb8uBxuphesc3g+vWCJ7e52esIyF4/emJ6wxv3Xphesc3k5vWCNu8P0gnUuzvM72549mZ6wzHl+YwAAgwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBs/8XuenrDEnenw/SEZX7xk99MT1jmantzesISF98+nZ6wzF9ffjo9YYlfPnhjesIyx9Pt9IQlbl6d792/PR2nJyzxzqNfTU9YxgsWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxC6ef/eXbXrECi+PN9MTlnn99HB6wjrH2+kFa9xcTy9Y5+e/nV6wxM32YnrCMud6H1/frqYnLPNk93R6whKPr/87PWEZL1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2189u57esMTV/sH0hHUOX00vWGa7+WZ6whqn0/SCZS4efj09YYlzviFX+0fTE9Z48Nr0gmUev7ydnrDE9uJf0xOW8YIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbb9dfTW/g+zqdphfA/21ffj49YY1L/z9/dNxGfkBcEACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjt//Tvf05vWOLZ4dX0hGX+9uT59IRlPvzj76cnLPHmw19PT1jm7T+/Pz1hiT+89bPpCcv849lhegLf00cf/316whIv3nt3esIyXrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdnE8fbJNj1jh1ek4PWGZy4vz7eJ7hxfTE9a4t59esM63T6cXLHH66ePpCcts22l6whL3zvjN4G47z9+0+8fz/Fy7nRcsAICcwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO0vz7WxLvfTC5a5/Prz6QnLbM//Mz1hjeNxesEyp9+9Mz1hiXvneht3u92r3Wl6whp3h+kFy9z/7mZ6whLbl59NT1jmfC8IAMAQgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEPsfbqmMAEjiodAAAAAASUVORK5CYII=" id="image6413a14ba7" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image042e0e9f3c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m20e8d7e6ad" d="M 0 0 
+       <path id="m2242ed6f90" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m20e8d7e6ad" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242ed6f90" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mcb39d70714" d="M 0 0 
+       <path id="m701f343775" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mcb39d70714" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m701f343775" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,14 +1303,48 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -2 -->
+    <!-- -3 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +5 -->
+    <!-- +4 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1328,9 +1362,28 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1383,8 +1436,36 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- -86 -->
+    <!-- -87 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -94 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +6 -->
+    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1417,71 +1498,22 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -94 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +7 -->
-    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +2 -->
+    <!-- +0 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +9 -->
+    <!-- +7 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1495,40 +1527,6 @@ z
    <g id="text_29">
     <!-- -36 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -2180,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagebd38deb1dc" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageaa5f87d647" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m6d4550768b" d="M 0 0 
+       <path id="mba761233e2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6d4550768b" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba761233e2" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.069922 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,12 +3011,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3058,109 +3056,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe373deb7c6">
+  <clipPath id="p52ac0cfe24">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me1324b5b1f" d="M 0 0 
+       <path id="m028c07a5d8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me1324b5b1f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me1324b5b1f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me1324b5b1f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me1324b5b1f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me1324b5b1f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me1324b5b1f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me1324b5b1f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m028c07a5d8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc9227f0b8d" d="M 0 0 
+       <path id="mdd29712582" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc9227f0b8d" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd29712582" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc9227f0b8d" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd29712582" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc9227f0b8d" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd29712582" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0258c2d3bd" d="M 0 0 
+       <path id="m0adb36bd3e" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0258c2d3bd" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0adb36bd3e" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 174.958571) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 175.671124) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 320.07273) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 313.82831) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5b749f5f83" d="M -2.5 2.5 
+     <path id="m63cc0edae1" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m5b749f5f83" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b749f5f83" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m63cc0edae1" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m63cc0edae1" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6559bca0bd" d="M 0 -2.5 
+     <path id="mb1e1c390ab" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m6559bca0bd" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6559bca0bd" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#mb1e1c390ab" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb1e1c390ab" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m943bf3ae02" d="M -0 3.535534 
+     <path id="ma56d26ecf0" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m943bf3ae02" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m943bf3ae02" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#ma56d26ecf0" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma56d26ecf0" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m57b24d7e42" d="M -0 2.5 
+     <path id="m9e2024cbe2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m57b24d7e42" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m9e2024cbe2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9551a98024" d="M -0.833333 2.5 
+     <path id="m194df667a0" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m9551a98024" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9551a98024" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m194df667a0" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m194df667a0" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m552b90ab43" d="M -1.25 2.5 
+     <path id="m0a2eda9a0c" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m552b90ab43" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m552b90ab43" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m0a2eda9a0c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a2eda9a0c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2ac8691bf2" d="M 0 -2.5 
+     <path id="m6e7b3d869c" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m2ac8691bf2" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2ac8691bf2" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6e7b3d869c" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5bf26fee29" d="M 0 -2.5 
+     <path id="me64a5284fe" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#m5bf26fee29" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bf26fee29" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#me64a5284fe" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me64a5284fe" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="ma3b8599f72" d="M 0 3.5 
+      <path id="m357f16c205" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma3b8599f72" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m357f16c205" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5b749f5f83" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m63cc0edae1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6559bca0bd" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb1e1c390ab" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m943bf3ae02" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma56d26ecf0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m57b24d7e42" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9e2024cbe2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9551a98024" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m194df667a0" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m552b90ab43" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0a2eda9a0c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2ac8691bf2" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m6e7b3d869c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5bf26fee29" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me64a5284fe" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 179.958571 
-L 214.084819 182.670049 
-L 206.266533 185.127052 
-L 187.75787 192.116847 
-L 186.58897 193.172104 
-L 184.505355 195.481632 
-L 164.72409 206.807742 
-L 150.950891 251.725081 
-L 98.348822 325.07273 
-" clip-path="url(#p35f8b32509)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p35f8b32509)">
-     <use xlink:href="#ma3b8599f72" x="226.647908" y="179.958571" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="214.084819" y="182.670049" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="206.266533" y="185.127052" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="187.75787" y="192.116847" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="186.58897" y="193.172104" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="184.505355" y="195.481632" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="164.72409" y="206.807742" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="150.950891" y="251.725081" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma3b8599f72" x="98.348822" y="325.07273" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 180.671124 
+L 214.084819 183.545645 
+L 206.266533 185.976577 
+L 187.75787 192.485037 
+L 186.58897 193.499057 
+L 184.505355 195.842174 
+L 164.72409 207.184059 
+L 150.950891 251.782768 
+L 98.348822 318.82831 
+" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pd383cd252b)">
+     <use xlink:href="#m357f16c205" x="226.647908" y="180.671124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="214.084819" y="183.545645" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="206.266533" y="185.976577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="187.75787" y="192.485037" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="186.58897" y="193.499057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="184.505355" y="195.842174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="164.72409" y="207.184059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="150.950891" y="251.782768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m357f16c205" x="98.348822" y="318.82831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,6 +2903,16 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2975,36 +2985,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -3028,16 +3008,6 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -3081,12 +3051,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3126,109 +3096,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p35f8b32509">
+  <clipPath id="pd383cd252b">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf8c43f7976)">
+   <g clip-path="url(#p346f9e4456)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagefeb9808ebb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagee78e607fec" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m57f0a7041d" d="M 0 0 
+       <path id="me9209b34ad" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m57f0a7041d" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m57f0a7041d" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m57f0a7041d" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m57f0a7041d" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m57f0a7041d" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m57f0a7041d" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m57f0a7041d" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m57f0a7041d" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m57f0a7041d" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m57f0a7041d" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m57f0a7041d" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me9209b34ad" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m92b64f61fe" d="M 0 0 
+       <path id="mbb3720818b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m92b64f61fe" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb3720818b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imageae1efd574a" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagef52552f2f6" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="me3b04a5372" d="M 0 0 
+       <path id="ma9a7d59937" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me3b04a5372" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma9a7d59937" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.069922 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2954,12 +2954,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf8c43f7976">
+  <clipPath id="p346f9e4456">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="386.202469pt" viewBox="0 0 570.260156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.260156 386.202469 
-L 570.260156 0 
+L 570.708594 386.202469 
+L 570.708594 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.255078 104.1264 
-L 291.880078 104.1264 
-L 291.880078 74.7432 
-L 187.255078 74.7432 
+    <path d="M 187.479297 104.1264 
+L 292.104297 104.1264 
+L 292.104297 74.7432 
+L 187.479297 74.7432 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.880078 104.1264 
-L 396.505078 104.1264 
-L 396.505078 74.7432 
-L 291.880078 74.7432 
+    <path d="M 292.104297 104.1264 
+L 396.729297 104.1264 
+L 396.729297 74.7432 
+L 292.104297 74.7432 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.505078 104.1264 
-L 501.130078 104.1264 
-L 501.130078 74.7432 
-L 396.505078 74.7432 
+    <path d="M 396.729297 104.1264 
+L 501.354297 104.1264 
+L 501.354297 74.7432 
+L 396.729297 74.7432 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.255078 133.5096 
-L 291.880078 133.5096 
-L 291.880078 104.1264 
-L 187.255078 104.1264 
+    <path d="M 187.479297 133.5096 
+L 292.104297 133.5096 
+L 292.104297 104.1264 
+L 187.479297 104.1264 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.880078 133.5096 
-L 396.505078 133.5096 
-L 396.505078 104.1264 
-L 291.880078 104.1264 
+    <path d="M 292.104297 133.5096 
+L 396.729297 133.5096 
+L 396.729297 104.1264 
+L 292.104297 104.1264 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.505078 133.5096 
-L 501.130078 133.5096 
-L 501.130078 104.1264 
-L 396.505078 104.1264 
+    <path d="M 396.729297 133.5096 
+L 501.354297 133.5096 
+L 501.354297 104.1264 
+L 396.729297 104.1264 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.255078 162.8928 
-L 291.880078 162.8928 
-L 291.880078 133.5096 
-L 187.255078 133.5096 
+    <path d="M 187.479297 162.8928 
+L 292.104297 162.8928 
+L 292.104297 133.5096 
+L 187.479297 133.5096 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.880078 162.8928 
-L 396.505078 162.8928 
-L 396.505078 133.5096 
-L 291.880078 133.5096 
+    <path d="M 292.104297 162.8928 
+L 396.729297 162.8928 
+L 396.729297 133.5096 
+L 292.104297 133.5096 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.505078 162.8928 
-L 501.130078 162.8928 
-L 501.130078 133.5096 
-L 396.505078 133.5096 
+    <path d="M 396.729297 162.8928 
+L 501.354297 162.8928 
+L 501.354297 133.5096 
+L 396.729297 133.5096 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.255078 192.276 
-L 291.880078 192.276 
-L 291.880078 162.8928 
-L 187.255078 162.8928 
+    <path d="M 187.479297 192.276 
+L 292.104297 192.276 
+L 292.104297 162.8928 
+L 187.479297 162.8928 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.880078 192.276 
-L 396.505078 192.276 
-L 396.505078 162.8928 
-L 291.880078 162.8928 
+    <path d="M 292.104297 192.276 
+L 396.729297 192.276 
+L 396.729297 162.8928 
+L 292.104297 162.8928 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.505078 192.276 
-L 501.130078 192.276 
-L 501.130078 162.8928 
-L 396.505078 162.8928 
+    <path d="M 396.729297 192.276 
+L 501.354297 192.276 
+L 501.354297 162.8928 
+L 396.729297 162.8928 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.255078 221.6592 
-L 291.880078 221.6592 
-L 291.880078 192.276 
-L 187.255078 192.276 
+    <path d="M 187.479297 221.6592 
+L 292.104297 221.6592 
+L 292.104297 192.276 
+L 187.479297 192.276 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.880078 221.6592 
-L 396.505078 221.6592 
-L 396.505078 192.276 
-L 291.880078 192.276 
+    <path d="M 292.104297 221.6592 
+L 396.729297 221.6592 
+L 396.729297 192.276 
+L 292.104297 192.276 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.505078 221.6592 
-L 501.130078 221.6592 
-L 501.130078 192.276 
-L 396.505078 192.276 
+    <path d="M 396.729297 221.6592 
+L 501.354297 221.6592 
+L 501.354297 192.276 
+L 396.729297 192.276 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.255078 251.0424 
-L 291.880078 251.0424 
-L 291.880078 221.6592 
-L 187.255078 221.6592 
+    <path d="M 187.479297 251.0424 
+L 292.104297 251.0424 
+L 292.104297 221.6592 
+L 187.479297 221.6592 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.880078 251.0424 
-L 396.505078 251.0424 
-L 396.505078 221.6592 
-L 291.880078 221.6592 
+    <path d="M 292.104297 251.0424 
+L 396.729297 251.0424 
+L 396.729297 221.6592 
+L 292.104297 221.6592 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.505078 251.0424 
-L 501.130078 251.0424 
-L 501.130078 221.6592 
-L 396.505078 221.6592 
+    <path d="M 396.729297 251.0424 
+L 501.354297 251.0424 
+L 501.354297 221.6592 
+L 396.729297 221.6592 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.255078 280.4256 
-L 291.880078 280.4256 
-L 291.880078 251.0424 
-L 187.255078 251.0424 
+    <path d="M 187.479297 280.4256 
+L 292.104297 280.4256 
+L 292.104297 251.0424 
+L 187.479297 251.0424 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.880078 280.4256 
-L 396.505078 280.4256 
-L 396.505078 251.0424 
-L 291.880078 251.0424 
+    <path d="M 292.104297 280.4256 
+L 396.729297 280.4256 
+L 396.729297 251.0424 
+L 292.104297 251.0424 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.505078 280.4256 
-L 501.130078 280.4256 
-L 501.130078 251.0424 
-L 396.505078 251.0424 
+    <path d="M 396.729297 280.4256 
+L 501.354297 280.4256 
+L 501.354297 251.0424 
+L 396.729297 251.0424 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.255078 309.8088 
-L 291.880078 309.8088 
-L 291.880078 280.4256 
-L 187.255078 280.4256 
+    <path d="M 187.479297 309.8088 
+L 292.104297 309.8088 
+L 292.104297 280.4256 
+L 187.479297 280.4256 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.880078 309.8088 
-L 396.505078 309.8088 
-L 396.505078 280.4256 
-L 291.880078 280.4256 
+    <path d="M 292.104297 309.8088 
+L 396.729297 309.8088 
+L 396.729297 280.4256 
+L 292.104297 280.4256 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.505078 309.8088 
-L 501.130078 309.8088 
-L 501.130078 280.4256 
-L 396.505078 280.4256 
+    <path d="M 396.729297 309.8088 
+L 501.354297 309.8088 
+L 501.354297 280.4256 
+L 396.729297 280.4256 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.255078 339.192 
-L 291.880078 339.192 
-L 291.880078 309.8088 
-L 187.255078 309.8088 
+    <path d="M 187.479297 339.192 
+L 292.104297 339.192 
+L 292.104297 309.8088 
+L 187.479297 309.8088 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.880078 339.192 
-L 396.505078 339.192 
-L 396.505078 309.8088 
-L 291.880078 309.8088 
+    <path d="M 292.104297 339.192 
+L 396.729297 339.192 
+L 396.729297 309.8088 
+L 292.104297 309.8088 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.505078 339.192 
-L 501.130078 339.192 
-L 501.130078 309.8088 
-L 396.505078 309.8088 
+    <path d="M 396.729297 339.192 
+L 501.354297 339.192 
+L 501.354297 309.8088 
+L 396.729297 309.8088 
 z
-" clip-path="url(#pe41e5cb8b7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf20f32977c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.242344 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.526563 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.098672 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.450391 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.180078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.116328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.557578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.182578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.818203 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.102578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.182578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.081328 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.305547 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.102578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.182578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.387578 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.611797 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.102578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.182578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.543828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.768047 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.116328 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.102578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.182578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.889453 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(98.113672 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.915703 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.139922 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(338.626328 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.850547 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,32 +1755,48 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 211 -->
-    <g transform="translate(440.468203 238.5583) scale(0.08 -0.08)">
+    <!-- 209 -->
+    <g transform="translate(440.692422 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.004453 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.228672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1909,7 +1925,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.116328 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1919,14 +1935,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.102578 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.182578 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1934,7 +1950,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.511328 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.735547 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1990,7 +2006,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2000,21 +2016,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.102578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.727578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.225703 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2041,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.116328 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2035,13 +2051,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.647578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.817578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2073,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.638828 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.863047 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2270,7 +2286,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2412,12 +2428,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2457,110 +2473,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe41e5cb8b7">
-   <rect x="82.630078" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pf20f32977c">
+   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p88b06a961e)">
+   <g clip-path="url(#p9c5857dfb0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3YsY6cVx2H4Z3d8To4CTGJcRSQLBpIRaQIKprcQYpcRkpaekrqtOm5ASoiKiSEoAsdUaAIjkDEDtF6Z3c2V0Blnfe//vQ8V/AbfXPmvN/sjv/++OZkyw4X0wt4Hser6QVr7U6nF6x1dTm9YK1796cXrPXs6+kFa52dTy/geWz9+3l+b3rBUhu//QAAuG0EKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqf2fD59Nb1hqf3o2PWGp483N9ISlHr76cHrCUp89+cf0hLU2/or7k5fuT09Y6nD3fHrCUn95/On0hKXeefDj6QlLPTs/Tk9Yarf7ZnrCUhu/HgAAuG0EKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBq/+jVH01vWOr+3YfTE5b68uKf0xOW+sE3235HeuWNn05PWOpst5+esNTx5Dg9YanvnzyYnrDU1YPL6QlLvXnv0fSEpQ7HbT+/ly+3/fuy7dsdAIBbR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDa73bbbtCnh/9MT1jqO2evTE9Y6vqN16cnLPXFV3+dnrDU15cX0xOW+tn3fj49YanLs+kFa/3v8HR6As/hv88eT09Y6+7D6QVLbbs+AQC4dQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp3fUffnkzPWKp43F6Afx/p94BX2h+X15sWz9/W/9+en4vtI0/PQAAbhsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/mn/42vWGp0/22G/vxp19OT1jqow/fnZ6w1K//+K/pCUu99+i16QlL/faTv09PWOpXH7w9PWGp3/z+8+kJS73/7lvTE5b6/Ktn0xOW+sUPX56esNS26wwAgFtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdofr391Mj1jp7OpqesJap/vpBWtdXUwvWOv83vSCtXYbf8e9OU4vWOvg/L3Qrrd9/x122z5/dzbeLxu/HQAAuG0EKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqf31zdX0hqXO7rw0PWGp48lxesJSp0+fTE9Y6vLOfnrCUue7bZ+/k6vL6QVrHS6mFyz1ZLftz/fdm22fvztn59MT1tr4+fMPKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqW39PfrTbYWP0AAAAAElFTkSuQmCC" id="image87a22da88b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6ElEQVR4nO3YPW5cVQCGYY89cSA/IpCQCJAiGqACKYKKhh1QsAxKWnpKalp6NkAFokJCCLrQEQEFJALlj8j22GNWQBWd9zhXz7OCT7pz7nnvrLZ/f3m6s2Sbg9kLeBrb49kLxlrtzl4w1vHR7AVjXbgye8FYh49nLxhrb3/2Ap7G0n+f+xdmLxhq4bcfAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1/nFzZ/aGoda7e7MnDLU9PZ09Yajrl6/PnjDUnYe/z54w1sI/cd987srsCUNtzu/PnjDUT3dvz54w1DvX3pg9YajD/e3sCUOtVk9mTxhq4dcDAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1vXn599oahrpy/PnvCUPcO/pg9YahXnyz7G+nS1bdnTxhqb7WePWGo7c529oShXt65NnvCUMfXjmZPGOrGhZuzJwy12S77+V08Wvb7Zdm3OwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtV6tlt2gjzb/zJ4w1PN7l2ZPGOrk6kuzJwz154OfZ08Y6vHRwewJQ7374nuzJwx1tDd7wVj/bh7NnsBTuH94d/aEsc5fn71gqGXXJwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtTr57pPT2SOG2m5nL4D/t+sb8Jnm/fJsW/r5W/rv0/N7pi386QEAcNYIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUusbP/wye8NQu+tlN/bd2/dmTxjqi49vzZ4w1Gff/zV7wlAf3Hxh9oShvvr219kThvr0o7dmTxjq829+mz1hqA9vvTJ7wlC/PTicPWGo91+7OHvCUMuuMwAAzhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBabU6+Pp09YqS94+PZE8baXc9eMNbxwewFY+1fmL1grNXCv3FPt7MXjLVx/p5pJ8u+/zarZZ+/cwvvl4XfDgAAnDUCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1Prk9Hj2hqH21vuzJwy1Xc1eMNbuw/uzJwx1dG49e8JQ+zvLPn87x0ezF4y1OZi9YKjHq2U/v0unyz5/53aX/f5c+vnzDygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBA6j/J1X2rX/GsGgAAAABJRU5ErkJggg==" id="image1894bd2286" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf12d0aa983" d="M 0 0 
+       <path id="m7c0bd0b811" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf12d0aa983" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf12d0aa983" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf12d0aa983" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf12d0aa983" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf12d0aa983" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf12d0aa983" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf12d0aa983" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf12d0aa983" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf12d0aa983" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf12d0aa983" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf12d0aa983" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf12d0aa983" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7c0bd0b811" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md7f9c14f0a" d="M 0 0 
+       <path id="m680eb3e83a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md7f9c14f0a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m680eb3e83a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1198,43 +1198,8 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -1 -->
+    <!-- -3 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +4 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -33 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1271,20 +1236,62 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +3 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -34 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +11 -->
+    <!-- +10 -->
     <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -2 -->
+    <!-- -4 -->
     <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -12 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1312,31 +1319,24 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -22 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_28">
+    <!-- -23 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_29">
-    <!-- +22 -->
+    <!-- +21 -->
     <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1348,8 +1348,64 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -6 -->
+    <!-- -8 -->
     <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -24 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1382,21 +1438,6 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -22 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1580,47 +1621,6 @@ z
    <g id="text_49">
     <!-- +238 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
@@ -2193,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image3d195fb54b" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image3e150843d4" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m0575eb9276" d="M 0 0 
+       <path id="mca6c818348" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m0575eb9276" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca6c818348" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3003,12 +3003,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3048,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p88b06a961e">
+  <clipPath id="p9c5857dfb0">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf8aa35560c" d="M 0 0 
+       <path id="mcf2d38bc57" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf8aa35560c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf8aa35560c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf8aa35560c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf8aa35560c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf8aa35560c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf8aa35560c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf8aa35560c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf2d38bc57" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m430520fc3e" d="M 0 0 
+       <path id="m56c0a3fe0e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m430520fc3e" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m430520fc3e" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m430520fc3e" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m98eed2c9d1" d="M 0 0 
+       <path id="m7d7e06588d" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m98eed2c9d1" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7d7e06588d" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 145.15828) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 145.876361) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 340.875359) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 334.14348) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8db6ed0cb6" d="M -2.5 2.5 
+     <path id="m178244bc6c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m8db6ed0cb6" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8db6ed0cb6" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#m178244bc6c" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m178244bc6c" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1f29a01c9e" d="M 0 -2.5 
+     <path id="m436450e9eb" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m1f29a01c9e" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1f29a01c9e" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#m436450e9eb" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m436450e9eb" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m940717add0" d="M -0 3.535534 
+     <path id="md307489ca2" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m940717add0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940717add0" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#md307489ca2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md307489ca2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9df66d0706" d="M -0 2.5 
+     <path id="ma6227aa52e" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m9df66d0706" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#ma6227aa52e" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mcd56cdd211" d="M -0.833333 2.5 
+     <path id="mb278c96180" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#mcd56cdd211" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd56cdd211" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#mb278c96180" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb278c96180" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m28e0e6c228" d="M -1.25 2.5 
+     <path id="m598bf75ba4" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m28e0e6c228" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m28e0e6c228" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#m598bf75ba4" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m598bf75ba4" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc91ec32150" d="M 0 -2.5 
+     <path id="mc3e4093720" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#mc91ec32150" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc91ec32150" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#mc3e4093720" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc3e4093720" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1dabe6d0ce" d="M 0 -2.5 
+     <path id="mdd9f67dd3d" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m1dabe6d0ce" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dabe6d0ce" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#mdd9f67dd3d" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdd9f67dd3d" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m7585c37067" d="M 0 3.5 
+      <path id="mf594d85f73" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m7585c37067" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mf594d85f73" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8db6ed0cb6" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m178244bc6c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1f29a01c9e" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m436450e9eb" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m940717add0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md307489ca2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9df66d0706" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma6227aa52e" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcd56cdd211" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb278c96180" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m28e0e6c228" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m598bf75ba4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc91ec32150" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc3e4093720" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1dabe6d0ce" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdd9f67dd3d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 150.15828 
-L 236.23654 154.28995 
-L 222.073314 158.93114 
-L 202.315941 169.893106 
-L 199.905291 171.668354 
-L 195.893147 175.782192 
-L 187.210062 189.70688 
-L 157.246106 245.295043 
-L 95.319203 345.875359 
-" clip-path="url(#pa41aa22d94)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pa41aa22d94)">
-     <use xlink:href="#m7585c37067" x="257.531237" y="150.15828" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="236.23654" y="154.28995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="222.073314" y="158.93114" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="202.315941" y="169.893106" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="199.905291" y="171.668354" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="195.893147" y="175.782192" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="187.210062" y="189.70688" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="157.246106" y="245.295043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m7585c37067" x="95.319203" y="345.875359" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 150.876361 
+L 236.23654 155.378808 
+L 222.073314 159.773191 
+L 202.315941 170.53176 
+L 199.905291 172.268949 
+L 195.893147 176.45193 
+L 187.210062 190.253023 
+L 157.246106 245.621259 
+L 95.319203 339.14348 
+" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p533e8fc221)">
+     <use xlink:href="#mf594d85f73" x="257.531237" y="150.876361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="236.23654" y="155.378808" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="222.073314" y="159.773191" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="202.315941" y="170.53176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="199.905291" y="172.268949" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="195.893147" y="176.45193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="187.210062" y="190.253023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="157.246106" y="245.621259" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mf594d85f73" x="95.319203" y="339.14348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2815,6 +2815,16 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2887,36 +2897,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -2940,16 +2920,6 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -2993,12 +2963,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3038,109 +3008,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa41aa22d94">
+  <clipPath id="p533e8fc221">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8c6a7a0946" d="M 0 0 
+       <path id="mbdc34b6d68" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8c6a7a0946" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8c6a7a0946" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbdc34b6d68" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m8b0983f97a" d="M 0 0 
+       <path id="mcba8310c94" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b0983f97a" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcba8310c94" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8b0983f97a" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcba8310c94" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8b0983f97a" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcba8310c94" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb371be0de8" d="M 0 0 
+       <path id="m137194c53c" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb371be0de8" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m137194c53c" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pa6e26facc4)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pef2b36634e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mcbf2e0bec5" d="M -2.5 2.5 
+     <path id="m672db5ea2e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#mcbf2e0bec5" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf2e0bec5" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#m672db5ea2e" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m672db5ea2e" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="med0ba230e0" d="M 0 -2.5 
+     <path id="m59c02e876f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#med0ba230e0" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#med0ba230e0" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#m59c02e876f" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59c02e876f" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="me1053fb2af" d="M -0 3.535534 
+     <path id="mf397ebec1b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#me1053fb2af" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me1053fb2af" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#mf397ebec1b" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf397ebec1b" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m2339eec407" d="M -0.833333 2.5 
+     <path id="mdab00f34b5" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#m2339eec407" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2339eec407" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#mdab00f34b5" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdab00f34b5" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mf1902c2251" d="M -1.25 2.5 
+     <path id="m859ae6c05d" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#mf1902c2251" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1902c2251" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#m859ae6c05d" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m859ae6c05d" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m75c8820f94" d="M 0 -2.5 
+     <path id="m5d601f7d23" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#m75c8820f94" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m75c8820f94" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#m5d601f7d23" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d601f7d23" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m1eea19a823" d="M 0 -2.5 
+     <path id="m9174fe90e3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#m1eea19a823" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eea19a823" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#m9174fe90e3" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9174fe90e3" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mfa52226795" d="M 0 3.5 
+      <path id="mb701ddf920" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mfa52226795" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mb701ddf920" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mcbf2e0bec5" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m672db5ea2e" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#med0ba230e0" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m59c02e876f" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#me1053fb2af" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf397ebec1b" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m2339eec407" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdab00f34b5" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mf1902c2251" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m859ae6c05d" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m75c8820f94" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m5d601f7d23" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m1eea19a823" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9174fe90e3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pa6e26facc4)">
-     <use xlink:href="#mfa52226795" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mfa52226795" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pef2b36634e)">
+     <use xlink:href="#mb701ddf920" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb701ddf920" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa6e26facc4">
+  <clipPath id="pef2b36634e">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m755ec1dd7e" d="M 0 0 
+       <path id="m3643087f7a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m755ec1dd7e" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3643087f7a" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m755ec1dd7e" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3643087f7a" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m2d0b051528" d="M 0 0 
+       <path id="maa8165ad80" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2d0b051528" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2d0b051528" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2d0b051528" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2d0b051528" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2d0b051528" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2d0b051528" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2d0b051528" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2d0b051528" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2d0b051528" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2d0b051528" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2d0b051528" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2d0b051528" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2d0b051528" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2d0b051528" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2d0b051528" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2d0b051528" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2d0b051528" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2d0b051528" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2d0b051528" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2d0b051528" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#maa8165ad80" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mcfc97f6081" d="M 0 0 
+       <path id="m5162ceafa8" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mcfc97f6081" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5162ceafa8" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#p8705ac50e0)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m1aa4a45215" d="M 0 3 
+     <path id="m216e03da85" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#m1aa4a45215" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m216e03da85" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mcada9f800a" d="M 0 3 
+     <path id="mf6d0e6a28b" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#mcada9f800a" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#mf6d0e6a28b" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m696979c4ec" d="M 0 3 
+     <path id="m50ca4d3758" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#m696979c4ec" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m50ca4d3758" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mc6f7dbbb15" d="M 0 5 
+     <path id="m5a4af8cd5b" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#mc6f7dbbb15" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m5a4af8cd5b" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m63549ba97d" d="M 0 3 
+     <path id="m17f69d86d0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#m63549ba97d" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m17f69d86d0" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mffae3a8ad3" d="M 0 3 
+     <path id="m46ec212e40" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#mffae3a8ad3" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m46ec212e40" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m89dc3ed188" d="M 0 3 
+     <path id="me766ba2e9c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#m89dc3ed188" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#me766ba2e9c" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m26d093bede" d="M 0 3 
+     <path id="m3288ff7b7c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p8705ac50e0)">
-     <use xlink:href="#m26d093bede" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p04bd6fe6c4)">
+     <use xlink:href="#m3288ff7b7c" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p8705ac50e0">
+  <clipPath id="p04bd6fe6c4">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p101eeb8f80)">
+   <g clip-path="url(#pfbd230267e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image093fe02a15" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image274abf036f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m236fdf17a9" d="M 0 0 
+       <path id="mc188663dab" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m236fdf17a9" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m236fdf17a9" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m236fdf17a9" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m236fdf17a9" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m236fdf17a9" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m236fdf17a9" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m236fdf17a9" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m236fdf17a9" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m236fdf17a9" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m236fdf17a9" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m236fdf17a9" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m236fdf17a9" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc188663dab" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m7d90e896b5" d="M 0 0 
+       <path id="m3d521f95f9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7d90e896b5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d521f95f9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image7ce7bf94c1" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2ebcb80172" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m9d68d4621a" d="M 0 0 
+       <path id="mecace9a284" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9d68d4621a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mecace9a284" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m9d68d4621a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mecace9a284" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9d68d4621a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mecace9a284" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m9d68d4621a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mecace9a284" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9d68d4621a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mecace9a284" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2873,12 +2873,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p101eeb8f80">
+  <clipPath id="pfbd230267e">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="386.202469pt" viewBox="0 0 570.260156 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.260156 386.202469 
-L 570.260156 0 
+L 570.708594 386.202469 
+L 570.708594 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.255078 104.1264 
-L 291.880078 104.1264 
-L 291.880078 74.7432 
-L 187.255078 74.7432 
+    <path d="M 187.479297 104.1264 
+L 292.104297 104.1264 
+L 292.104297 74.7432 
+L 187.479297 74.7432 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.880078 104.1264 
-L 396.505078 104.1264 
-L 396.505078 74.7432 
-L 291.880078 74.7432 
+    <path d="M 292.104297 104.1264 
+L 396.729297 104.1264 
+L 396.729297 74.7432 
+L 292.104297 74.7432 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.505078 104.1264 
-L 501.130078 104.1264 
-L 501.130078 74.7432 
-L 396.505078 74.7432 
+    <path d="M 396.729297 104.1264 
+L 501.354297 104.1264 
+L 501.354297 74.7432 
+L 396.729297 74.7432 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.255078 133.5096 
-L 291.880078 133.5096 
-L 291.880078 104.1264 
-L 187.255078 104.1264 
+    <path d="M 187.479297 133.5096 
+L 292.104297 133.5096 
+L 292.104297 104.1264 
+L 187.479297 104.1264 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.880078 133.5096 
-L 396.505078 133.5096 
-L 396.505078 104.1264 
-L 291.880078 104.1264 
+    <path d="M 292.104297 133.5096 
+L 396.729297 133.5096 
+L 396.729297 104.1264 
+L 292.104297 104.1264 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.505078 133.5096 
-L 501.130078 133.5096 
-L 501.130078 104.1264 
-L 396.505078 104.1264 
+    <path d="M 396.729297 133.5096 
+L 501.354297 133.5096 
+L 501.354297 104.1264 
+L 396.729297 104.1264 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.255078 162.8928 
-L 291.880078 162.8928 
-L 291.880078 133.5096 
-L 187.255078 133.5096 
+    <path d="M 187.479297 162.8928 
+L 292.104297 162.8928 
+L 292.104297 133.5096 
+L 187.479297 133.5096 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.880078 162.8928 
-L 396.505078 162.8928 
-L 396.505078 133.5096 
-L 291.880078 133.5096 
+    <path d="M 292.104297 162.8928 
+L 396.729297 162.8928 
+L 396.729297 133.5096 
+L 292.104297 133.5096 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.505078 162.8928 
-L 501.130078 162.8928 
-L 501.130078 133.5096 
-L 396.505078 133.5096 
+    <path d="M 396.729297 162.8928 
+L 501.354297 162.8928 
+L 501.354297 133.5096 
+L 396.729297 133.5096 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.255078 192.276 
-L 291.880078 192.276 
-L 291.880078 162.8928 
-L 187.255078 162.8928 
+    <path d="M 187.479297 192.276 
+L 292.104297 192.276 
+L 292.104297 162.8928 
+L 187.479297 162.8928 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.880078 192.276 
-L 396.505078 192.276 
-L 396.505078 162.8928 
-L 291.880078 162.8928 
+    <path d="M 292.104297 192.276 
+L 396.729297 192.276 
+L 396.729297 162.8928 
+L 292.104297 162.8928 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.505078 192.276 
-L 501.130078 192.276 
-L 501.130078 162.8928 
-L 396.505078 162.8928 
+    <path d="M 396.729297 192.276 
+L 501.354297 192.276 
+L 501.354297 162.8928 
+L 396.729297 162.8928 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.255078 221.6592 
-L 291.880078 221.6592 
-L 291.880078 192.276 
-L 187.255078 192.276 
+    <path d="M 187.479297 221.6592 
+L 292.104297 221.6592 
+L 292.104297 192.276 
+L 187.479297 192.276 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.880078 221.6592 
-L 396.505078 221.6592 
-L 396.505078 192.276 
-L 291.880078 192.276 
+    <path d="M 292.104297 221.6592 
+L 396.729297 221.6592 
+L 396.729297 192.276 
+L 292.104297 192.276 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.505078 221.6592 
-L 501.130078 221.6592 
-L 501.130078 192.276 
-L 396.505078 192.276 
+    <path d="M 396.729297 221.6592 
+L 501.354297 221.6592 
+L 501.354297 192.276 
+L 396.729297 192.276 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.255078 251.0424 
-L 291.880078 251.0424 
-L 291.880078 221.6592 
-L 187.255078 221.6592 
+    <path d="M 187.479297 251.0424 
+L 292.104297 251.0424 
+L 292.104297 221.6592 
+L 187.479297 221.6592 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.880078 251.0424 
-L 396.505078 251.0424 
-L 396.505078 221.6592 
-L 291.880078 221.6592 
+    <path d="M 292.104297 251.0424 
+L 396.729297 251.0424 
+L 396.729297 221.6592 
+L 292.104297 221.6592 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.505078 251.0424 
-L 501.130078 251.0424 
-L 501.130078 221.6592 
-L 396.505078 221.6592 
+    <path d="M 396.729297 251.0424 
+L 501.354297 251.0424 
+L 501.354297 221.6592 
+L 396.729297 221.6592 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.255078 280.4256 
-L 291.880078 280.4256 
-L 291.880078 251.0424 
-L 187.255078 251.0424 
+    <path d="M 187.479297 280.4256 
+L 292.104297 280.4256 
+L 292.104297 251.0424 
+L 187.479297 251.0424 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.880078 280.4256 
-L 396.505078 280.4256 
-L 396.505078 251.0424 
-L 291.880078 251.0424 
+    <path d="M 292.104297 280.4256 
+L 396.729297 280.4256 
+L 396.729297 251.0424 
+L 292.104297 251.0424 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.505078 280.4256 
-L 501.130078 280.4256 
-L 501.130078 251.0424 
-L 396.505078 251.0424 
+    <path d="M 396.729297 280.4256 
+L 501.354297 280.4256 
+L 501.354297 251.0424 
+L 396.729297 251.0424 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.255078 309.8088 
-L 291.880078 309.8088 
-L 291.880078 280.4256 
-L 187.255078 280.4256 
+    <path d="M 187.479297 309.8088 
+L 292.104297 309.8088 
+L 292.104297 280.4256 
+L 187.479297 280.4256 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.880078 309.8088 
-L 396.505078 309.8088 
-L 396.505078 280.4256 
-L 291.880078 280.4256 
+    <path d="M 292.104297 309.8088 
+L 396.729297 309.8088 
+L 396.729297 280.4256 
+L 292.104297 280.4256 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.505078 309.8088 
-L 501.130078 309.8088 
-L 501.130078 280.4256 
-L 396.505078 280.4256 
+    <path d="M 396.729297 309.8088 
+L 501.354297 309.8088 
+L 501.354297 280.4256 
+L 396.729297 280.4256 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.255078 339.192 
-L 291.880078 339.192 
-L 291.880078 309.8088 
-L 187.255078 309.8088 
+    <path d="M 187.479297 339.192 
+L 292.104297 339.192 
+L 292.104297 309.8088 
+L 187.479297 309.8088 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.880078 339.192 
-L 396.505078 339.192 
-L 396.505078 309.8088 
-L 291.880078 309.8088 
+    <path d="M 292.104297 339.192 
+L 396.729297 339.192 
+L 396.729297 309.8088 
+L 292.104297 309.8088 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.505078 339.192 
-L 501.130078 339.192 
-L 501.130078 309.8088 
-L 396.505078 309.8088 
+    <path d="M 396.729297 339.192 
+L 501.354297 339.192 
+L 501.354297 309.8088 
+L 396.729297 309.8088 
 z
-" clip-path="url(#p3d2cb37380)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03382f488f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.242344 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.526563 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.098672 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.450391 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.180078 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.116328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.557578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.182578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.818203 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.116328 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.102578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.182578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.511328 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.735547 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.116328 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.102578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.182578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.543828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.768047 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.116328 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.102578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.182578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.081328 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.305547 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.116328 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.102578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.182578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.387578 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.611797 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.116328 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.102578 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(441.182578 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.406797 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.889453 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.113672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(226.915703 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.139922 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 35 -->
-    <g transform="translate(338.626328 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.850547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
@@ -1887,9 +1887,39 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 271 -->
-    <g transform="translate(440.468203 267.9415) scale(0.08 -0.08)">
+    <!-- 267 -->
+    <g transform="translate(440.692422 267.9415) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
 L 3944 3988 
@@ -1900,29 +1930,15 @@ L 428 3781
 L 428 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.004453 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.228672 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1987,7 +2003,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.116328 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1997,21 +2013,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.102578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.727578 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.225703 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2022,7 +2038,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.116328 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2032,13 +2048,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.647578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.817578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2054,7 +2070,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.731797 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.956016 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2127,36 +2143,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2198,7 +2184,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T03:22:04Z  ·  Linux chungus x86_64  ·  commit ce9578ba  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2340,12 +2326,12 @@ z
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2385,110 +2371,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3063.232422 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3124.755859 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3188.378906 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3252.001953 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3315.625 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3442.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3d2cb37380">
-   <rect x="82.630078" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p03382f488f">
+   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-24T03:22:04Z",
+  "date": "2026-06-24T07:32:44Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "ce9578ba",
+  "git_commit": "6ed05ade",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 41.69,
-   "decompress_mbps": 194.1
+   "compress_mbps": 40.81,
+   "decompress_mbps": 192.5
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 38.41,
-   "decompress_mbps": 221.05
+   "compress_mbps": 37.08,
+   "decompress_mbps": 218.79
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 35.46,
-   "decompress_mbps": 240.53
+   "compress_mbps": 34.01,
+   "decompress_mbps": 237.81
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 242.12
+   "compress_mbps": 27.67,
+   "decompress_mbps": 240.42
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.93,
-   "decompress_mbps": 245.14
+   "compress_mbps": 26.72,
+   "decompress_mbps": 243.55
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 251.77
+   "compress_mbps": 24.85,
+   "decompress_mbps": 249.58
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 20.34,
-   "decompress_mbps": 251.3
+   "compress_mbps": 20.17,
+   "decompress_mbps": 249.87
   },
   {
    "compressor": "native",
@@ -85,7 +85,7 @@
    "out_size": 54127,
    "ratio": 0.3559,
    "compress_mbps": 9.16,
-   "decompress_mbps": 253.15
+   "decompress_mbps": 250.97
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.51,
-   "decompress_mbps": 252.52
+   "compress_mbps": 1.78,
+   "decompress_mbps": 250.74
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 38.81,
-   "decompress_mbps": 186.04
+   "compress_mbps": 38.45,
+   "decompress_mbps": 185.72
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 35.73,
-   "decompress_mbps": 201.78
+   "compress_mbps": 35.32,
+   "decompress_mbps": 201.82
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 33.41,
-   "decompress_mbps": 219.64
+   "compress_mbps": 32.94,
+   "decompress_mbps": 218.98
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 223.86
+   "compress_mbps": 25.6,
+   "decompress_mbps": 223.52
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 225.38
+   "compress_mbps": 24.87,
+   "decompress_mbps": 224.7
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.85,
-   "decompress_mbps": 229.05
+   "compress_mbps": 23.67,
+   "decompress_mbps": 228.08
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.42,
-   "decompress_mbps": 229.6
+   "compress_mbps": 21.24,
+   "decompress_mbps": 228.56
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.89,
-   "decompress_mbps": 229.32
+   "compress_mbps": 8.93,
+   "decompress_mbps": 229.51
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.68,
-   "decompress_mbps": 229.82
+   "compress_mbps": 2.05,
+   "decompress_mbps": 228.42
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 34.68,
-   "decompress_mbps": 221.35
+   "compress_mbps": 33.99,
+   "decompress_mbps": 218.78
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 227.52
+   "compress_mbps": 33.08,
+   "decompress_mbps": 226.09
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 232.61
+   "compress_mbps": 32.18,
+   "decompress_mbps": 230.46
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.54,
-   "decompress_mbps": 240.51
+   "compress_mbps": 30.2,
+   "decompress_mbps": 238.74
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 250.39
+   "compress_mbps": 29.71,
+   "decompress_mbps": 245.79
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.23,
-   "decompress_mbps": 249.11
+   "compress_mbps": 28.9,
+   "decompress_mbps": 245.84
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 252.85
+   "compress_mbps": 25.41,
+   "decompress_mbps": 249.81
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.67,
-   "decompress_mbps": 251.74
+   "compress_mbps": 9.62,
+   "decompress_mbps": 248.03
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 2.03,
-   "decompress_mbps": 251.61
+   "compress_mbps": 2.38,
+   "decompress_mbps": 249.38
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.55,
-   "decompress_mbps": 151.74
+   "compress_mbps": 23.24,
+   "decompress_mbps": 148.73
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.96,
-   "decompress_mbps": 152.72
+   "compress_mbps": 22.77,
+   "decompress_mbps": 150.49
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.67,
-   "decompress_mbps": 156.98
+   "compress_mbps": 22.42,
+   "decompress_mbps": 154.29
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 160.21
+   "compress_mbps": 21.3,
+   "decompress_mbps": 156.56
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 161.36
+   "compress_mbps": 21.11,
+   "decompress_mbps": 158.05
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 161.3
+   "compress_mbps": 20.75,
+   "decompress_mbps": 158.35
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.24,
-   "decompress_mbps": 162.31
+   "compress_mbps": 18.97,
+   "decompress_mbps": 159.05
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.04,
-   "decompress_mbps": 161.88
+   "compress_mbps": 7.02,
+   "decompress_mbps": 158.68
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 2.01,
-   "decompress_mbps": 161.59
+   "compress_mbps": 2.35,
+   "decompress_mbps": 159.2
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.75,
-   "decompress_mbps": 70.49
+   "compress_mbps": 11.71,
+   "decompress_mbps": 68.85
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.64,
-   "decompress_mbps": 71.18
+   "compress_mbps": 11.59,
+   "decompress_mbps": 69.86
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.56,
-   "decompress_mbps": 71.34
+   "compress_mbps": 11.51,
+   "decompress_mbps": 69.53
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.36,
-   "decompress_mbps": 71.65
+   "compress_mbps": 11.34,
+   "decompress_mbps": 70.11
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.34,
-   "decompress_mbps": 71.85
+   "compress_mbps": 11.32,
+   "decompress_mbps": 69.87
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.34,
-   "decompress_mbps": 71.92
+   "compress_mbps": 11.31,
+   "decompress_mbps": 70.45
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.15,
-   "decompress_mbps": 72.22
+   "compress_mbps": 11.08,
+   "decompress_mbps": 70.49
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.84,
-   "decompress_mbps": 72.22
+   "compress_mbps": 3.82,
+   "decompress_mbps": 70.27
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.86,
-   "decompress_mbps": 72.06
+   "compress_mbps": 2.11,
+   "decompress_mbps": 70.29
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 67.05,
-   "decompress_mbps": 354.84
+   "compress_mbps": 65.25,
+   "decompress_mbps": 352.23
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 63.2,
-   "decompress_mbps": 382.9
+   "compress_mbps": 60.31,
+   "decompress_mbps": 381.58
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 61.88,
-   "decompress_mbps": 406.62
+   "compress_mbps": 61.17,
+   "decompress_mbps": 402.39
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 57.93,
-   "decompress_mbps": 430.04
+   "compress_mbps": 57.87,
+   "decompress_mbps": 427.0
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 57.03,
-   "decompress_mbps": 410.94
+   "compress_mbps": 56.72,
+   "decompress_mbps": 408.23
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 53.57,
-   "decompress_mbps": 423.54
+   "compress_mbps": 53.11,
+   "decompress_mbps": 410.96
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.6,
-   "decompress_mbps": 427.35
+   "compress_mbps": 20.53,
+   "decompress_mbps": 427.98
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.32,
-   "decompress_mbps": 432.67
+   "compress_mbps": 7.39,
+   "decompress_mbps": 432.98
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.15,
-   "decompress_mbps": 435.14
+   "compress_mbps": 1.23,
+   "decompress_mbps": 435.5
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 45.87,
-   "decompress_mbps": 203.98
+   "compress_mbps": 44.66,
+   "decompress_mbps": 202.6
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 41.65,
-   "decompress_mbps": 220.18
+   "compress_mbps": 40.39,
+   "decompress_mbps": 217.96
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 38.3,
-   "decompress_mbps": 245.36
+   "compress_mbps": 36.78,
+   "decompress_mbps": 243.06
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 30.28,
-   "decompress_mbps": 248.97
+   "compress_mbps": 29.65,
+   "decompress_mbps": 247.21
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 29.18,
-   "decompress_mbps": 251.29
+   "compress_mbps": 28.54,
+   "decompress_mbps": 251.0
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 27.14,
-   "decompress_mbps": 255.55
+   "compress_mbps": 26.66,
+   "decompress_mbps": 254.42
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 256.12
+   "compress_mbps": 22.12,
+   "decompress_mbps": 255.63
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.98,
-   "decompress_mbps": 256.57
+   "compress_mbps": 9.92,
+   "decompress_mbps": 256.24
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.56,
-   "decompress_mbps": 260.06
+   "compress_mbps": 1.82,
+   "decompress_mbps": 255.5
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 39.63,
-   "decompress_mbps": 177.26
+   "compress_mbps": 38.78,
+   "decompress_mbps": 175.7
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 196.75
+   "compress_mbps": 35.34,
+   "decompress_mbps": 195.44
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 32.97,
-   "decompress_mbps": 216.22
+   "compress_mbps": 31.81,
+   "decompress_mbps": 214.63
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 24.0,
-   "decompress_mbps": 220.72
+   "compress_mbps": 23.35,
+   "decompress_mbps": 218.58
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 23.01,
-   "decompress_mbps": 220.6
+   "compress_mbps": 22.54,
+   "decompress_mbps": 216.54
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 21.29,
-   "decompress_mbps": 224.58
+   "compress_mbps": 20.93,
+   "decompress_mbps": 221.35
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.13,
-   "decompress_mbps": 224.67
+   "compress_mbps": 18.12,
+   "decompress_mbps": 221.41
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.4,
-   "decompress_mbps": 224.88
+   "compress_mbps": 8.41,
+   "decompress_mbps": 222.59
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.49,
-   "decompress_mbps": 225.28
+   "compress_mbps": 1.75,
+   "decompress_mbps": 221.76
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 127.64,
-   "decompress_mbps": 490.82
+   "compress_mbps": 125.1,
+   "decompress_mbps": 482.42
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 112.68,
-   "decompress_mbps": 518.52
+   "compress_mbps": 110.69,
+   "decompress_mbps": 505.87
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 96.51,
-   "decompress_mbps": 559.22
+   "compress_mbps": 95.36,
+   "decompress_mbps": 547.73
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 75.83,
-   "decompress_mbps": 472.72
+   "compress_mbps": 75.64,
+   "decompress_mbps": 464.63
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 73.01,
-   "decompress_mbps": 506.87
+   "compress_mbps": 73.03,
+   "decompress_mbps": 498.82
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 65.66,
-   "decompress_mbps": 555.95
+   "compress_mbps": 65.45,
+   "decompress_mbps": 545.1
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 37.15,
-   "decompress_mbps": 595.3
+   "compress_mbps": 36.76,
+   "decompress_mbps": 578.87
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.62,
-   "decompress_mbps": 631.21
+   "compress_mbps": 16.67,
+   "decompress_mbps": 621.92
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 1.03,
-   "decompress_mbps": 647.45
+   "compress_mbps": 1.09,
+   "decompress_mbps": 640.94
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.57,
-   "decompress_mbps": 187.96
+   "compress_mbps": 26.51,
+   "decompress_mbps": 186.49
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.96,
-   "decompress_mbps": 191.95
+   "compress_mbps": 25.78,
+   "decompress_mbps": 191.31
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.35,
-   "decompress_mbps": 194.55
+   "compress_mbps": 25.2,
+   "decompress_mbps": 194.47
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 22.93,
-   "decompress_mbps": 203.17
+   "compress_mbps": 23.02,
+   "decompress_mbps": 201.79
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.47,
-   "decompress_mbps": 207.87
+   "compress_mbps": 22.57,
+   "decompress_mbps": 211.36
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.31,
-   "decompress_mbps": 213.69
+   "compress_mbps": 21.32,
+   "decompress_mbps": 216.29
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.4,
-   "decompress_mbps": 218.04
+   "compress_mbps": 17.34,
+   "decompress_mbps": 217.45
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.36,
-   "decompress_mbps": 219.31
+   "compress_mbps": 5.32,
+   "decompress_mbps": 219.13
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.66,
-   "decompress_mbps": 221.18
+   "compress_mbps": 1.84,
+   "decompress_mbps": 220.23
   },
   {
    "compressor": "native",
@@ -915,7 +915,7 @@
    "out_size": 1747,
    "ratio": 0.4133,
    "compress_mbps": 12.95,
-   "decompress_mbps": 77.16
+   "decompress_mbps": 75.88
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.94,
-   "decompress_mbps": 76.89
+   "compress_mbps": 12.87,
+   "decompress_mbps": 75.9
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.91,
-   "decompress_mbps": 77.03
+   "compress_mbps": 12.85,
+   "decompress_mbps": 75.96
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.65,
-   "decompress_mbps": 77.66
+   "compress_mbps": 12.59,
+   "decompress_mbps": 76.56
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.63,
-   "decompress_mbps": 77.71
+   "compress_mbps": 12.64,
+   "decompress_mbps": 76.5
   },
   {
    "compressor": "native",
@@ -965,7 +965,7 @@
    "out_size": 1732,
    "ratio": 0.4097,
    "compress_mbps": 12.62,
-   "decompress_mbps": 77.48
+   "decompress_mbps": 76.48
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.48,
-   "decompress_mbps": 77.55
+   "compress_mbps": 12.47,
+   "decompress_mbps": 76.38
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 77.53
+   "compress_mbps": 4.14,
+   "decompress_mbps": 76.57
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.22,
-   "decompress_mbps": 77.73
+   "compress_mbps": 2.46,
+   "decompress_mbps": 76.55
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 38.05,
-   "decompress_mbps": 176.74
+   "compress_mbps": 40.66,
+   "decompress_mbps": 180.47
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 37.5,
-   "decompress_mbps": 195.8
+   "compress_mbps": 36.48,
+   "decompress_mbps": 195.0
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 34.28,
-   "decompress_mbps": 216.58
+   "compress_mbps": 33.53,
+   "decompress_mbps": 213.45
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.92,
-   "decompress_mbps": 218.8
+   "compress_mbps": 25.56,
+   "decompress_mbps": 218.22
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.4,
-   "decompress_mbps": 218.55
+   "compress_mbps": 25.22,
+   "decompress_mbps": 219.64
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.36,
-   "decompress_mbps": 222.88
+   "compress_mbps": 23.27,
+   "decompress_mbps": 223.75
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 19.64,
-   "decompress_mbps": 225.32
+   "compress_mbps": 19.57,
+   "decompress_mbps": 223.21
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 9.09,
-   "decompress_mbps": 234.57
+   "compress_mbps": 8.91,
+   "decompress_mbps": 231.11
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.49,
-   "decompress_mbps": 226.45
+   "compress_mbps": 1.75,
+   "decompress_mbps": 232.17
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 54.03,
-   "decompress_mbps": 195.54
+   "compress_mbps": 53.27,
+   "decompress_mbps": 195.05
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 51.1,
-   "decompress_mbps": 206.94
+   "compress_mbps": 50.2,
+   "decompress_mbps": 205.62
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 48.36,
-   "decompress_mbps": 213.78
+   "compress_mbps": 46.84,
+   "decompress_mbps": 211.89
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 39.36,
-   "decompress_mbps": 222.2
+   "compress_mbps": 38.72,
+   "decompress_mbps": 219.95
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 37.64,
-   "decompress_mbps": 226.87
+   "compress_mbps": 37.03,
+   "decompress_mbps": 225.91
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.99,
-   "decompress_mbps": 232.85
+   "compress_mbps": 32.44,
+   "decompress_mbps": 230.44
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 22.03,
-   "decompress_mbps": 232.43
+   "compress_mbps": 21.64,
+   "decompress_mbps": 229.74
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.89,
-   "decompress_mbps": 234.12
+   "compress_mbps": 6.75,
+   "decompress_mbps": 223.14
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.48,
-   "decompress_mbps": 228.28
+   "compress_mbps": 1.63,
+   "decompress_mbps": 231.46
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 55.29,
-   "decompress_mbps": 212.22
+   "compress_mbps": 54.1,
+   "decompress_mbps": 211.59
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 50.49,
-   "decompress_mbps": 220.04
+   "compress_mbps": 49.52,
+   "decompress_mbps": 220.82
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 44.29,
-   "decompress_mbps": 231.24
+   "compress_mbps": 43.42,
+   "decompress_mbps": 229.54
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.96,
-   "decompress_mbps": 214.2
+   "compress_mbps": 31.59,
+   "decompress_mbps": 213.18
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.22,
-   "decompress_mbps": 210.64
+   "compress_mbps": 30.01,
+   "decompress_mbps": 210.22
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.55,
-   "decompress_mbps": 217.58
+   "compress_mbps": 27.19,
+   "decompress_mbps": 216.34
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 20.27,
-   "decompress_mbps": 221.35
+   "compress_mbps": 20.17,
+   "decompress_mbps": 219.72
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.08,
-   "decompress_mbps": 225.03
+   "compress_mbps": 8.12,
+   "decompress_mbps": 223.44
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 1.15,
-   "decompress_mbps": 233.49
+   "compress_mbps": 1.26,
+   "decompress_mbps": 233.75
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 138.14,
-   "decompress_mbps": 617.64
+   "compress_mbps": 134.78,
+   "decompress_mbps": 616.51
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 117.69,
-   "decompress_mbps": 690.74
+   "compress_mbps": 113.36,
+   "decompress_mbps": 687.31
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 98.6,
-   "decompress_mbps": 762.79
+   "compress_mbps": 98.15,
+   "decompress_mbps": 762.76
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 85.98,
-   "decompress_mbps": 773.34
+   "compress_mbps": 85.08,
+   "decompress_mbps": 747.53
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 83.03,
-   "decompress_mbps": 853.19
+   "compress_mbps": 82.49,
+   "decompress_mbps": 846.2
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 76.24,
-   "decompress_mbps": 910.62
+   "compress_mbps": 74.86,
+   "decompress_mbps": 902.75
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 43.09,
-   "decompress_mbps": 923.88
+   "compress_mbps": 42.64,
+   "decompress_mbps": 922.1
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.72,
-   "decompress_mbps": 914.54
+   "compress_mbps": 22.54,
+   "decompress_mbps": 903.63
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.8,
-   "decompress_mbps": 831.3
+   "compress_mbps": 0.89,
+   "decompress_mbps": 882.21
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 40.03,
-   "decompress_mbps": 134.67
+   "compress_mbps": 39.17,
+   "decompress_mbps": 131.95
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.32,
-   "decompress_mbps": 137.77
+   "compress_mbps": 38.14,
+   "decompress_mbps": 136.55
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 37.09,
-   "decompress_mbps": 142.02
+   "compress_mbps": 37.1,
+   "decompress_mbps": 140.32
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 30.9,
-   "decompress_mbps": 150.91
+   "compress_mbps": 30.38,
+   "decompress_mbps": 150.33
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 30.19,
-   "decompress_mbps": 156.41
+   "compress_mbps": 29.95,
+   "decompress_mbps": 155.7
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 29.15,
-   "decompress_mbps": 158.97
+   "compress_mbps": 28.79,
+   "decompress_mbps": 156.3
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 25.6,
-   "decompress_mbps": 159.22
+   "compress_mbps": 25.51,
+   "decompress_mbps": 155.89
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.9,
-   "decompress_mbps": 161.62
+   "compress_mbps": 6.82,
+   "decompress_mbps": 160.83
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 2.04,
-   "decompress_mbps": 166.83
+   "compress_mbps": 2.28,
+   "decompress_mbps": 161.36
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 57.9,
-   "decompress_mbps": 227.19
+   "compress_mbps": 56.32,
+   "decompress_mbps": 236.5
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 54.84,
-   "decompress_mbps": 233.67
+   "compress_mbps": 52.83,
+   "decompress_mbps": 245.48
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 53.27,
-   "decompress_mbps": 239.51
+   "compress_mbps": 52.31,
+   "decompress_mbps": 253.06
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 48.28,
-   "decompress_mbps": 249.64
+   "compress_mbps": 47.42,
+   "decompress_mbps": 261.01
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 47.86,
-   "decompress_mbps": 253.84
+   "compress_mbps": 46.83,
+   "decompress_mbps": 264.95
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 48.16,
-   "decompress_mbps": 262.75
+   "compress_mbps": 47.21,
+   "decompress_mbps": 258.13
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 44.94,
-   "decompress_mbps": 265.83
+   "compress_mbps": 44.24,
+   "decompress_mbps": 261.55
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.42,
-   "decompress_mbps": 279.27
+   "compress_mbps": 12.27,
+   "decompress_mbps": 273.33
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 2.33,
-   "decompress_mbps": 278.54
+   "compress_mbps": 2.7,
+   "decompress_mbps": 273.21
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 49.41,
-   "decompress_mbps": 231.9
+   "compress_mbps": 48.77,
+   "decompress_mbps": 231.07
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 43.99,
-   "decompress_mbps": 244.21
+   "compress_mbps": 43.47,
+   "decompress_mbps": 243.08
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 37.68,
-   "decompress_mbps": 278.48
+   "compress_mbps": 37.34,
+   "decompress_mbps": 276.1
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.83,
-   "decompress_mbps": 272.6
+   "compress_mbps": 26.55,
+   "decompress_mbps": 270.09
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 286.42
+   "compress_mbps": 24.46,
+   "decompress_mbps": 284.01
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.36,
-   "decompress_mbps": 287.61
+   "compress_mbps": 20.11,
+   "decompress_mbps": 282.6
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 13.16,
-   "decompress_mbps": 302.5
+   "compress_mbps": 13.02,
+   "decompress_mbps": 301.65
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.64,
-   "decompress_mbps": 299.88
+   "compress_mbps": 7.56,
+   "decompress_mbps": 292.39
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 0.99,
-   "decompress_mbps": 292.54
+   "compress_mbps": 1.14,
+   "decompress_mbps": 289.62
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 72.66,
-   "decompress_mbps": 305.35
+   "compress_mbps": 71.7,
+   "decompress_mbps": 303.43
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 65.82,
-   "decompress_mbps": 325.52
+   "compress_mbps": 64.43,
+   "decompress_mbps": 322.75
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 59.31,
-   "decompress_mbps": 339.2
+   "compress_mbps": 58.1,
+   "decompress_mbps": 336.85
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 48.72,
-   "decompress_mbps": 347.46
+   "compress_mbps": 48.52,
+   "decompress_mbps": 344.17
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 47.17,
-   "decompress_mbps": 357.3
+   "compress_mbps": 47.04,
+   "decompress_mbps": 354.7
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 43.95,
-   "decompress_mbps": 366.22
+   "compress_mbps": 43.81,
+   "decompress_mbps": 361.6
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 32.61,
-   "decompress_mbps": 367.52
+   "compress_mbps": 32.57,
+   "decompress_mbps": 361.9
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.77,
-   "decompress_mbps": 328.54
+   "compress_mbps": 12.83,
+   "decompress_mbps": 336.69
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5169629,
    "ratio": 0.2393,
-   "compress_mbps": 1.46,
-   "decompress_mbps": 369.73
+   "compress_mbps": 1.64,
+   "decompress_mbps": 361.43
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 35.7,
-   "decompress_mbps": 133.92
+   "compress_mbps": 34.52,
+   "decompress_mbps": 134.13
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 33.37,
-   "decompress_mbps": 135.31
+   "compress_mbps": 32.68,
+   "decompress_mbps": 134.68
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 31.46,
-   "decompress_mbps": 142.36
+   "compress_mbps": 31.0,
+   "decompress_mbps": 141.89
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 26.46,
-   "decompress_mbps": 143.78
+   "compress_mbps": 25.83,
+   "decompress_mbps": 144.02
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 25.86,
-   "decompress_mbps": 144.33
+   "compress_mbps": 25.34,
+   "decompress_mbps": 141.78
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 25.07,
-   "decompress_mbps": 143.42
+   "compress_mbps": 24.76,
+   "decompress_mbps": 143.17
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 23.99,
-   "decompress_mbps": 142.63
+   "compress_mbps": 23.49,
+   "decompress_mbps": 141.88
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.24,
-   "decompress_mbps": 146.57
+   "compress_mbps": 6.26,
+   "decompress_mbps": 145.86
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.34,
-   "decompress_mbps": 144.63
+   "compress_mbps": 2.6,
+   "decompress_mbps": 143.38
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 53.8,
-   "decompress_mbps": 231.58
+   "compress_mbps": 53.09,
+   "decompress_mbps": 229.8
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 49.2,
-   "decompress_mbps": 250.78
+   "compress_mbps": 48.01,
+   "decompress_mbps": 248.49
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 45.51,
-   "decompress_mbps": 269.98
+   "compress_mbps": 44.97,
+   "decompress_mbps": 267.59
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 36.89,
-   "decompress_mbps": 274.72
+   "compress_mbps": 36.65,
+   "decompress_mbps": 274.82
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 35.52,
-   "decompress_mbps": 279.41
+   "compress_mbps": 34.97,
+   "decompress_mbps": 278.7
   },
   {
    "compressor": "native",
@@ -4835,7 +4835,7 @@
    "out_size": 12184501,
    "ratio": 0.2939,
    "compress_mbps": 31.97,
-   "decompress_mbps": 286.54
+   "decompress_mbps": 286.61
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.65,
-   "decompress_mbps": 288.53
+   "compress_mbps": 24.54,
+   "decompress_mbps": 287.26
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.45,
-   "decompress_mbps": 291.01
+   "compress_mbps": 11.44,
+   "decompress_mbps": 288.01
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.38,
-   "decompress_mbps": 292.92
+   "compress_mbps": 1.6,
+   "decompress_mbps": 290.11
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 35.41,
-   "decompress_mbps": 130.02
+   "compress_mbps": 34.91,
+   "decompress_mbps": 128.68
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 35.12,
-   "decompress_mbps": 130.82
+   "compress_mbps": 35.06,
+   "decompress_mbps": 129.81
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 35.28,
-   "decompress_mbps": 132.98
+   "compress_mbps": 34.63,
+   "decompress_mbps": 131.85
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 32.95,
-   "decompress_mbps": 120.37
+   "compress_mbps": 32.91,
+   "decompress_mbps": 119.71
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.26,
-   "decompress_mbps": 121.58
+   "compress_mbps": 32.98,
+   "decompress_mbps": 121.67
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 121.86
+   "compress_mbps": 32.25,
+   "decompress_mbps": 122.06
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 33.06,
-   "decompress_mbps": 122.49
+   "compress_mbps": 32.62,
+   "decompress_mbps": 122.35
   },
   {
    "compressor": "native",
@@ -4945,7 +4945,7 @@
    "out_size": 6278507,
    "ratio": 0.7409,
    "compress_mbps": 4.74,
-   "decompress_mbps": 124.09
+   "decompress_mbps": 123.53
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.03,
-   "decompress_mbps": 123.94
+   "compress_mbps": 3.42,
+   "decompress_mbps": 124.58
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 109.05,
-   "decompress_mbps": 428.02
+   "compress_mbps": 106.02,
+   "decompress_mbps": 424.57
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 97.04,
-   "decompress_mbps": 486.52
+   "compress_mbps": 95.42,
+   "decompress_mbps": 481.81
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 85.79,
-   "decompress_mbps": 580.38
+   "compress_mbps": 84.48,
+   "decompress_mbps": 523.46
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 69.31,
-   "decompress_mbps": 573.26
+   "compress_mbps": 68.78,
+   "decompress_mbps": 521.72
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 66.69,
-   "decompress_mbps": 626.71
+   "compress_mbps": 66.0,
+   "decompress_mbps": 569.86
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 61.51,
-   "decompress_mbps": 678.73
+   "compress_mbps": 60.6,
+   "decompress_mbps": 629.92
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 41.29,
-   "decompress_mbps": 687.09
+   "compress_mbps": 40.71,
+   "decompress_mbps": 682.83
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.52,
-   "decompress_mbps": 695.51
+   "compress_mbps": 20.49,
+   "decompress_mbps": 610.52
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 637424,
    "ratio": 0.1192,
-   "compress_mbps": 1.01,
-   "decompress_mbps": 684.21
+   "compress_mbps": 1.17,
+   "decompress_mbps": 667.34
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR indexes directly into the covered length-code range of the L9 optimal parser's `scanBounds` instead of scanning all 29 entries of `Inflate.lengthBase` for every candidate. `lengthBase` is sorted ascending, so the boundaries that fall inside a candidate's interval `(prevLen, len)` form a contiguous slot range: a precomputed `lengthBoundaryStart[v]` gives the first slot whose base exceeds `v`, the scan starts there (dropping the now-redundant `prevLen < b` test, true for every slot by monotonicity), and stops as soon as `b ≥ len` (all later bases are larger). The DP's #1 sampled symbol from the [#2622](https://github.com/kim-em/lean-zip/issues/2622) profile now runs a few iterations per slot instead of 29.

Same boundaries, same order, same running arg-min as the full `0..28` scan, so `chLen`/`chDist` and the emitted bytes are unchanged. Verified byte-identical (size + CRC) across all 11 Canterbury files, and about 9% off the full `deflateRaw` level-9 path on the corpus (266 to 242 ms per round, stable across trials). This keeps the exact DP output and only stops scanning length codes that cannot qualify, so it carries zero ratio risk and fits the L9 ratio-priority constraint. It is orthogonal to and composes with [#2580](https://github.com/kim-em/lean-zip/issues/2580) (proven-bounds reads).

The code is heuristic (it never enters a correctness proof), so the gate is an identity test on the choice arrays rather than a theorem. A regression test pins `lengthBoundaryStart` against an independent first-exceeding-slot scan and asserts `lengthBase` is strictly ascending, so a future reorder cannot silently invalidate the monotonicity the optimization relies on.

Closes [#2641](https://github.com/kim-em/lean-zip/issues/2641).

🤖 Prepared with Claude Code