### PR TITLE
perf: respread the L4-L6 ladder, sweep libdeflate 1-12, record memcpy ceilings

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -50,7 +50,9 @@ optional nicety.
 
 The graphs show **native before vs after** on the real corpora (Canterbury +
 Silesia), overlaid on the existing other-language curves (zlib, miniz_oxide,
-libdeflate, Go, JS, Zig, OCaml) for context. The before/after **overlay** PNGs
+libdeflate, Go, JS, Zig, OCaml) for context. Native sweeps levels 1–9;
+`libdeflate` is swept 1–12 (its full range, the others cap at 9), so its
+curve carries the extra dense points 10–12. The before/after **overlay** PNGs
 (`$W/perf_before_after_*`) are a report artifact — NOT committed; they live
 only in the PR comment. The **dashboard** (`bench/results/latest.json` and the
 routine `bench/graphs/*.svg`), by contrast, **is** refreshed and committed inside

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -548,12 +548,16 @@ attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockByt
 /-- Hash-chain search depth per compression level (levels ≥ 5). Higher levels
     search deeper for longer matches (better ratio on diverse input) at higher
     cost; the `chainWalk` early-stop keeps repetitive input fast at any depth.
-    The ratio gain saturates around 256–512 (measured), so level 9 caps there. -/
+    The ratio gain saturates around 256–512 (measured), so level 9 caps there.
+
+    Level 4 uses depth 32 (was 48): with the graduated lazy-gate (see `goodMatch`)
+    it is the fast/loose anchor of the lazy tier, so a shallower chain there evens
+    the L3→L4→L5 ratio spread (#2710 D3). -/
 def chainDepth (level : UInt8) : Nat :=
   if level ≤ 1 then 8
   else if level ≤ 2 then 16
   else if level ≤ 3 then 32
-  else if level ≤ 4 then 48
+  else if level ≤ 4 then 32
   else if level ≤ 5 then 64
   else if level ≤ 6 then 128
   else if level ≤ 7 then 256
@@ -575,9 +579,19 @@ def insertCap (level : UInt8) : Nat :=
 /-- Lazy `good_match` threshold (zlib-style): the lazy matcher skips the
     one-byte-lookahead probe once the first match is at least this long, since a
     long first match is rarely improved by deferral. Lower → more gating (faster,
-    slightly worse ratio). `259 > 258` disables gating. SPIKE: uniform 8. -/
+    slightly worse ratio); `259 > 258` disables gating.
+
+    Graduated across the lazy tier (#2710) to de-bunch L4/5/6: at uniform `8` the
+    gate fired so eagerly that the chain-depth ladder (48/64/128) barely moved the
+    ratio, so the three levels clustered on the Pareto. Raising the threshold up
+    the ladder lets the one-byte lookahead (and the deeper chain) actually run, so
+    L5/L6 trade speed for ratio and spread apart; L7+ stays ungated (the top
+    single-block point). A pure heuristic — every `goodMatch` keeps the matcher
+    contracts (`lz77ChainLazyIter_resolves` holds ∀ goodMatch). -/
 def goodMatch (level : UInt8) : Nat :=
-  if level ≤ 6 then 8
+  if level ≤ 4 then 8
+  else if level ≤ 5 then 16
+  else if level ≤ 6 then 64
   else 259
 
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -135,6 +135,12 @@ def Row.toJson (r : Row) : String :=
 /-! ## Matrix -/
 
 def levels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+/-- libdeflate's full level range. Unlike zlib/miniz/native (capped at 9),
+    libdeflate exposes 1–12, and its densest points (10–12) are exactly the
+    ones the comparison Pareto needs from it — so it is swept to 12 here while
+    every other codec stays on the shared `levels`. -/
+def libdeflateLevels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 def reps : Nat := 5
 
 /-- Run one compressor over a list of `(pattern, bytes)` workloads × levels,
@@ -155,11 +161,15 @@ def runWorkloads
       let ratio := outSize.toFloat / (max size 1).toFloat
       let cNs ← measureNs size theReps (compress data level >>= sink)
       -- Decompress timing uses a canonical zlib-FFI raw-deflate stream so all
-      -- decoders are measured on identical, format-correct input.
+      -- decoders are measured on identical, format-correct input. The reference
+      -- encoder is zlib, whose `deflateInit2` only accepts levels 0–9, so the
+      -- level is clamped here: the stream is only a fixed decode workload (its
+      -- density barely shifts past L9), and libdeflate's extended levels 10–12
+      -- would otherwise crash this path with a `deflateInit2: stream error`.
       let dMBps ← match decompress? with
         | none => pure none
         | some dec => do
-          let ref ← RawDeflate.compress data level.toUInt8
+          let ref ← RawDeflate.compress data (min level 9).toUInt8
           -- The decompressed size is known here; pass it so the native decoder
           -- pre-sizes its output buffer, matching the production ZIP/gzip path
           -- where the uncompressed size comes from the archive metadata. The FFI
@@ -257,7 +267,11 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
     else
       let cz ← runWorkloads "zlib"        files zlibCompress       (some fun d _ => RawDeflate.decompress d) (theLevels := lvls) (theReps := rps)
       let cm ← runWorkloads "miniz_oxide" files minizCompress      (some fun d _ => MinizOxide.decompress d) (theLevels := lvls) (theReps := rps)
-      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some fun d _ => Libdeflate.decompress d) (theLevels := lvls) (theReps := rps)
+      -- libdeflate sweeps 1–12 (its full range); the others cap at 9. A level
+      -- override (the native-only dashboard regen) is for the Lean codec, so
+      -- libdeflate keeps its own full list unless that override is in effect.
+      let llvls := match levelOverride with | some ls => ls | none => libdeflateLevels
+      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some fun d _ => Libdeflate.decompress d) (theLevels := llvls) (theReps := rps)
       rows := rows ++ cn ++ cz ++ cm ++ cl
 
   let date ← shell "date" ["-u", "+%Y-%m-%dT%H:%M:%SZ"]

--- a/bench/README.md
+++ b/bench/README.md
@@ -32,7 +32,7 @@ implementations (no SIMD/asm, or GC'd, or JIT'd) — not just the C + SIMD ceili
 | `native` | lean-zip pure-Lean DEFLATE | the thing we are improving |
 | `zlib` | system zlib (FFI) | the ubiquitous baseline |
 | `miniz_oxide` | Rust miniz_oxide (FFI) | widely-used Rust reimplementation |
-| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar |
+| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar; swept over its full **levels 1–12** (the others cap at 9), so its densest points (10–12) appear on the Pareto |
 | `zopfli` | zopfli (FFI) | maximum-ratio ceiling — **frozen** (see below); never in the routine matrix |
 
 **Language-native peers** (each a self-verifying CLI under
@@ -66,7 +66,8 @@ whose toolchain is unavailable is skipped, so the dashboard degrades gracefully.
 
 ## Workloads
 
-The **real compression corpora** from the literature, swept over levels 1–9.
+The **real compression corpora** from the literature, swept over levels 1–9
+(`libdeflate` over its full 1–12 — see *Compressors compared*).
 Each corpus is a subdirectory of [`corpora/`](corpora); every file in it is one
 single-size workload tagged `<corpus>/<file>`, and the harness discovers corpora
 by directory (nothing hard-codes Canterbury — a new corpus slots in once its
@@ -112,14 +113,14 @@ complements give precise numbers and per-file detail:
 - `<corpus>_ratio_heatmap.svg` / `_compress_heatmap.svg` — per file, relative to
   zlib (red = worse), showing *where* a codec wins or loses without 100 bars.
 
-### Canterbury corpus (11 small files, levels 1–9)
+### Canterbury corpus (11 small files, levels 1–9; libdeflate 1–12)
 
 ![canterbury compression speed vs ratio](graphs/canterbury_compress_pareto.svg)
 ![canterbury summary table](graphs/canterbury_summary.svg)
 ![canterbury ratio vs zlib per file](graphs/canterbury_ratio_heatmap.svg)
 ![canterbury compress speed vs zlib per file](graphs/canterbury_compress_heatmap.svg)
 
-### Silesia corpus (12 large files, levels 1/6/9)
+### Silesia corpus (12 large files, levels 1–9; libdeflate 1–12)
 
 ![silesia compression speed vs ratio](graphs/silesia_compress_pareto.svg)
 ![silesia decode throughput vs input density](graphs/silesia_decode_density.svg)
@@ -127,6 +128,36 @@ complements give precise numbers and per-file detail:
 ![silesia summary table](graphs/silesia_summary.svg)
 ![silesia ratio vs zlib per file](graphs/silesia_ratio_heatmap.svg)
 ![silesia compress speed vs zlib per file](graphs/silesia_compress_heatmap.svg)
+
+### Memory-bandwidth ceilings (recorded, not plotted)
+
+The two `memcpy`-class anchors bound what any DEFLATE codec could ever reach;
+both are **recorded here and deliberately kept off the Pareto** (each blows out a
+log axis by orders of magnitude):
+
+- **Compress ceiling ≈ 8.4 GB/s** — `deflateStored` (level 0: no match, no
+  Huffman) over Silesia, ratio 1.0. The compress fast-end anchor.
+- **Decode ceiling ≈ 40 GB/s** — output-side `memcpy` over Silesia (the decode
+  charts carry the per-corpus value as their top band).
+
+The gap from the level-0 compress ceiling (~8400 MB/s) to native level 1 (~51
+MB/s in the packed production path) is **~160×**, and it lives almost entirely in
+the **encode path** (Huffman sizing + token emit), not the matcher: a level-1
+knob sweep over the *boxed harness* path (a slower path used only for the sweep —
+hence its lower absolute ~27→30 MB/s) showed total throughput essentially flat as
+the hash-chain shallowed from depth 16 to 1, while ratio worsened. Match is not
+the wall; the encode path is.
+
+A natural follow-up — making level 1 a **fixed-Huffman-only fast emit** (skip the
+dynamic-tree construction) — was measured and *rejected*: in the packed
+production path it is a Pareto **regression on Silesia** (paired, same machine:
+~0.86–0.92× the speed at ratio 0.40–0.44 vs 0.347). This is consistent with the
+fixed block being looser, so the extra output bytes it writes cost more than the
+dynamic tree it skips — large files are emit-bound on *bytes written*, and the
+dynamic block is both tighter and faster there. (The win flips on small files —
+Canterbury +30–40% — where the dynamic-tree construction is a larger fraction of
+the work.) So a real fast-L1 corner needs a genuinely faster per-byte emit (a
+faster `BitWriter`), not a different block type; that is left as future work.
 
 ## Decoding (decode-density)
 

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p52ac0cfe24)">
+   <g clip-path="url(#pa0f7468ef2)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image042e0e9f3c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDklEQVR4nO3YzYrk5RmH4a7+8oNmHMFRM4uEiEfgTnDv3iPxADyLnEJCVtllEeI6G89AiRgkjB80PaPOtDU91VXZuTfcLw8213UEP/gXb908m/0Pfz0c8dvy/Hp6wTrbH6cXLHHY3UxPWGZz8cb0hDVeenV6wTqb4+kFa7zYTi9Y545+s8PVf6cnLHM3vxgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO/16czW9YYnnt9fTE5b53WvvTE9Y5uLem9MTlthcP5mesMy/fv58esISD88fTE9YZre/mZ6wxNPddnrCMtvbF9MTlnj/3h+mJyzjggUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxzY/P/3aYHrHCz7un0xOWebB/dXrCOrub6QVrPLuaXrDOm+9OL1ji6eF6esIyd/V9fHC4mJ6wzKOju/mGPLx8Mj1hGRcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiJ1ePL6c3rDExen59IR1tt9OL1jmcP3T9IQ19vvpBctsXvl+esISF2cvT09Y5uLs/vSENU7u7rv/cLubnrDE4fqb6QnLuGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMROD5ffTm8AfsMO3/xnesIax5vpBfxa+8P0AviFCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDETj++/Hp6wxJPtrfTE5b57NFP0xOW+ftHH0xPWOKtV34/PWGZ9/78l+kJS3z4zuvTE5b58vF2egK/0j/++e/pCUtc/+mT6QnLuGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbLPbf3qYHrHC7X43PYH/w9nz7fSENU5Opxes8+xqesESt/ffnp6wzP6wn56wxNnx+fSEZW72d/NtPN/dzd/i0ZELFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMROj1/cTG9Y4vjs5ekJ63z3xfSCZQ7PnkxPWGN3O71gmc1bf5yesMTJfnrBOicn59MT1nh2Nb1gmfPd3fyvPnz31fSEZVywAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPY/H6SJArqNPQYAAAAASUVORK5CYII=" id="image36ff921109" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2242ed6f90" d="M 0 0 
+       <path id="mf8c81c3ecd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2242ed6f90" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2242ed6f90" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2242ed6f90" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2242ed6f90" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2242ed6f90" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2242ed6f90" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2242ed6f90" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2242ed6f90" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2242ed6f90" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2242ed6f90" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2242ed6f90" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf8c81c3ecd" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m701f343775" d="M 0 0 
+       <path id="maf1b86608b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maf1b86608b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,8 +1303,37 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
+    <!-- -14 -->
+    <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
     <!-- -3 -->
-    <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1343,52 +1372,49 @@ z
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- +4 -->
-    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -61 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -58 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -87 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1429,16 +1455,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -87 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1464,72 +1480,58 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +6 -->
-    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+    <!-- -40 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -8 -->
+    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +2 -->
+    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +0 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +7 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -16 -->
+    <!-- -30 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -36 -->
+    <!-- -39 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1556,18 +1558,19 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- +9 -->
-    <g transform="translate(189.012035 104.25537) scale(0.065 -0.065)">
+    <!-- +11 -->
+    <g transform="translate(186.944223 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- -24 -->
+    <!-- -25 -->
     <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_35">
@@ -1579,83 +1582,84 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- -46 -->
+    <!-- -45 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- +6 -->
+    <!-- +7 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +9 -->
-    <g transform="translate(385.266027 104.25537) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -4 -->
+    <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- +12 -->
+    <!-- +14 -->
     <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- -17 -->
+    <!-- -18 -->
     <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- +229 -->
+    <!-- +230 -->
     <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- +249 -->
+    <!-- +248 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +303 -->
+    <!-- +305 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +74 -->
+    <!-- +73 -->
     <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
@@ -1676,39 +1680,39 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +230 -->
+    <!-- +235 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +267 -->
+    <!-- +272 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +267 -->
+    <!-- +271 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +394 -->
+    <!-- +402 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1862,35 +1866,35 @@ z
     </g>
    </g>
    <g id="text_70">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(345.498276 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- -22 -->
+    <!-- -21 -->
     <g transform="translate(384.749074 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_72">
-    <!-- -11 -->
-    <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_72">
+    <!-- -10 -->
+    <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_73">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(463.250671 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_74">
@@ -1918,11 +1922,11 @@ z
     </g>
    </g>
    <g id="text_77">
-    <!-- -30 -->
+    <!-- -29 -->
     <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_78">
@@ -1950,35 +1954,35 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +25 -->
+    <!-- +26 -->
     <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_82">
-    <!-- +46 -->
-    <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_82">
+    <!-- +47 -->
+    <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_83">
-    <!-- -27 -->
+    <!-- -26 -->
     <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- +54 -->
+    <!-- +56 -->
     <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_85">
@@ -2006,11 +2010,11 @@ z
     </g>
    </g>
    <g id="text_88">
-    <!-- +26 -->
+    <!-- +28 -->
     <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_89">
@@ -2039,36 +2043,37 @@ z
     </g>
    </g>
    <g id="text_92">
-    <!-- +68 -->
+    <!-- +69 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- +77 -->
+    <!-- +79 -->
     <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- +97 -->
-    <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_95">
-    <!-- +107 -->
-    <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
+    <!-- +100 -->
+    <g transform="translate(420.381201 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_95">
+    <!-- +110 -->
+    <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_96">
@@ -2080,11 +2085,11 @@ z
     </g>
    </g>
    <g id="text_97">
-    <!-- -36 -->
+    <!-- -37 -->
     <g transform="translate(109.993485 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
@@ -2096,19 +2101,19 @@ z
     </g>
    </g>
    <g id="text_99">
-    <!-- -54 -->
+    <!-- -53 -->
     <g transform="translate(188.495082 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
-    <!-- -74 -->
+    <!-- -75 -->
     <g transform="translate(227.74588 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_101">
@@ -2128,35 +2133,35 @@ z
     </g>
    </g>
    <g id="text_103">
-    <!-- -37 -->
+    <!-- -36 -->
     <g transform="translate(345.498276 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_104">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(384.749074 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_105">
-    <!-- -47 -->
+    <!-- -46 -->
     <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
-    <!-- -43 -->
+    <!-- -42 -->
     <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
@@ -2178,23 +2183,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageaa5f87d647" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image23f4658c42" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mba761233e2" d="M 0 0 
+       <path id="m2bf9556398" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="303.41775" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
-      <!-- −3 -->
-      <g transform="translate(554.779688 280.800792) scale(0.1 -0.1)">
+      <!-- −4 -->
+      <g transform="translate(554.779688 307.216968) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2205,91 +2210,118 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="275.273038" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
-      <!-- −2 -->
-      <g transform="translate(554.779688 252.079903) scale(0.1 -0.1)">
+      <!-- −3 -->
+      <g transform="translate(554.779688 279.072257) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="247.128327" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
-      <!-- −1 -->
-      <g transform="translate(554.779688 223.359013) scale(0.1 -0.1)">
+      <!-- −2 -->
+      <g transform="translate(554.779688 250.927546) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="218.983616" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
-      <!-- 0 -->
-      <g transform="translate(554.779688 194.638123) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
+      <!-- −1 -->
+      <g transform="translate(554.779688 222.782835) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
-      <!-- 1 -->
-      <g transform="translate(554.779688 165.917234) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
+      <!-- 0 -->
+      <g transform="translate(554.779688 194.638123) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="162.694193" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
-      <!-- 2 -->
-      <g transform="translate(554.779688 137.196344) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
+      <!-- 1 -->
+      <g transform="translate(554.779688 166.493412) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="134.549482" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
+      <!-- 2 -->
+      <g transform="translate(554.779688 138.348701) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="106.404771" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_115">
       <!-- 3 -->
-      <g transform="translate(554.779688 108.475455) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 110.20399) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
     </g>
-    <g id="text_115">
+    <g id="ytick_17">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m2bf9556398" x="547.779688" y="78.26006" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_116">
+      <!-- 4 -->
+      <g transform="translate(554.779688 82.059278) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_117">
      <!-- % vs zlib (higher=faster) -->
      <g transform="translate(581.120313 253.142811) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2395,7 +2427,7 @@ z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_116">
+  <g id="text_118">
    <!-- Compression speed vs zlib  (canterbury, level 6, relative to zlib) -->
    <g transform="translate(80.680313 17.182125) scale(0.12 -0.12)">
     <defs>
@@ -2939,9 +2971,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3559.632812 0)"/>
    </g>
   </g>
-  <g id="text_117">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
+  <g id="text_119">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(174.361641 393.150844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2983,21 +3015,6 @@ L 628 0
 L 628 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-32"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
@@ -3010,14 +3027,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3073,129 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(141.708281 401.184) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p52ac0cfe24">
+  <clipPath id="pa0f7468ef2">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m028c07a5d8" d="M 0 0 
+       <path id="m0c853b0ea9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m028c07a5d8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m028c07a5d8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m028c07a5d8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m028c07a5d8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m028c07a5d8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m028c07a5d8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m028c07a5d8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0c853b0ea9" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.796763 
-L 637.2 347.796763 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.794125 
+L 637.2 347.794125 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdd29712582" d="M 0 0 
+       <path id="m5bc24d26dd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bc24d26dd" x="49.078125" y="347.794125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.595982) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.593344) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.680056 
-L 637.2 238.680056 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.671475 
+L 637.2 238.671475 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bc24d26dd" x="49.078125" y="238.671475" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.479274) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.470693) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.680056
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.563348 
-L 637.2 129.563348 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.548824 
+L 637.2 129.548824 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5bc24d26dd" x="49.078125" y="129.548824" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.362567) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.348043) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.563348
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.851571 
-L 637.2 404.851571 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.85204 
+L 637.2 404.85204 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0adb36bd3e" d="M 0 0 
+       <path id="m4211cee7eb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="404.85204" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.218667 
-L 637.2 391.218667 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.218394 
+L 637.2 391.218394 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="391.218394" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.644165 
-L 637.2 380.644165 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.643316 
+L 637.2 380.643316 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="380.643316" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 372.004168 
-L 637.2 372.004168 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 372.002849 
+L 637.2 372.002849 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="372.002849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.699155 
-L 637.2 364.699155 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.697438 
+L 637.2 364.697438 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="364.697438" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.371265 
-L 637.2 358.371265 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.369203 
+L 637.2 358.369203 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="358.369203" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.78967 
-L 637.2 352.78967 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.787304 
+L 637.2 352.787304 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="352.787304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.949361 
-L 637.2 314.949361 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.944934 
+L 637.2 314.944934 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="314.944934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.734863 
-L 637.2 295.734863 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.729389 
+L 637.2 295.729389 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="295.729389" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.101959 
-L 637.2 282.101959 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.095743 
+L 637.2 282.095743 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="282.095743" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.527458 
-L 637.2 271.527458 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.520666 
+L 637.2 271.520666 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="271.520666" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.887461 
-L 637.2 262.887461 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.880198 
+L 637.2 262.880198 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="262.880198" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.582447 
-L 637.2 255.582447 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.574787 
+L 637.2 255.574787 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="255.574787" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.254557 
-L 637.2 249.254557 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.246552 
+L 637.2 249.246552 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="249.246552" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.672962 
-L 637.2 243.672962 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.664653 
+L 637.2 243.664653 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="243.664653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.832653 
-L 637.2 205.832653 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.822283 
+L 637.2 205.822283 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="205.822283" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.618155 
-L 637.2 186.618155 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.606739 
+L 637.2 186.606739 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="186.606739" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 172.985251 
-L 637.2 172.985251 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.973092 
+L 637.2 172.973092 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="172.973092" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.41075 
-L 637.2 162.41075 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.398015 
+L 637.2 162.398015 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="162.398015" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.770753 
-L 637.2 153.770753 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.757548 
+L 637.2 153.757548 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="153.757548" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.46574 
-L 637.2 146.46574 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.452136 
+L 637.2 146.452136 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="146.452136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.137849 
-L 637.2 140.137849 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.123901 
+L 637.2 140.123901 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="140.123901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.556255 
-L 637.2 134.556255 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.542003 
+L 637.2 134.542003 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="134.542003" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.715946 
-L 637.2 96.715946 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.699633 
+L 637.2 96.699633 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="96.699633" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.501447 
-L 637.2 77.501447 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.484088 
+L 637.2 77.484088 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="77.484088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.868544 
-L 637.2 63.868544 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.850442 
+L 637.2 63.850442 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="63.850442" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.294042 
-L 637.2 53.294042 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.275364 
+L 637.2 53.275364 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4211cee7eb" x="49.078125" y="53.275364" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 175.671124) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 174.658925) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.82831) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 314.062955) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,130 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.25942 
-L 308.273931 102.64095 
-L 271.230161 116.240058 
-L 217.83458 119.978674 
-L 177.077692 138.359262 
-L 162.880539 157.659557 
-L 160.741445 165.081439 
-L 153.966678 183.30847 
-L 151.589614 194.354473 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.313493 
+L 308.273931 102.421091 
+L 271.230161 116.327394 
+L 217.83458 120.382973 
+L 177.077692 138.617204 
+L 162.880539 157.853373 
+L 160.741445 165.206651 
+L 153.966678 183.421601 
+L 151.589614 194.547792 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m63cc0edae1" d="M -2.5 2.5 
+     <path id="m950ec8fc50" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m63cc0edae1" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m950ec8fc50" x="355.479835" y="95.313493" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="308.273931" y="102.421091" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="271.230161" y="116.327394" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="217.83458" y="120.382973" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="177.077692" y="138.617204" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="162.880539" y="157.853373" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="160.741445" y="165.206651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="153.966678" y="183.421601" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m950ec8fc50" x="151.589614" y="194.547792" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 75.906758 
-L 283.721324 98.757435 
-L 218.882044 120.902897 
-L 187.447228 126.710903 
-L 176.342474 138.212475 
-L 163.054314 161.207386 
-L 162.210539 168.678909 
-L 159.303811 175.634901 
-L 157.793928 179.408171 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 75.923437 
+L 283.721324 98.712758 
+L 218.882044 120.84103 
+L 187.447228 126.722619 
+L 176.342474 138.141105 
+L 163.054314 161.210403 
+L 162.210539 168.642341 
+L 159.303811 175.65043 
+L 157.793928 179.428978 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb1e1c390ab" d="M 0 -2.5 
+     <path id="md6f7f9792b" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#mb1e1c390ab" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#md6f7f9792b" x="531.649087" y="75.923437" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="283.721324" y="98.712758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="218.882044" y="120.84103" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="187.447228" y="126.722619" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="176.342474" y="138.141105" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="163.054314" y="161.210403" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="162.210539" y="168.642341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="159.303811" y="175.65043" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md6f7f9792b" x="157.793928" y="179.428978" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 81.892474 
-L 186.982691 88.798621 
-L 179.779306 91.094902 
-L 157.610419 99.337194 
-L 148.722526 107.793132 
-L 144.388162 121.197738 
-L 127.071247 144.456083 
-L 124.491988 152.059912 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 81.977303 
+L 186.982691 88.569521 
+L 179.779306 91.060549 
+L 157.610419 99.274769 
+L 148.722526 107.725256 
+L 144.388162 121.180806 
+L 127.071247 144.493165 
+L 124.491988 152.19846 
+L 92.613662 207.445032 
+L 87.348715 224.975665 
+L 86.053433 241.552789 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma56d26ecf0" d="M -0 3.535534 
+     <path id="m4904c88f62" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#ma56d26ecf0" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m4904c88f62" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="203.775848" y="81.977303" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="186.982691" y="88.569521" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="179.779306" y="91.060549" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="157.610419" y="99.274769" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="148.722526" y="107.725256" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="144.388162" y="121.180806" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="127.071247" y="144.493165" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="124.491988" y="152.19846" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="92.613662" y="207.445032" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="87.348715" y="224.975665" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4904c88f62" x="86.053433" y="241.552789" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9e2024cbe2" d="M -0 2.5 
+     <path id="mfb57a2d64b" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m9e2024cbe2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#mfb57a2d64b" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 178.157653 
-L 278.798176 181.06557 
-L 251.17632 188.680634 
-L 200.806828 186.322161 
-L 169.803221 202.757761 
-L 161.916638 211.158991 
-L 158.697104 214.041592 
-L 154.26679 230.364582 
-L 153.096464 236.337782 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 178.145776 
+L 278.798176 181.053852 
+L 251.17632 188.66933 
+L 200.806828 186.310728 
+L 169.803221 202.747223 
+L 161.916638 211.148911 
+L 158.697104 214.031669 
+L 154.26679 230.355548 
+L 153.096464 236.329074 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m194df667a0" d="M -0.833333 2.5 
+     <path id="mfc37a279a4" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1877,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m194df667a0" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#mfc37a279a4" x="362.865999" y="178.145776" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="278.798176" y="181.053852" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="251.17632" y="188.66933" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="200.806828" y="186.310728" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="169.803221" y="202.747223" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="161.916638" y="211.148911" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="158.697104" y="214.031669" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="154.26679" y="230.355548" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc37a279a4" x="153.096464" y="236.329074" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 144.650944 
-L 250.236474 147.192871 
-L 225.418659 152.799409 
-L 212.328936 158.91628 
-L 209.030149 156.82091 
-L 197.547749 167.982576 
-L 194.819287 169.49094 
-L 193.12279 177.004847 
-L 192.79794 181.853352 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 144.637242 
+L 250.236474 147.179307 
+L 225.418659 152.78615 
+L 212.328936 158.903355 
+L 209.030149 156.807871 
+L 197.547749 167.970144 
+L 194.819287 169.478591 
+L 193.12279 176.992907 
+L 192.79794 181.841676 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0a2eda9a0c" d="M -1.25 2.5 
+     <path id="m123b1ca1c1" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1916,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m0a2eda9a0c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m123b1ca1c1" x="301.619021" y="144.637242" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="250.236474" y="147.179307" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="225.418659" y="152.78615" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="212.328936" y="158.903355" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="209.030149" y="156.807871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="197.547749" y="167.970144" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="194.819287" y="169.478591" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="193.12279" y="176.992907" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m123b1ca1c1" x="192.79794" y="181.841676" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.264704 
-L 206.45578 117.943158 
-L 206.45578 118.023409 
-L 206.45578 118.008666 
-L 171.767499 133.507746 
-L 163.54283 144.396316 
-L 160.174881 150.295858 
-L 154.179217 168.595905 
-L 152.4406 178.324207 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.249565 
+L 206.45578 117.928001 
+L 206.45578 118.008257 
+L 206.45578 117.993513 
+L 171.767499 133.493437 
+L 163.54283 144.3826 
+L 160.174881 150.282463 
+L 154.179217 168.583507 
+L 152.4406 178.312339 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6e7b3d869c" d="M 0 -2.5 
+     <path id="m71a9579f5a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1953,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m71a9579f5a" x="206.45578" y="118.249565" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="206.45578" y="117.928001" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="206.45578" y="118.008257" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="206.45578" y="117.993513" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="171.767499" y="133.493437" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="163.54283" y="144.3826" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="160.174881" y="150.282463" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="154.179217" y="168.583507" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m71a9579f5a" x="152.4406" y="178.312339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 173.595159 
-L 592.067397 175.027997 
-L 534.807821 181.390376 
-L 327.802209 176.703263 
-L 275.83761 187.043834 
-L 258.25125 199.15685 
-L 256.777056 204.107569 
-L 248.769854 218.250617 
-L 246.264594 228.00198 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 173.583033 
+L 592.067397 175.015949 
+L 534.807821 181.378674 
+L 327.802209 176.691306 
+L 275.83761 187.032441 
+L 258.25125 199.146116 
+L 256.777056 204.097105 
+L 248.769854 218.240923 
+L 246.264594 227.992817 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me64a5284fe" d="M 0 -2.5 
+     <path id="m34ea5b1d67" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1986,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#me64a5284fe" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m34ea5b1d67" x="610.467188" y="173.583033" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="592.067397" y="175.015949" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="534.807821" y="181.378674" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="327.802209" y="176.691306" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="275.83761" y="187.032441" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="258.25125" y="199.146116" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="256.777056" y="204.097105" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="248.769854" y="218.240923" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m34ea5b1d67" x="246.264594" y="227.992817" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2018,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m357f16c205" d="M 0 3.5 
+      <path id="m2dc9e45807" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2031,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m357f16c205" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m2dc9e45807" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2094,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m63cc0edae1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m950ec8fc50" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2112,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb1e1c390ab" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md6f7f9792b" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2161,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma56d26ecf0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4904c88f62" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2208,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9e2024cbe2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfb57a2d64b" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2228,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m194df667a0" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfc37a279a4" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2286,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0a2eda9a0c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m123b1ca1c1" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2355,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6e7b3d869c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m71a9579f5a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2397,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me64a5284fe" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m34ea5b1d67" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2467,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 180.671124 
-L 214.084819 183.545645 
-L 206.266533 185.976577 
-L 187.75787 192.485037 
-L 186.58897 193.499057 
-L 184.505355 195.842174 
-L 164.72409 207.184059 
-L 150.950891 251.782768 
-L 98.348822 318.82831 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m357f16c205" x="226.647908" y="180.671124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="214.084819" y="183.545645" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="206.266533" y="185.976577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="187.75787" y="192.485037" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="186.58897" y="193.499057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="184.505355" y="195.842174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="164.72409" y="207.184059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="150.950891" y="251.782768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="98.348822" y="318.82831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 179.658925 
+L 214.084819 182.188231 
+L 206.266533 184.607719 
+L 189.843461 189.996097 
+L 173.124337 196.623807 
+L 168.540542 201.480702 
+L 164.72409 206.24033 
+L 150.950891 250.946401 
+L 98.348822 319.062955 
+" clip-path="url(#p53831f4806)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p53831f4806)">
+     <use xlink:href="#m2dc9e45807" x="226.647908" y="179.658925" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="214.084819" y="182.188231" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="206.266533" y="184.607719" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="189.843461" y="189.996097" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="173.124337" y="196.623807" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="168.540542" y="201.480702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="164.72409" y="206.24033" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="150.950891" y="250.946401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2dc9e45807" x="98.348822" y="319.062955" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2897,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(201.361641 457.626844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,16 +2909,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2926,6 +2922,61 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2985,59 +3036,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3d" d="M 678 2906 
-L 4684 2906 
-L 4684 2381 
-L 678 2381 
-L 678 2906 
-z
-M 678 1631 
-L 4684 1631 
-L 4684 1100 
-L 678 1100 
-L 678 1631 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-32"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
@@ -3050,14 +3048,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3096,109 +3094,142 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(168.708281 465.66) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd383cd252b">
+  <clipPath id="p53831f4806">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p346f9e4456)">
+   <g clip-path="url(#p102095f8e5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagee78e607fec" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/ElEQVR4nO3YwYqkVx2H4aqe7qYnwQFlEkPcBdxJUHDjbMRl7iRXkGXI3utQb0AQkWQTFDdugjtxJyGEzBgnM0N3T/VXuYQxcOQv9T7PFfwOH3Xq5ey3f//muDs1z76aXrDU8fFpnWe32+3+9cHvpycs9c/Pnk9PWO6Xv31vesJy+5/+fHrCWvuz6QXrPf1iesF6Vw+mFyz1ux/+enrCcif4SwIA+O+JIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP3N4Q/H6RGrHXfb9ISl9ifYrBdnl9MTlrrdrqcnLHfx979OT1ju8JNH0xOWOmy30xOWe354Oj1huYcndj28fPBwesJyp/cvCwDwHYghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC084vnX09vWO/mxfSCtY7b9IL17j+YXrDU5fSA/4Hj0+fTE5a7+ObJ9ISlLrbD9ITl7p/ifXf9bHrBUhfnp3fjeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v6w/ek4PWK143GbnrDUdmLn2e12u4uzy+kJS90dD9MTlrv37Mn0hPW+9+b0gqVebrfTE5Z7fP359ITl3ro5n56w1Pb9t6cnLOdlCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO//bl3+e3rDc2W4/PWGpN157OD1hubvtMD1hqct7V9MTlnv/k0+nJyz30S9+PD1hqcNxm56w3Id/+cf0hOUevf369ISl3n/30fSE5bwMAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIG3/8u6Px+kRq93eXU9PWOr+/mp6Aq9wuz9MT1juPzdfTU9Y7gdXb01PWGo7btMTlvv65svpCcs9ufliesJS7zx4d3rCcl6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkLbfto+P0yOA/0OH2+kF651fTi/gFa7vXkxPWO7q3mvTE3gFL0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO58ewKttu216wnJnd6d1ppf70zrPbrfbnX/26fSE5fY/+9X0hKW2/fSC9R5ffz49YbkfvTixd4c33plesNyJfSEAgO9GDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApH0LwRGJOifp+JcAAAAASUVORK5CYII=" id="imagebeb160b552" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me9209b34ad" d="M 0 0 
+       <path id="m2d887defe5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9209b34ad" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me9209b34ad" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me9209b34ad" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me9209b34ad" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me9209b34ad" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me9209b34ad" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me9209b34ad" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me9209b34ad" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me9209b34ad" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me9209b34ad" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me9209b34ad" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d887defe5" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mbb3720818b" d="M 0 0 
+       <path id="m9fef2fd501" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fef2fd501" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1341,37 +1341,56 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -0 -->
+    <!-- -1 -->
     <g transform="translate(262.85143 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +17 -->
-    <g transform="translate(297.102876 68.904519) scale(0.065 -0.065)">
+    <!-- +6 -->
+    <g transform="translate(299.170688 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1389,15 +1408,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -2 -->
+    <!-- -3 -->
     <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +3 -->
-    <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1432,15 +1444,22 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +3 -->
+    <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- +0 -->
-    <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(490.072138 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1671,38 +1690,6 @@ z
    <g id="text_60">
     <!-- -6 -->
     <g transform="translate(376.461784 174.957073) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
     </g>
@@ -1845,6 +1832,18 @@ z
    <g id="text_80">
     <!-- +7 -->
     <g transform="translate(299.170688 245.658775) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2093,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagef52552f2f6" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0ba2301c0e" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="ma9a7d59937" d="M 0 0 
+       <path id="m7d88aec881" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d88aec881" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(174.361641 393.150844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2926,21 +2925,6 @@ L 628 0
 L 628 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-32"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
@@ -2953,14 +2937,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2983,129 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(141.708281 401.184) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p346f9e4456">
+  <clipPath id="p102095f8e5">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432.9pt" height="386.007781pt" viewBox="0 0 432.9 386.007781" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,233 +21,233 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 386.202469 
-L 570.708594 386.202469 
-L 570.708594 0 
+   <path d="M 0 386.007781 
+L 432.9 386.007781 
+L 432.9 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.479297 104.1264 
-L 292.104297 104.1264 
-L 292.104297 74.7432 
-L 187.479297 74.7432 
+    <path d="M 111.825 104.1264 
+L 216.45 104.1264 
+L 216.45 74.7432 
+L 111.825 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.104297 104.1264 
-L 396.729297 104.1264 
-L 396.729297 74.7432 
-L 292.104297 74.7432 
+    <path d="M 216.45 104.1264 
+L 321.075 104.1264 
+L 321.075 74.7432 
+L 216.45 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.729297 104.1264 
-L 501.354297 104.1264 
-L 501.354297 74.7432 
-L 396.729297 74.7432 
+    <path d="M 321.075 104.1264 
+L 425.7 104.1264 
+L 425.7 74.7432 
+L 321.075 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.479297 133.5096 
-L 292.104297 133.5096 
-L 292.104297 104.1264 
-L 187.479297 104.1264 
+    <path d="M 111.825 133.5096 
+L 216.45 133.5096 
+L 216.45 104.1264 
+L 111.825 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.104297 133.5096 
-L 396.729297 133.5096 
-L 396.729297 104.1264 
-L 292.104297 104.1264 
+    <path d="M 216.45 133.5096 
+L 321.075 133.5096 
+L 321.075 104.1264 
+L 216.45 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.729297 133.5096 
-L 501.354297 133.5096 
-L 501.354297 104.1264 
-L 396.729297 104.1264 
+    <path d="M 321.075 133.5096 
+L 425.7 133.5096 
+L 425.7 104.1264 
+L 321.075 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.479297 162.8928 
-L 292.104297 162.8928 
-L 292.104297 133.5096 
-L 187.479297 133.5096 
+    <path d="M 111.825 162.8928 
+L 216.45 162.8928 
+L 216.45 133.5096 
+L 111.825 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.104297 162.8928 
-L 396.729297 162.8928 
-L 396.729297 133.5096 
-L 292.104297 133.5096 
+    <path d="M 216.45 162.8928 
+L 321.075 162.8928 
+L 321.075 133.5096 
+L 216.45 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.729297 162.8928 
-L 501.354297 162.8928 
-L 501.354297 133.5096 
-L 396.729297 133.5096 
+    <path d="M 321.075 162.8928 
+L 425.7 162.8928 
+L 425.7 133.5096 
+L 321.075 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #bde379; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.479297 192.276 
-L 292.104297 192.276 
-L 292.104297 162.8928 
-L 187.479297 162.8928 
+    <path d="M 111.825 192.276 
+L 216.45 192.276 
+L 216.45 162.8928 
+L 111.825 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.104297 192.276 
-L 396.729297 192.276 
-L 396.729297 162.8928 
-L 292.104297 162.8928 
+    <path d="M 216.45 192.276 
+L 321.075 192.276 
+L 321.075 162.8928 
+L 216.45 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.729297 192.276 
-L 501.354297 192.276 
-L 501.354297 162.8928 
-L 396.729297 162.8928 
+    <path d="M 321.075 192.276 
+L 425.7 192.276 
+L 425.7 162.8928 
+L 321.075 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #abdb6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.479297 221.6592 
-L 292.104297 221.6592 
-L 292.104297 192.276 
-L 187.479297 192.276 
+    <path d="M 111.825 221.6592 
+L 216.45 221.6592 
+L 216.45 192.276 
+L 111.825 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.104297 221.6592 
-L 396.729297 221.6592 
-L 396.729297 192.276 
-L 292.104297 192.276 
+    <path d="M 216.45 221.6592 
+L 321.075 221.6592 
+L 321.075 192.276 
+L 216.45 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.729297 221.6592 
-L 501.354297 221.6592 
-L 501.354297 192.276 
-L 396.729297 192.276 
+    <path d="M 321.075 221.6592 
+L 425.7 221.6592 
+L 425.7 192.276 
+L 321.075 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.479297 251.0424 
-L 292.104297 251.0424 
-L 292.104297 221.6592 
-L 187.479297 221.6592 
+    <path d="M 111.825 251.0424 
+L 216.45 251.0424 
+L 216.45 221.6592 
+L 111.825 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.104297 251.0424 
-L 396.729297 251.0424 
-L 396.729297 221.6592 
-L 292.104297 221.6592 
+    <path d="M 216.45 251.0424 
+L 321.075 251.0424 
+L 321.075 221.6592 
+L 216.45 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.729297 251.0424 
-L 501.354297 251.0424 
-L 501.354297 221.6592 
-L 396.729297 221.6592 
+    <path d="M 321.075 251.0424 
+L 425.7 251.0424 
+L 425.7 221.6592 
+L 321.075 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.479297 280.4256 
-L 292.104297 280.4256 
-L 292.104297 251.0424 
-L 187.479297 251.0424 
+    <path d="M 111.825 280.4256 
+L 216.45 280.4256 
+L 216.45 251.0424 
+L 111.825 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.104297 280.4256 
-L 396.729297 280.4256 
-L 396.729297 251.0424 
-L 292.104297 251.0424 
+    <path d="M 216.45 280.4256 
+L 321.075 280.4256 
+L 321.075 251.0424 
+L 216.45 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.729297 280.4256 
-L 501.354297 280.4256 
-L 501.354297 251.0424 
-L 396.729297 251.0424 
+    <path d="M 321.075 280.4256 
+L 425.7 280.4256 
+L 425.7 251.0424 
+L 321.075 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.479297 309.8088 
-L 292.104297 309.8088 
-L 292.104297 280.4256 
-L 187.479297 280.4256 
+    <path d="M 111.825 309.8088 
+L 216.45 309.8088 
+L 216.45 280.4256 
+L 111.825 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.104297 309.8088 
-L 396.729297 309.8088 
-L 396.729297 280.4256 
-L 292.104297 280.4256 
+    <path d="M 216.45 309.8088 
+L 321.075 309.8088 
+L 321.075 280.4256 
+L 216.45 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.729297 309.8088 
-L 501.354297 309.8088 
-L 501.354297 280.4256 
-L 396.729297 280.4256 
+    <path d="M 321.075 309.8088 
+L 425.7 309.8088 
+L 425.7 280.4256 
+L 321.075 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.479297 339.192 
-L 292.104297 339.192 
-L 292.104297 309.8088 
-L 187.479297 309.8088 
+    <path d="M 111.825 339.192 
+L 216.45 339.192 
+L 216.45 309.8088 
+L 111.825 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.104297 339.192 
-L 396.729297 339.192 
-L 396.729297 309.8088 
-L 292.104297 309.8088 
+    <path d="M 216.45 339.192 
+L 321.075 339.192 
+L 321.075 309.8088 
+L 216.45 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.729297 339.192 
-L 501.354297 339.192 
-L 501.354297 309.8088 
-L 396.729297 309.8088 
+    <path d="M 321.075 339.192 
+L 425.7 339.192 
+L 425.7 309.8088 
+L 321.075 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p225397f078)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(44.812266 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(152.096484 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.668594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(329.020312 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(40.75 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(261.1275 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1033,16 +1033,28 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 925 -->
-    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
+    <!-- 927 -->
+    <g transform="translate(365.7525 91.6423) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(35.388125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1153,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,18 +1163,8 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 121.0255) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1202,7 +1204,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1212,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.305547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(52.65125 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1236,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,22 +1246,22 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 700 -->
-    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+    <!-- 693 -->
+    <g transform="translate(365.7525 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.611797 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(35.9575 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1371,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,22 +1381,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 730 -->
-    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
+    <!-- 737 -->
+    <g transform="translate(365.7525 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.768047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(44.11375 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1456,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1466,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,311 +1494,15 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- lean-zip (native) -->
-    <g transform="translate(98.113672 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
-L 1656 4863 
-L 1656 0 
-L 538 0 
-L 538 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
-L 4056 0 
-L 2931 0 
-L 2931 347 
-L 2931 1631 
-Q 2931 2084 2911 2256 
-Q 2891 2428 2841 2509 
-Q 2775 2619 2662 2680 
-Q 2550 2741 2406 2741 
-Q 2056 2741 1856 2470 
-Q 1656 2200 1656 1722 
-L 1656 0 
-L 538 0 
-L 538 3500 
-L 1656 3500 
-L 1656 2988 
-Q 1909 3294 2193 3439 
-Q 2478 3584 2822 3584 
-Q 3428 3584 3742 3212 
-Q 4056 2841 4056 2131 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
-L 2309 2297 
-L 2309 1388 
-L 347 1388 
-L 347 2297 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
-L 3419 3500 
-L 3419 2719 
-L 1575 800 
-L 3419 800 
-L 3419 0 
-L 288 0 
-L 288 781 
-L 2131 2700 
-L 366 2700 
-L 366 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
-L 1484 -844 
-Q 1006 -72 778 623 
-Q 550 1319 550 2003 
-Q 550 2688 779 3389 
-Q 1009 4091 1484 4856 
-L 2413 4856 
-Q 2013 4116 1813 3408 
-Q 1613 2700 1613 2009 
-Q 1613 1319 1811 609 
-Q 2009 -100 2413 -844 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-76" d="M 97 3500 
-L 1216 3500 
-L 2088 1081 
-L 2956 3500 
-L 4078 3500 
-L 2700 0 
-L 1472 0 
-L 97 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-29" d="M 513 -844 
-Q 913 -100 1113 609 
-Q 1313 1319 1313 2009 
-Q 1313 2700 1113 3408 
-Q 913 4116 513 4856 
-L 1441 4856 
-Q 1916 4091 2145 3389 
-Q 2375 2688 2375 2003 
-Q 2375 1319 2147 623 
-Q 1919 -72 1441 -844 
-L 513 -844 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-6c"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.304 -->
-    <g transform="translate(227.139922 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
-Q 2944 3213 2780 3570 
-Q 2616 3928 2228 3928 
-Q 1841 3928 1675 3570 
-Q 1509 3213 1509 2338 
-Q 1509 1453 1675 1090 
-Q 1841 728 2228 728 
-Q 2613 728 2778 1090 
-Q 2944 1453 2944 2338 
-z
-M 4147 2328 
-Q 4147 1169 3647 539 
-Q 3147 -91 2228 -91 
-Q 1306 -91 806 539 
-Q 306 1169 306 2328 
-Q 306 3491 806 4120 
-Q 1306 4750 2228 4750 
-Q 3147 4750 3647 4120 
-Q 4147 3491 4147 2328 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
-L 1778 1209 
-L 1778 0 
-L 653 0 
-L 653 1209 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 25 -->
-    <g transform="translate(338.850547 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 209 -->
-    <g transform="translate(440.692422 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.228672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(20.574375 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1923,9 +1629,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.340547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1933,24 +1639,260 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_31">
+   <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.326797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_32">
+   <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(441.406797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
+   <g id="text_29">
+    <!-- lean-zip (native) -->
+    <g transform="translate(22.459375 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
+L 2309 2297 
+L 2309 1388 
+L 347 1388 
+L 347 2297 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-6c"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.300 -->
+    <g transform="translate(151.485625 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 22 -->
+    <g transform="translate(263.19625 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 212 -->
+    <g transform="translate(365.038125 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.735547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(23.08125 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2006,7 +1948,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2016,21 +1958,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(368.2975 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(48.795625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2041,7 +1983,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2051,13 +1993,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(266.2175 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(369.3875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2073,7 +2015,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.863047 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(59.20875 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2286,8 +2228,8 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(87.061641 369.318844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2377,6 +2319,76 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(54.408281 377.352) scale(0.07 -0.07)">
+    <defs>
      <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
 L 1894 563 
@@ -2416,167 +2428,102 @@ L 750 794
 z
 " transform="scale(0.015625)"/>
     </defs>
-    <use xlink:href="#DejaVuSans-32"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
-    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
-    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
-    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf20f32977c">
-   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p225397f078">
+   <rect x="7.2" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9c5857dfb0)">
+   <g clip-path="url(#p9a1e9490f9)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6ElEQVR4nO3YPW5cVQCGYY89cSA/IpCQCJAiGqACKYKKhh1QsAxKWnpKalp6NkAFokJCCLrQEQEFJALlj8j22GNWQBWd9zhXz7OCT7pz7nnvrLZ/f3m6s2Sbg9kLeBrb49kLxlrtzl4w1vHR7AVjXbgye8FYh49nLxhrb3/2Ap7G0n+f+xdmLxhq4bcfAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1/nFzZ/aGoda7e7MnDLU9PZ09Yajrl6/PnjDUnYe/z54w1sI/cd987srsCUNtzu/PnjDUT3dvz54w1DvX3pg9YajD/e3sCUOtVk9mTxhq4dcDAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1vXn599oahrpy/PnvCUPcO/pg9YahXnyz7G+nS1bdnTxhqb7WePWGo7c529oShXt65NnvCUMfXjmZPGOrGhZuzJwy12S77+V08Wvb7Zdm3OwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtV6tlt2gjzb/zJ4w1PN7l2ZPGOrk6kuzJwz154OfZ08Y6vHRwewJQ7374nuzJwx1tDd7wVj/bh7NnsBTuH94d/aEsc5fn71gqGXXJwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtTr57pPT2SOG2m5nL4D/t+sb8Jnm/fJsW/r5W/rv0/N7pi386QEAcNYIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUusbP/wye8NQu+tlN/bd2/dmTxjqi49vzZ4w1Gff/zV7wlAf3Hxh9oShvvr219kThvr0o7dmTxjq829+mz1hqA9vvTJ7wlC/PTicPWGo91+7OHvCUMuuMwAAzhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBabU6+Pp09YqS94+PZE8baXc9eMNbxwewFY+1fmL1grNXCv3FPt7MXjLVx/p5pJ8u+/zarZZ+/cwvvl4XfDgAAnDUCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1Prk9Hj2hqH21vuzJwy1Xc1eMNbuw/uzJwx1dG49e8JQ+zvLPn87x0ezF4y1OZi9YKjHq2U/v0unyz5/53aX/f5c+vnzDygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBA6j/J1X2rX/GsGgAAAABJRU5ErkJggg==" id="image1894bd2286" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJw0lEQVR4nO3YTYoeVQCG0f5+0um0jbYaMhODOxDchLggp24gO3ALLsFhBo7EgSDOVEggqIkaO6b7+3EDOpL73LY4ZwVvQVXdp2p1ePnF8WTJ9tezF4x173L2grH+/HX2grHW69kLxtrvZi8Y6/R89oKxbv6avWCspT9/q4Vf327h5/uds9kLhlr43QkAwG0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASG1/OjybvWGozWY7e8JQ3z79evaEoT568OHsCUO9eL3s52+1WfY37v0757MnDLXfLvv9+Xzhz9/F9nL2hKF26+vZE4baH69mTxhq2acDAAC3jgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASG3funt/9oahLu5czp4w1C+vns2eMNTbu+3sCUOdnT+cPWGo1WrZ37jH42H2hKEu1hezJwy1Olv2/Xm2OZ89YajDwp+/s5PT2ROGWvbTBwDArSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIbdcLb9DXu6vZE4Y6v3M+e8JQhzcuZ08Y6rerH2dPGOrmcD17wlDv3ftg9oSh9ss+Hk52u2Xfn6vNxewJQ13tXsyeMNR+s+zzfeGvFwAAbhsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAanX44dFx9gj4V8fD7AVjrXwDAvAPFn7+Of0AAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUttHP38/e8NQh+Nx9oShPv38m9kThvrqs49nTxjq8ZOnsycM9f6bd2dPGOrxk6vZE4b65OH92ROG+u75i9kThnrnbNn/mP64OcyeMNS7Z6ezJwy17LsTAIBbR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApFaHw5fH2SOGev1y9oKhXq53sycMdXE8nT1hrM3Sr287ewH/xe569oKxVv7B/K8t/f2yX/b57ukDACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASG1nDxhuvexLPJxcz54w1qvfZy8Y6vDWg9kThlofD7MnjLXw+3Pp9vcuZk8YanOz8PNhs+zz/eT6avaCofwBBQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEj9DfPcddcDlHF3AAAAAElFTkSuQmCC" id="image1460504213" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7c0bd0b811" d="M 0 0 
+       <path id="mc20abcff44" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7c0bd0b811" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc20abcff44" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m680eb3e83a" d="M 0 0 
+       <path id="m3a332693b7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3a332693b7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,8 +1138,95 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +10 -->
-    <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
+    <!-- -2 -->
+    <g transform="translate(112.574598 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -19 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +38 -->
+    <g transform="translate(189.510723 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1156,51 +1243,6 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -3 -->
-    <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1233,124 +1275,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +3 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -34 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +10 -->
-    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -4 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -12 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -23 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +21 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -12 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -8 -->
-    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1391,21 +1315,304 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -50 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +5 -->
+    <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -8 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_27">
+    <!-- -32 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -34 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +9 -->
+    <g transform="translate(433.242927 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -23 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -1 -->
+    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
    <g id="text_32">
-    <!-- -24 -->
+    <!-- -31 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +0 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -24 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+   <g id="text_35">
+    <!-- +32 -->
+    <g transform="translate(189.510723 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -23 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- -10 -->
+    <g transform="translate(271.616379 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- +0 -->
+    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- -3 -->
+    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- -15 -->
+    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- -8 -->
+    <g transform="translate(434.793786 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- -12 -->
+    <g transform="translate(473.003372 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- +3 -->
+    <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- -9 -->
+    <g transform="translate(555.625982 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- +244 -->
+    <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- +249 -->
+    <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- +508 -->
+    <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- +133 -->
+    <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_49">
+    <!-- +238 -->
+    <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- +189 -->
+    <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- +283 -->
+    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_52">
+    <!-- +156 -->
+    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1439,260 +1646,14 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -11 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -6 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -15 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- -5 -->
-    <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- +1 -->
-    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- -3 -->
-    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- -13 -->
-    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- +1 -->
-    <g transform="translate(433.242927 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- -6 -->
-    <g transform="translate(475.071185 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- +9 -->
-    <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- -12 -->
-    <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- +256 -->
-    <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- +252 -->
-    <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- +305 -->
-    <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- +133 -->
-    <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- +238 -->
-    <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- +189 -->
-    <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- +281 -->
-    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_52">
-    <!-- +152 -->
-    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +259 -->
+    <!-- +227 -->
     <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_54">
-    <!-- +186 -->
-    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_55">
-    <!-- +210 -->
-    <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_56">
-    <!-- +160 -->
-    <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_57">
-    <!-- -97 -->
-    <g transform="translate(110.506785 180.060583) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1705,6 +1666,42 @@ L 525 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_54">
+    <!-- +201 -->
+    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_55">
+    <!-- +220 -->
+    <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_56">
+    <!-- +187 -->
+    <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_57">
+    <!-- -97 -->
+    <g transform="translate(110.506785 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -1719,11 +1716,11 @@ z
     </g>
    </g>
    <g id="text_59">
-    <!-- -98 -->
+    <!-- -97 -->
     <g transform="translate(191.061582 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_60">
@@ -1768,11 +1765,11 @@ z
     </g>
    </g>
    <g id="text_65">
-    <!-- -96 -->
+    <!-- -97 -->
     <g transform="translate(432.725974 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
@@ -1800,27 +1797,27 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +31 -->
+    <!-- +32 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +30 -->
+    <!-- +27 -->
     <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- +28 -->
+    <!-- +93 -->
     <g transform="translate(189.510723 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_72">
@@ -1855,66 +1852,67 @@ z
     </g>
    </g>
    <g id="text_76">
-    <!-- +11 -->
+    <!-- +12 -->
     <g transform="translate(390.897716 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
-    <!-- +64 -->
+    <!-- +49 -->
     <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- +11 -->
+    <!-- +15 -->
     <g transform="translate(471.452513 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- +45 -->
+    <!-- +50 -->
     <g transform="translate(511.729912 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- +18 -->
+    <!-- +30 -->
     <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_81">
-    <!-- +35 -->
+    <!-- +36 -->
     <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +8 -->
+    <!-- +5 -->
     <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_83">
-    <!-- +43 -->
-    <g transform="translate(189.510723 253.732149) scale(0.065 -0.065)">
+    <!-- +115 -->
+    <g transform="translate(187.44291 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_84">
@@ -1934,11 +1932,11 @@ z
     </g>
    </g>
    <g id="text_86">
-    <!-- +20 -->
+    <!-- +21 -->
     <g transform="translate(310.342919 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
@@ -1958,35 +1956,35 @@ z
     </g>
    </g>
    <g id="text_89">
-    <!-- +50 -->
+    <!-- +36 -->
     <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- +11 -->
+    <!-- +16 -->
     <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +18 -->
+    <!-- +22 -->
     <g transform="translate(511.729912 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- -19 -->
+    <!-- -11 -->
     <g transform="translate(553.558169 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -1998,27 +1996,28 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- +73 -->
+    <!-- +69 -->
     <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +76 -->
-    <g transform="translate(189.510723 290.567931) scale(0.065 -0.065)">
+    <!-- +165 -->
+    <g transform="translate(187.44291 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- +44 -->
+    <!-- +45 -->
     <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_97">
@@ -2038,52 +2037,51 @@ z
     </g>
    </g>
    <g id="text_99">
-    <!-- +34 -->
+    <!-- +35 -->
     <g transform="translate(350.620317 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_100">
-    <!-- +41 -->
+    <!-- +42 -->
     <g transform="translate(390.897716 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_101">
-    <!-- +105 -->
-    <g transform="translate(429.107302 290.567931) scale(0.065 -0.065)">
+    <!-- +86 -->
+    <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_102">
-    <!-- +47 -->
+    <!-- +53 -->
     <g transform="translate(471.452513 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_103">
-    <!-- +59 -->
+    <!-- +64 -->
     <g transform="translate(511.729912 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_104">
-    <!-- +57 -->
+    <!-- +73 -->
     <g transform="translate(552.00731 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_105">
@@ -2095,19 +2093,19 @@ z
     </g>
    </g>
    <g id="text_106">
-    <!-- -44 -->
+    <!-- -46 -->
     <g transform="translate(150.784184 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
-    <!-- -44 -->
+    <!-- -16 -->
     <g transform="translate(191.061582 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_108">
@@ -2143,43 +2141,43 @@ z
     </g>
    </g>
    <g id="text_112">
-    <!-- -50 -->
+    <!-- -49 -->
     <g transform="translate(392.448575 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_113">
-    <!-- -42 -->
+    <!-- -47 -->
     <g transform="translate(432.725974 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_114">
-    <!-- -43 -->
+    <!-- -40 -->
     <g transform="translate(473.003372 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_115">
-    <!-- -56 -->
+    <!-- -55 -->
     <g transform="translate(513.280771 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_116">
-    <!-- -45 -->
+    <!-- -39 -->
     <g transform="translate(553.558169 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2193,23 +2191,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image3e150843d4" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image39bcdedcaa" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mca6c818348" d="M 0 0 
+       <path id="md03768520f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md03768520f" x="601.779688" y="296.336608" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
-      <!-- −3 -->
-      <g transform="translate(608.779688 325.122218) scale(0.1 -0.1)">
+      <!-- −4 -->
+      <g transform="translate(608.779688 300.135827) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2220,19 +2218,19 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md03768520f" x="601.779688" y="246.510744" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.576178) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 250.309963) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2241,70 +2239,43 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md03768520f" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
-      <!-- −1 -->
-      <g transform="translate(608.779688 242.030139) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_12">
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_120">
       <!-- 0 -->
       <g transform="translate(608.779688 200.484099) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_25">
+    <g id="ytick_12">
+     <g id="line2d_24">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md03768520f" x="601.779688" y="146.859017" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_121">
-      <!-- 1 -->
-      <g transform="translate(608.779688 158.93806) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_26">
-      <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_122">
+     <g id="text_120">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.392021) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 150.658236) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
-    <g id="ytick_15">
-     <g id="line2d_27">
+    <g id="ytick_13">
+     <g id="line2d_25">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md03768520f" x="601.779688" y="97.033154" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_123">
-      <!-- 3 -->
-      <g transform="translate(608.779688 75.845981) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-33"/>
+     <g id="text_121">
+      <!-- 4 -->
+      <g transform="translate(608.779688 100.832372) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
     </g>
-    <g id="text_124">
+    <g id="text_122">
      <!-- % vs zlib (higher=faster) -->
      <g transform="translate(635.120313 258.988787) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2429,7 +2400,7 @@ z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_125">
+  <g id="text_123">
    <!-- Compression speed vs zlib  (silesia, level 6, relative to zlib) -->
    <g transform="translate(122.993437 17.182125) scale(0.12 -0.12)">
     <defs>
@@ -2909,9 +2880,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3304.394531 0)"/>
    </g>
   </g>
-  <g id="text_126">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
+  <g id="text_124">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(201.361641 393.150844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2975,21 +2946,6 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-32"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
@@ -3002,14 +2958,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3004,129 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(168.708281 401.184) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9c5857dfb0">
+  <clipPath id="p9a1e9490f9">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mcf2d38bc57" d="M 0 0 
+       <path id="m7dc131a54b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcf2d38bc57" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7dc131a54b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 368.088255 
-L 637.2 368.088255 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.059524 
+L 637.2 368.059524 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m56c0a3fe0e" d="M 0 0 
+       <path id="m48330bc40e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48330bc40e" x="49.078125" y="368.059524" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 371.887474) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.858742) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 243.475737 
-L 637.2 243.475737 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.319809 
+L 637.2 243.319809 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48330bc40e" x="49.078125" y="243.319809" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 247.274956) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.119028) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 243.475737
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 118.863219 
-L 637.2 118.863219 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.580095 
+L 637.2 118.580095 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48330bc40e" x="49.078125" y="118.580095" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 122.662438) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.379314) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,282 +935,282 @@ L 637.2 118.863219
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.600361 
-L 637.2 405.600361 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.609919 
+L 637.2 405.609919 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7d7e06588d" d="M 0 0 
+       <path id="m332fa765a5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="405.609919" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 395.733387 
-L 637.2 395.733387 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.732873 
+L 637.2 395.732873 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="395.732873" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 387.390979 
-L 637.2 387.390979 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.38195 
+L 637.2 387.38195 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="387.38195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 380.164456 
-L 637.2 380.164456 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.148051 
+L 637.2 380.148051 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="380.148051" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 373.790211 
-L 637.2 373.790211 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.7673 
+L 637.2 373.7673 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="373.7673" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 330.57615 
-L 637.2 330.57615 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.509128 
+L 637.2 330.509128 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="330.509128" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 308.632974 
-L 637.2 308.632974 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.543555 
+L 637.2 308.543555 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="308.543555" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.064044 
-L 637.2 293.064044 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 292.958732 
+L 637.2 292.958732 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="292.958732" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 280.987843 
-L 637.2 280.987843 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 280.870205 
+L 637.2 280.870205 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="280.870205" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 271.120868 
-L 637.2 271.120868 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 270.993159 
+L 637.2 270.993159 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="270.993159" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 262.77846 
-L 637.2 262.77846 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.642235 
+L 637.2 262.642235 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="262.642235" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 255.551938 
-L 637.2 255.551938 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.408337 
+L 637.2 255.408337 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="255.408337" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.177693 
-L 637.2 249.177693 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.027586 
+L 637.2 249.027586 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="249.027586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 205.963631 
-L 637.2 205.963631 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.769414 
+L 637.2 205.769414 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="205.769414" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 184.020456 
-L 637.2 184.020456 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 183.80384 
+L 637.2 183.80384 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="183.80384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 168.451525 
-L 637.2 168.451525 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.219018 
+L 637.2 168.219018 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="168.219018" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 156.375325 
-L 637.2 156.375325 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.130491 
+L 637.2 156.130491 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="156.130491" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 146.50835 
-L 637.2 146.50835 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.253445 
+L 637.2 146.253445 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="146.253445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 138.165942 
-L 637.2 138.165942 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 137.902521 
+L 637.2 137.902521 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="137.902521" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 130.93942 
-L 637.2 130.93942 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 130.668622 
+L 637.2 130.668622 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="130.668622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 124.565175 
-L 637.2 124.565175 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.287871 
+L 637.2 124.287871 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="124.287871" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 81.351113 
-L 637.2 81.351113 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.029699 
+L 637.2 81.029699 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="81.029699" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 59.407938 
-L 637.2 59.407938 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.064126 
+L 637.2 59.064126 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m332fa765a5" x="49.078125" y="59.064126" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 145.876361) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 144.247053) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 334.14348) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 334.08424) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1693,124 +1693,130 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 377.110281 107.572658 
-L 323.801439 112.143178 
-L 272.665744 128.289861 
-L 235.168828 129.778148 
-L 186.228265 150.062022 
-L 158.303164 172.157864 
-L 149.489547 182.173164 
-L 140.563162 202.575355 
-L 138.984853 209.263476 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 107.789193 
+L 323.801439 112.897532 
+L 272.665744 129.021093 
+L 235.168828 131.639976 
+L 186.228265 152.328685 
+L 158.303164 174.106898 
+L 149.489547 186.730217 
+L 140.563162 206.355101 
+L 138.984853 212.977992 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m178244bc6c" d="M -2.5 2.5 
+     <path id="m3baa5a9075" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m178244bc6c" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m3baa5a9075" x="377.110281" y="107.789193" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="323.801439" y="112.897532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="272.665744" y="129.021093" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="235.168828" y="131.639976" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="186.228265" y="152.328685" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="158.303164" y="174.106898" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="149.489547" y="186.730217" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="140.563162" y="206.355101" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3baa5a9075" x="138.984853" y="212.977992" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 610.467187 71.829514 
-L 319.880958 101.654884 
-L 210.281253 129.793447 
-L 196.287076 133.571842 
-L 176.054419 147.433896 
-L 152.161413 174.830826 
-L 146.720208 186.628416 
-L 143.994022 196.353927 
-L 142.666037 200.270771 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 74.243021 
+L 319.880958 103.515489 
+L 210.281253 131.491746 
+L 196.287076 134.71639 
+L 176.054419 148.860935 
+L 152.161413 177.847813 
+L 146.720208 188.518304 
+L 143.994022 197.852921 
+L 142.666037 202.095941 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m436450e9eb" d="M 0 -2.5 
+     <path id="m68a4d98c7e" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m436450e9eb" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m68a4d98c7e" x="610.467187" y="74.243021" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="319.880958" y="103.515489" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="210.281253" y="131.491746" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="196.287076" y="134.71639" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="176.054419" y="148.860935" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="152.161413" y="177.847813" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="146.720208" y="188.518304" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="143.994022" y="197.852921" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m68a4d98c7e" x="142.666037" y="202.095941" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <path d="M 292.033351 64.890426 
-L 242.839153 80.520583 
-L 218.251194 86.060539 
-L 197.814984 90.141422 
-L 166.378359 98.767475 
-L 145.830392 110.20084 
-L 134.598477 125.76687 
-L 124.077268 149.129162 
-L 122.462976 157.203722 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 242.839153 80.502262 
+L 218.251194 85.940504 
+L 197.814984 90.294441 
+L 166.378359 98.708378 
+L 145.830392 109.988821 
+L 134.598477 125.696246 
+L 124.077268 148.796457 
+L 122.462976 156.85766 
+L 81.012077 219.198069 
+L 77.44276 238.654528 
+L 76.953425 251.727422 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md307489ca2" d="M -0 3.535534 
+     <path id="m106ff73eae" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#md307489ca2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m106ff73eae" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="242.839153" y="80.502262" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="218.251194" y="85.940504" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="197.814984" y="90.294441" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="166.378359" y="98.708378" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="145.830392" y="109.988821" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="134.598477" y="125.696246" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="124.077268" y="148.796457" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="122.462976" y="156.85766" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="81.012077" y="219.198069" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="77.44276" y="238.654528" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106ff73eae" x="76.953425" y="251.727422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma6227aa52e" d="M -0 2.5 
+     <path id="mac7c4034bc" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#ma6227aa52e" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#mac7c4034bc" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
-    <path d="M 432.495268 103.672741 
-L 300.62247 118.022676 
-L 266.967623 125.683 
-L 226.040946 126.152114 
-L 180.985721 144.080759 
-L 164.441833 158.457887 
-L 157.761315 167.001817 
-L 151.269082 181.244808 
-L 150.327087 186.982195 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 432.495268 103.374112 
+L 300.62247 117.738695 
+L 266.967623 125.406837 
+L 226.040946 125.87643 
+L 180.985721 143.823375 
+L 164.441833 158.215179 
+L 157.761315 166.76783 
+L 151.269082 181.025359 
+L 150.327087 186.768602 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb278c96180" d="M -0.833333 2.5 
+     <path id="ma32d591cce" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,31 +1831,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mb278c96180" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#ma32d591cce" x="432.495268" y="103.374112" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="300.62247" y="117.738695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="266.967623" y="125.406837" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="226.040946" y="125.87643" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="180.985721" y="143.823375" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="164.441833" y="158.215179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="157.761315" y="166.76783" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="151.269082" y="181.025359" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma32d591cce" x="150.327087" y="186.768602" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
-    <path d="M 345.030867 135.087035 
-L 273.364924 141.893443 
-L 240.719951 147.934009 
-L 221.353978 153.24805 
-L 207.129625 155.190071 
-L 181.064802 166.690306 
-L 179.282169 170.285179 
-L 177.719335 175.659634 
-L 177.643939 181.03308 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 345.030867 134.820471 
+L 273.364924 141.633826 
+L 240.719951 147.680558 
+L 221.353978 153.000023 
+L 207.129625 154.944027 
+L 181.064802 166.456001 
+L 179.282169 170.054543 
+L 177.719335 175.434484 
+L 177.643939 180.813415 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m598bf75ba4" d="M -1.25 2.5 
+     <path id="m7eda2b1d56" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,31 +1870,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m598bf75ba4" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m7eda2b1d56" x="345.030867" y="134.820471" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="273.364924" y="141.633826" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="240.719951" y="147.680558" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="221.353978" y="153.000023" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="207.129625" y="154.944027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="181.064802" y="166.456001" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="179.282169" y="170.054543" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="177.719335" y="175.434484" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7eda2b1d56" x="177.643939" y="180.813415" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
-    <path d="M 226.871027 113.078527 
-L 226.871027 113.102618 
-L 226.871027 113.251157 
-L 226.871027 113.159816 
-L 177.768423 132.098656 
-L 160.37503 145.292152 
-L 153.995779 152.427338 
-L 147.106887 167.637027 
-L 145.871703 174.910889 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 112.789499 
+L 226.871027 112.813614 
+L 226.871027 112.962305 
+L 226.871027 112.87087 
+L 177.768423 131.829042 
+L 160.37503 145.036005 
+L 153.995779 152.178474 
+L 147.106887 167.403688 
+L 145.871703 174.684974 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc3e4093720" d="M 0 -2.5 
+     <path id="m29e49b6227" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,31 +1907,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m29e49b6227" x="226.871027" y="112.789499" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="226.871027" y="112.813614" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="226.871027" y="112.962305" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="226.871027" y="112.87087" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="177.768423" y="131.829042" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="160.37503" y="145.036005" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="153.995779" y="152.178474" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="147.106887" y="167.403688" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m29e49b6227" x="145.871703" y="174.684974" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
-    <path d="M 585.66883 174.374171 
-L 527.144592 176.439455 
-L 457.339427 184.525165 
-L 292.124837 179.218412 
-L 243.129344 190.901895 
-L 213.541392 204.840226 
-L 204.551957 212.456838 
-L 195.860087 228.889995 
-L 194.019853 234.405357 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 585.66883 174.147709 
+L 527.144592 176.215101 
+L 457.339427 184.309064 
+L 292.124837 178.996894 
+L 243.129344 190.692304 
+L 213.541392 204.644861 
+L 204.551957 212.269248 
+L 195.860087 228.719179 
+L 194.019853 234.240171 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdd9f67dd3d" d="M 0 -2.5 
+     <path id="m1da80f5684" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1940,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mdd9f67dd3d" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m1da80f5684" x="585.66883" y="174.147709" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="527.144592" y="176.215101" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="457.339427" y="184.309064" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="292.124837" y="178.996894" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="243.129344" y="190.692304" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="213.541392" y="204.644861" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="204.551957" y="212.269248" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="195.860087" y="228.719179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1da80f5684" x="194.019853" y="234.240171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1972,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mf594d85f73" d="M 0 3.5 
+      <path id="m0fc5b6abdf" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1985,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mf594d85f73" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0fc5b6abdf" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2048,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m178244bc6c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3baa5a9075" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2066,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m436450e9eb" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m68a4d98c7e" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2115,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md307489ca2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m106ff73eae" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2162,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma6227aa52e" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mac7c4034bc" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2182,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb278c96180" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma32d591cce" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2240,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m598bf75ba4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7eda2b1d56" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2309,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc3e4093720" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m29e49b6227" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2351,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdd9f67dd3d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1da80f5684" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2421,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 150.876361 
-L 236.23654 155.378808 
-L 222.073314 159.773191 
-L 202.315941 170.53176 
-L 199.905291 172.268949 
-L 195.893147 176.45193 
-L 187.210062 190.253023 
-L 157.246106 245.621259 
-L 95.319203 339.14348 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mf594d85f73" x="257.531237" y="150.876361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="236.23654" y="155.378808" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="222.073314" y="159.773191" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="202.315941" y="170.53176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="199.905291" y="172.268949" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="195.893147" y="176.45193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="187.210062" y="190.253023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="157.246106" y="245.621259" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="95.319203" y="339.14348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 149.247053 
+L 236.23654 153.955321 
+L 222.073314 158.341824 
+L 206.688505 169.25101 
+L 196.746946 174.506565 
+L 189.151456 183.068441 
+L 187.210062 188.724781 
+L 157.246106 244.735485 
+L 95.319203 339.08424 
+" clip-path="url(#pd68a50cf80)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pd68a50cf80)">
+     <use xlink:href="#m0fc5b6abdf" x="257.531237" y="149.247053" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="236.23654" y="153.955321" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="222.073314" y="158.341824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="206.688505" y="169.25101" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="196.746946" y="174.506565" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="189.151456" y="183.068441" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="187.210062" y="188.724781" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="157.246106" y="244.735485" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0fc5b6abdf" x="95.319203" y="339.08424" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2809,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(201.361641 457.626844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2815,16 +2821,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2838,6 +2834,61 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2897,59 +2948,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3d" d="M 678 2906 
-L 4684 2906 
-L 4684 2381 
-L 678 2381 
-L 678 2906 
-z
-M 678 1631 
-L 4684 1631 
-L 4684 1100 
-L 678 1100 
-L 678 1631 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
-z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-32"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
@@ -2962,14 +2960,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3008,109 +3006,142 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(168.708281 465.66) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p533e8fc221">
+  <clipPath id="pd68a50cf80">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mbdc34b6d68" d="M 0 0 
+       <path id="mb28527404a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbdc34b6d68" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbdc34b6d68" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb28527404a" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mcba8310c94" d="M 0 0 
+       <path id="mb95e95e5b5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcba8310c94" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb95e95e5b5" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcba8310c94" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb95e95e5b5" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mcba8310c94" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb95e95e5b5" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m137194c53c" d="M 0 0 
+       <path id="m3d2b24754f" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m137194c53c" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3d2b24754f" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pef2b36634e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pdb8893f334)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m672db5ea2e" d="M -2.5 2.5 
+     <path id="m88f0ddec30" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#m672db5ea2e" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m672db5ea2e" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#m88f0ddec30" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88f0ddec30" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m59c02e876f" d="M 0 -2.5 
+     <path id="m47670cd0a5" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#m59c02e876f" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59c02e876f" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#m47670cd0a5" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47670cd0a5" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mf397ebec1b" d="M -0 3.535534 
+     <path id="m7597c3e4de" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#mf397ebec1b" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf397ebec1b" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#m7597c3e4de" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7597c3e4de" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mdab00f34b5" d="M -0.833333 2.5 
+     <path id="ma65a7a0c19" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#mdab00f34b5" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdab00f34b5" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#ma65a7a0c19" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma65a7a0c19" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m859ae6c05d" d="M -1.25 2.5 
+     <path id="m1658539764" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#m859ae6c05d" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m859ae6c05d" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#m1658539764" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1658539764" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m5d601f7d23" d="M 0 -2.5 
+     <path id="m25f0a00c60" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#m5d601f7d23" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d601f7d23" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#m25f0a00c60" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m25f0a00c60" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m9174fe90e3" d="M 0 -2.5 
+     <path id="mbb437ea60a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#m9174fe90e3" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9174fe90e3" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#mbb437ea60a" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb437ea60a" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mb701ddf920" d="M 0 3.5 
+      <path id="mdb78fddd9d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mb701ddf920" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mdb78fddd9d" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m672db5ea2e" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m88f0ddec30" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m59c02e876f" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m47670cd0a5" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mf397ebec1b" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7597c3e4de" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mdab00f34b5" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma65a7a0c19" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m859ae6c05d" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1658539764" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m5d601f7d23" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m25f0a00c60" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m9174fe90e3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbb437ea60a" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pef2b36634e)">
-     <use xlink:href="#mb701ddf920" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mb701ddf920" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pdb8893f334)">
+     <use xlink:href="#mdb78fddd9d" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdb78fddd9d" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pef2b36634e">
+  <clipPath id="pdb8893f334">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3643087f7a" d="M 0 0 
+       <path id="md2167e38ed" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3643087f7a" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2167e38ed" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3643087f7a" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md2167e38ed" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="maa8165ad80" d="M 0 0 
+       <path id="m84b2e48418" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#maa8165ad80" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#maa8165ad80" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#maa8165ad80" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#maa8165ad80" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#maa8165ad80" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#maa8165ad80" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#maa8165ad80" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#maa8165ad80" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#maa8165ad80" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#maa8165ad80" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#maa8165ad80" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#maa8165ad80" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#maa8165ad80" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#maa8165ad80" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#maa8165ad80" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#maa8165ad80" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#maa8165ad80" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#maa8165ad80" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#maa8165ad80" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#maa8165ad80" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m84b2e48418" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m5162ceafa8" d="M 0 0 
+       <path id="m5922751fdf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m5162ceafa8" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5922751fdf" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#p04bd6fe6c4)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p623a39c3a0)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m216e03da85" d="M 0 3 
+     <path id="m7ec5521097" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m216e03da85" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#m7ec5521097" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mf6d0e6a28b" d="M 0 3 
+     <path id="md0648ba5d4" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#mf6d0e6a28b" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#md0648ba5d4" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m50ca4d3758" d="M 0 3 
+     <path id="m6304167356" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m50ca4d3758" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#m6304167356" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m5a4af8cd5b" d="M 0 5 
+     <path id="ma5667605d3" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m5a4af8cd5b" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#ma5667605d3" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m17f69d86d0" d="M 0 3 
+     <path id="mde01835a06" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m17f69d86d0" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#mde01835a06" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m46ec212e40" d="M 0 3 
+     <path id="m65ada92917" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m46ec212e40" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#m65ada92917" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="me766ba2e9c" d="M 0 3 
+     <path id="ma2aae2df30" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#me766ba2e9c" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#ma2aae2df30" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m3288ff7b7c" d="M 0 3 
+     <path id="m99a1db5b81" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p04bd6fe6c4)">
-     <use xlink:href="#m3288ff7b7c" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p623a39c3a0)">
+     <use xlink:href="#m99a1db5b81" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p04bd6fe6c4">
+  <clipPath id="p623a39c3a0">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfbd230267e)">
+   <g clip-path="url(#p5c973a6271)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image274abf036f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAElEQVR4nO3Yy4qfdx3H8ZnM5EAmzSRBa7EewBQXjbUbodSFq+JCKiheglfgxpUr8Q5cdetCN0pxo6SLLgv1bF1ZrAc8EGJj0ljGZDKZv1fwXkj58ZU/r9cVfOB5+D3v57d7euuVzc4WOv7+zekJS5x96bnpCcvsPvnR6QlLbH7z2+kJS+x+9sb0hCU2R/enJyxz+5uvTk9Y4snvvDw9YYndax+ZnrDG8dH0gmVOf7ad5/2Z6QEAAPz/EosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKTdfx+/upkescLBv25PT1ji3csXpycs85+T96cnLPHx946nJyzx3oefmp6wxOnmdHrCMlf3r01PWOPOn6cXLHH/6nY+ryf+9PvpCctsPv3C9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJD2D+7cmt6wxsUr0wuW2GyOpycs87HXfzE9YY2XvjS9YInDd/8xPWGN05PpBescbOn5cf7S9IIlLv9zO7/Pdz95fXrCMlf/+tb0hCXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABp99Hjm5vpESvs3f7j9IQlbj1xbnrCMu8/ujc9YYnrf7k3PWGJk898fnrCEkcn96cnLHO4d2V6whKbd34+PWGJB596bnrCEhfeenN6wjIPn39xesISbhYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPvjd76xmR6xwrULB9MTlnj73p3pCct8/bu/mp6wxK+//eXpCUscnj+cnrDEt9745fSEZb7w9IXpCUt89fqL0xOWeP1vb05PWOLS2e18D3d2dnZ+9Ie70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN1Hj29upkescPfh7ekJSxzsX56esMzb9343PWGJZ67cmJ6wxGZzOj1hiUsn2/sP/ffT7TwXnz54ZnrCEg8eH01PWGJbz46dnZ2dvTP70xOW2N5TEQCAD0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGl/b3d/esMSH9q7Nj1hjb1z0wuWOTx/OD1hiYP9y9MTlni8OZmesMTp2e39h35qc3F6Av+Dbf0+H28eTE9Y5v7D29MTltjeUxEAgA9MLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPanB6zy+Ic/mJ6wxN5XvjY9YZlzexemJyyxeeMn0xOW2Hvhi9MT1jg5ml6wzPEr35uesMSZlz83PWGJk088Oz1hiYuv/XR6wjIHz9+YnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg/ReSTZXeH3nLpwAAAABJRU5ErkJggg==" id="image9880e25537" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc188663dab" d="M 0 0 
+       <path id="m9f3fdb7cb7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc188663dab" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc188663dab" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc188663dab" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc188663dab" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc188663dab" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc188663dab" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc188663dab" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc188663dab" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc188663dab" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc188663dab" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc188663dab" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc188663dab" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f3fdb7cb7" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m3d521f95f9" d="M 0 0 
+       <path id="m2e2e3008df" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2e2e3008df" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,24 +1138,9 @@ L 563.817548 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +0 -->
-    <g transform="translate(110.390926 69.553235) scale(0.065 -0.065)">
+    <!-- -0 -->
+    <g transform="translate(111.941786 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
 Q 1056 3291 1056 2328 
@@ -1178,27 +1163,62 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1225,10 +1245,36 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- +0 -->
-    <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    <!-- -2 -->
+    <g transform="translate(228.97711 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1274,51 +1320,22 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- +8 -->
+    <!-- +7 -->
     <g transform="translate(383.473351 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1363,10 +1380,10 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- -0 -->
+    <!-- -1 -->
     <g transform="translate(463.04776 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1404,10 +1421,10 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- +4 -->
+    <!-- +3 -->
     <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1434,32 +1451,6 @@ z
    <g id="text_36">
     <!-- -2 -->
     <g transform="translate(228.97711 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
@@ -1621,38 +1612,6 @@ z
    <g id="text_59">
     <!-- -6 -->
     <g transform="translate(189.965336 180.060583) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
     </g>
@@ -2101,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2ebcb80172" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image471d11bcf5" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mecace9a284" d="M 0 0 
+       <path id="m58885a1999" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58885a1999" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58885a1999" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58885a1999" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58885a1999" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58885a1999" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(201.361641 393.150844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2845,19 +2804,43 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
 z
-M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2872,14 +2855,14 @@ z
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2901,129 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(168.708281 401.184) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfbd230267e">
+  <clipPath id="p5c973a6271">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432.9pt" height="386.007781pt" viewBox="0 0 432.9 386.007781" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,233 +21,233 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 386.202469 
-L 570.708594 386.202469 
-L 570.708594 0 
+   <path d="M 0 386.007781 
+L 432.9 386.007781 
+L 432.9 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.479297 104.1264 
-L 292.104297 104.1264 
-L 292.104297 74.7432 
-L 187.479297 74.7432 
+    <path d="M 111.825 104.1264 
+L 216.45 104.1264 
+L 216.45 74.7432 
+L 111.825 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.104297 104.1264 
-L 396.729297 104.1264 
-L 396.729297 74.7432 
-L 292.104297 74.7432 
+    <path d="M 216.45 104.1264 
+L 321.075 104.1264 
+L 321.075 74.7432 
+L 216.45 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.729297 104.1264 
-L 501.354297 104.1264 
-L 501.354297 74.7432 
-L 396.729297 74.7432 
+    <path d="M 321.075 104.1264 
+L 425.7 104.1264 
+L 425.7 74.7432 
+L 321.075 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.479297 133.5096 
-L 292.104297 133.5096 
-L 292.104297 104.1264 
-L 187.479297 104.1264 
+    <path d="M 111.825 133.5096 
+L 216.45 133.5096 
+L 216.45 104.1264 
+L 111.825 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.104297 133.5096 
-L 396.729297 133.5096 
-L 396.729297 104.1264 
-L 292.104297 104.1264 
+    <path d="M 216.45 133.5096 
+L 321.075 133.5096 
+L 321.075 104.1264 
+L 216.45 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.729297 133.5096 
-L 501.354297 133.5096 
-L 501.354297 104.1264 
-L 396.729297 104.1264 
+    <path d="M 321.075 133.5096 
+L 425.7 133.5096 
+L 425.7 104.1264 
+L 321.075 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.479297 162.8928 
-L 292.104297 162.8928 
-L 292.104297 133.5096 
-L 187.479297 133.5096 
+    <path d="M 111.825 162.8928 
+L 216.45 162.8928 
+L 216.45 133.5096 
+L 111.825 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.104297 162.8928 
-L 396.729297 162.8928 
-L 396.729297 133.5096 
-L 292.104297 133.5096 
+    <path d="M 216.45 162.8928 
+L 321.075 162.8928 
+L 321.075 133.5096 
+L 216.45 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.729297 162.8928 
-L 501.354297 162.8928 
-L 501.354297 133.5096 
-L 396.729297 133.5096 
+    <path d="M 321.075 162.8928 
+L 425.7 162.8928 
+L 425.7 133.5096 
+L 321.075 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.479297 192.276 
-L 292.104297 192.276 
-L 292.104297 162.8928 
-L 187.479297 162.8928 
+    <path d="M 111.825 192.276 
+L 216.45 192.276 
+L 216.45 162.8928 
+L 111.825 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.104297 192.276 
-L 396.729297 192.276 
-L 396.729297 162.8928 
-L 292.104297 162.8928 
+    <path d="M 216.45 192.276 
+L 321.075 192.276 
+L 321.075 162.8928 
+L 216.45 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.729297 192.276 
-L 501.354297 192.276 
-L 501.354297 162.8928 
-L 396.729297 162.8928 
+    <path d="M 321.075 192.276 
+L 425.7 192.276 
+L 425.7 162.8928 
+L 321.075 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.479297 221.6592 
-L 292.104297 221.6592 
-L 292.104297 192.276 
-L 187.479297 192.276 
+    <path d="M 111.825 221.6592 
+L 216.45 221.6592 
+L 216.45 192.276 
+L 111.825 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.104297 221.6592 
-L 396.729297 221.6592 
-L 396.729297 192.276 
-L 292.104297 192.276 
+    <path d="M 216.45 221.6592 
+L 321.075 221.6592 
+L 321.075 192.276 
+L 216.45 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.729297 221.6592 
-L 501.354297 221.6592 
-L 501.354297 192.276 
-L 396.729297 192.276 
+    <path d="M 321.075 221.6592 
+L 425.7 221.6592 
+L 425.7 192.276 
+L 321.075 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fff2aa; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.479297 251.0424 
-L 292.104297 251.0424 
-L 292.104297 221.6592 
-L 187.479297 221.6592 
+    <path d="M 111.825 251.0424 
+L 216.45 251.0424 
+L 216.45 221.6592 
+L 111.825 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.104297 251.0424 
-L 396.729297 251.0424 
-L 396.729297 221.6592 
-L 292.104297 221.6592 
+    <path d="M 216.45 251.0424 
+L 321.075 251.0424 
+L 321.075 221.6592 
+L 216.45 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.729297 251.0424 
-L 501.354297 251.0424 
-L 501.354297 221.6592 
-L 396.729297 221.6592 
+    <path d="M 321.075 251.0424 
+L 425.7 251.0424 
+L 425.7 221.6592 
+L 321.075 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #f5fbb2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.479297 280.4256 
-L 292.104297 280.4256 
-L 292.104297 251.0424 
-L 187.479297 251.0424 
+    <path d="M 111.825 280.4256 
+L 216.45 280.4256 
+L 216.45 251.0424 
+L 111.825 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.104297 280.4256 
-L 396.729297 280.4256 
-L 396.729297 251.0424 
-L 292.104297 251.0424 
+    <path d="M 216.45 280.4256 
+L 321.075 280.4256 
+L 321.075 251.0424 
+L 216.45 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.729297 280.4256 
-L 501.354297 280.4256 
-L 501.354297 251.0424 
-L 396.729297 251.0424 
+    <path d="M 321.075 280.4256 
+L 425.7 280.4256 
+L 425.7 251.0424 
+L 321.075 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.479297 309.8088 
-L 292.104297 309.8088 
-L 292.104297 280.4256 
-L 187.479297 280.4256 
+    <path d="M 111.825 309.8088 
+L 216.45 309.8088 
+L 216.45 280.4256 
+L 111.825 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.104297 309.8088 
-L 396.729297 309.8088 
-L 396.729297 280.4256 
-L 292.104297 280.4256 
+    <path d="M 216.45 309.8088 
+L 321.075 309.8088 
+L 321.075 280.4256 
+L 216.45 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.729297 309.8088 
-L 501.354297 309.8088 
-L 501.354297 280.4256 
-L 396.729297 280.4256 
+    <path d="M 321.075 309.8088 
+L 425.7 309.8088 
+L 425.7 280.4256 
+L 321.075 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.479297 339.192 
-L 292.104297 339.192 
-L 292.104297 309.8088 
-L 187.479297 309.8088 
+    <path d="M 111.825 339.192 
+L 216.45 339.192 
+L 216.45 309.8088 
+L 111.825 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.104297 339.192 
-L 396.729297 339.192 
-L 396.729297 309.8088 
-L 292.104297 309.8088 
+    <path d="M 216.45 339.192 
+L 321.075 339.192 
+L 321.075 309.8088 
+L 216.45 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.729297 339.192 
-L 501.354297 339.192 
-L 501.354297 309.8088 
-L 396.729297 309.8088 
+    <path d="M 321.075 339.192 
+L 425.7 339.192 
+L 425.7 309.8088 
+L 321.075 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p244b368da6)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(44.812266 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(152.096484 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.668594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(329.020312 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(40.75 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(261.1275 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -951,8 +951,8 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 878 -->
-    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
+    <!-- 860 -->
+    <g transform="translate(365.7525 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -993,15 +993,45 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(35.388125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1130,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,46 +1161,14 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(263.6725 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1176,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.735547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(23.08125 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1347,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.768047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(44.11375 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(365.7525 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.305547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(52.65125 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1551,23 +1549,23 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 37 -->
-    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
+    <!-- 36 -->
+    <g transform="translate(263.6725 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 451 -->
-    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
+    <!-- 419 -->
+    <g transform="translate(365.7525 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.611797 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(35.9575 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.340547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1635,23 +1633,23 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(339.326797 238.5583) scale(0.08 -0.08)">
+    <!-- 33 -->
+    <g transform="translate(263.6725 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 532 -->
-    <g transform="translate(441.406797 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <!-- 493 -->
+    <g transform="translate(365.7525 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.113672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(22.459375 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1759,8 +1757,8 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- 0.332 -->
-    <g transform="translate(227.139922 267.9415) scale(0.08 -0.08)">
+    <!-- 0.330 -->
+    <g transform="translate(151.485625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1822,6 +1820,25 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 30 -->
+    <g transform="translate(263.19625 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 272 -->
+    <g transform="translate(365.038125 267.9415) scale(0.08 -0.08)">
+     <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
 L 3897 0 
@@ -1844,82 +1861,6 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 35 -->
-    <g transform="translate(338.850547 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 267 -->
-    <g transform="translate(440.692422 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
 L 3944 3988 
@@ -1932,13 +1873,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.228672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(20.574375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2003,7 +1944,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2013,21 +1954,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(263.6725 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(368.2975 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(48.795625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2038,7 +1979,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(152.68625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2048,13 +1989,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(266.2175 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(369.3875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2070,7 +2011,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.956016 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(76.301719 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2143,6 +2084,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2184,8 +2155,8 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
+   <!-- 2026-06-24T16:06:59Z  ·  Linux chungus x86_64  ·  commit 1ae66d3c -->
+   <g style="fill: #555555" transform="translate(87.061641 369.318844) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2275,6 +2246,76 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3321.923828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3385.400391 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3449.023438 0)"/>
+   </g>
+   <!--   ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(54.408281 377.352) scale(0.07 -0.07)">
+    <defs>
      <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
 L 1894 563 
@@ -2314,167 +2355,102 @@ L 750 794
 z
 " transform="scale(0.015625)"/>
     </defs>
-    <use xlink:href="#DejaVuSans-32"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
-    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
-    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
-    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-20"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(31.787109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(63.574219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(95.361328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(127.148438 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(158.935547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(186.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(248.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(309.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(372.900391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(436.376953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(475.240234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(536.421875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(595.601562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(657.125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(698.238281 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(731.929688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(759.712891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(821.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(882.515625 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(945.894531 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(1009.517578 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(1043.208984 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1102.388672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1166.011719 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1197.798828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1261.421875 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(1325.044922 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1356.832031 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(1420.455078 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1456.539062 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1495.402344 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1550.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1614.005859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1645.792969 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1677.580078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1709.367188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1741.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1772.941406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1812.150391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(1875.529297 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1914.392578 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1975.574219 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2038.953125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2102.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(2165.808594 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(2229.285156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2292.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2331.873047 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(2363.660156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2447.449219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2479.236328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2576.648438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2638.171875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2701.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2729.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2790.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2854.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2885.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2937.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3001.355469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3062.634766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3126.111328 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3178.210938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3241.589844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3302.771484 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(3341.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3375.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3407.458984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3448.572266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3509.851562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3549.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3576.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3638.025391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3697.595703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3749.695312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3781.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3844.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3906.482422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3945.691406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4007.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4046.578125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4143.990234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4171.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4235.152344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4262.935547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4315.035156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4354.244141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4382.027344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p03382f488f">
-   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p244b368da6">
+   <rect x="7.2" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-24T07:32:44Z",
+  "date": "2026-06-24T16:06:59Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "6ed05ade",
+  "git_commit": "1ae66d3c\n",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.81,
-   "decompress_mbps": 192.5
+   "compress_mbps": 39.66,
+   "decompress_mbps": 196.23
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 218.79
+   "compress_mbps": 38.32,
+   "decompress_mbps": 222.96
   },
   {
    "compressor": "native",
@@ -34,38 +34,38 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.01,
-   "decompress_mbps": 237.81
+   "compress_mbps": 35.4,
+   "decompress_mbps": 243.38
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 4,
-   "out_size": 54765,
-   "ratio": 0.3601,
-   "compress_mbps": 27.67,
-   "decompress_mbps": 240.42
+   "out_size": 54959,
+   "ratio": 0.3614,
+   "compress_mbps": 29.48,
+   "decompress_mbps": 177.3
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 5,
-   "out_size": 54681,
-   "ratio": 0.3595,
-   "compress_mbps": 26.72,
-   "decompress_mbps": 243.55
+   "out_size": 54594,
+   "ratio": 0.359,
+   "compress_mbps": 24.4,
+   "decompress_mbps": 247.33
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 6,
-   "out_size": 54535,
-   "ratio": 0.3586,
-   "compress_mbps": 24.85,
-   "decompress_mbps": 249.58
+   "out_size": 54437,
+   "ratio": 0.3579,
+   "compress_mbps": 21.96,
+   "decompress_mbps": 252.41
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 249.87
+   "compress_mbps": 20.61,
+   "decompress_mbps": 254.24
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.16,
-   "decompress_mbps": 250.97
+   "compress_mbps": 9.3,
+   "decompress_mbps": 254.55
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.78,
-   "decompress_mbps": 250.74
+   "compress_mbps": 1.79,
+   "decompress_mbps": 255.28
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 38.45,
-   "decompress_mbps": 185.72
+   "compress_mbps": 39.22,
+   "decompress_mbps": 186.34
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 35.32,
-   "decompress_mbps": 201.82
+   "compress_mbps": 36.13,
+   "decompress_mbps": 202.46
   },
   {
    "compressor": "native",
@@ -124,38 +124,38 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 218.98
+   "compress_mbps": 33.75,
+   "decompress_mbps": 220.63
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 4,
-   "out_size": 49034,
-   "ratio": 0.3917,
-   "compress_mbps": 25.6,
-   "decompress_mbps": 223.52
+   "out_size": 49102,
+   "ratio": 0.3923,
+   "compress_mbps": 27.35,
+   "decompress_mbps": 225.66
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 5,
-   "out_size": 48992,
-   "ratio": 0.3914,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 224.7
+   "out_size": 48949,
+   "ratio": 0.391,
+   "compress_mbps": 23.61,
+   "decompress_mbps": 227.46
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 6,
-   "out_size": 48934,
-   "ratio": 0.3909,
-   "compress_mbps": 23.67,
-   "decompress_mbps": 228.08
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 22.11,
+   "decompress_mbps": 231.43
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 228.56
+   "compress_mbps": 21.63,
+   "decompress_mbps": 231.82
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.93,
-   "decompress_mbps": 229.51
+   "compress_mbps": 9.11,
+   "decompress_mbps": 232.24
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.05,
-   "decompress_mbps": 228.42
+   "compress_mbps": 2.06,
+   "decompress_mbps": 230.71
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.99,
-   "decompress_mbps": 218.78
+   "compress_mbps": 35.26,
+   "decompress_mbps": 222.14
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.08,
-   "decompress_mbps": 226.09
+   "compress_mbps": 34.16,
+   "decompress_mbps": 228.19
   },
   {
    "compressor": "native",
@@ -214,38 +214,38 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.18,
-   "decompress_mbps": 230.46
+   "compress_mbps": 33.17,
+   "decompress_mbps": 232.27
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 4,
-   "out_size": 7968,
-   "ratio": 0.3239,
-   "compress_mbps": 30.2,
-   "decompress_mbps": 238.74
+   "out_size": 7986,
+   "ratio": 0.3246,
+   "compress_mbps": 31.8,
+   "decompress_mbps": 242.6
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 5,
-   "out_size": 7961,
-   "ratio": 0.3236,
-   "compress_mbps": 29.71,
-   "decompress_mbps": 245.79
+   "out_size": 7946,
+   "ratio": 0.323,
+   "compress_mbps": 28.98,
+   "decompress_mbps": 248.68
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 6,
-   "out_size": 7949,
-   "ratio": 0.3231,
-   "compress_mbps": 28.9,
-   "decompress_mbps": 245.84
+   "out_size": 7932,
+   "ratio": 0.3224,
+   "compress_mbps": 26.29,
+   "decompress_mbps": 250.64
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 249.81
+   "compress_mbps": 26.24,
+   "decompress_mbps": 252.31
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.62,
-   "decompress_mbps": 248.03
+   "compress_mbps": 9.91,
+   "decompress_mbps": 254.69
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 2.38,
-   "decompress_mbps": 249.38
+   "compress_mbps": 2.39,
+   "decompress_mbps": 254.87
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 148.73
+   "compress_mbps": 23.88,
+   "decompress_mbps": 152.69
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.77,
-   "decompress_mbps": 150.49
+   "compress_mbps": 23.4,
+   "decompress_mbps": 153.61
   },
   {
    "compressor": "native",
@@ -304,38 +304,38 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 154.29
+   "compress_mbps": 23.0,
+   "decompress_mbps": 158.06
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 4,
-   "out_size": 3147,
-   "ratio": 0.2822,
-   "compress_mbps": 21.3,
-   "decompress_mbps": 156.56
+   "out_size": 3153,
+   "ratio": 0.2828,
+   "compress_mbps": 21.83,
+   "decompress_mbps": 147.49
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 5,
-   "out_size": 3141,
-   "ratio": 0.2817,
-   "compress_mbps": 21.11,
-   "decompress_mbps": 158.05
+   "out_size": 3135,
+   "ratio": 0.2812,
+   "compress_mbps": 20.83,
+   "decompress_mbps": 162.47
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 6,
-   "out_size": 3133,
-   "ratio": 0.281,
-   "compress_mbps": 20.75,
-   "decompress_mbps": 158.35
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 19.71,
+   "decompress_mbps": 162.34
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 18.97,
-   "decompress_mbps": 159.05
+   "compress_mbps": 19.53,
+   "decompress_mbps": 162.57
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.02,
-   "decompress_mbps": 158.68
+   "compress_mbps": 7.2,
+   "decompress_mbps": 164.59
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 2.35,
-   "decompress_mbps": 159.2
+   "compress_mbps": 2.36,
+   "decompress_mbps": 162.78
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.71,
-   "decompress_mbps": 68.85
+   "compress_mbps": 12.04,
+   "decompress_mbps": 70.55
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.59,
-   "decompress_mbps": 69.86
+   "compress_mbps": 11.9,
+   "decompress_mbps": 70.92
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 69.53
+   "compress_mbps": 11.82,
+   "decompress_mbps": 71.13
   },
   {
    "compressor": "native",
@@ -404,28 +404,28 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.34,
-   "decompress_mbps": 70.11
+   "compress_mbps": 11.7,
+   "decompress_mbps": 71.62
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 5,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 69.87
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 11.42,
+   "decompress_mbps": 71.41
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 6,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.31,
-   "decompress_mbps": 70.45
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 11.35,
+   "decompress_mbps": 68.86
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.08,
-   "decompress_mbps": 70.49
+   "compress_mbps": 11.24,
+   "decompress_mbps": 71.68
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.82,
-   "decompress_mbps": 70.27
+   "compress_mbps": 3.92,
+   "decompress_mbps": 72.03
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 2.11,
-   "decompress_mbps": 70.29
+   "compress_mbps": 2.12,
+   "decompress_mbps": 71.97
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 65.25,
-   "decompress_mbps": 352.23
+   "compress_mbps": 67.59,
+   "decompress_mbps": 357.94
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 60.31,
-   "decompress_mbps": 381.58
+   "compress_mbps": 63.26,
+   "decompress_mbps": 381.78
   },
   {
    "compressor": "native",
@@ -484,38 +484,38 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 61.17,
-   "decompress_mbps": 402.39
+   "compress_mbps": 62.5,
+   "decompress_mbps": 410.95
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 4,
-   "out_size": 239898,
-   "ratio": 0.233,
-   "compress_mbps": 57.87,
-   "decompress_mbps": 427.0
+   "out_size": 240014,
+   "ratio": 0.2331,
+   "compress_mbps": 59.97,
+   "decompress_mbps": 433.19
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 5,
-   "out_size": 239804,
-   "ratio": 0.2329,
-   "compress_mbps": 56.72,
-   "decompress_mbps": 408.23
+   "out_size": 218178,
+   "ratio": 0.2119,
+   "compress_mbps": 39.42,
+   "decompress_mbps": 414.63
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 6,
-   "out_size": 239606,
-   "ratio": 0.2327,
-   "compress_mbps": 53.11,
-   "decompress_mbps": 410.96
+   "out_size": 215530,
+   "ratio": 0.2093,
+   "compress_mbps": 30.25,
+   "decompress_mbps": 428.31
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 427.98
+   "compress_mbps": 20.35,
+   "decompress_mbps": 414.01
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.39,
-   "decompress_mbps": 432.98
+   "compress_mbps": 7.4,
+   "decompress_mbps": 438.17
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.23,
-   "decompress_mbps": 435.5
+   "compress_mbps": 1.18,
+   "decompress_mbps": 438.95
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.66,
-   "decompress_mbps": 202.6
+   "compress_mbps": 45.96,
+   "decompress_mbps": 204.74
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.39,
-   "decompress_mbps": 217.96
+   "compress_mbps": 41.7,
+   "decompress_mbps": 221.52
   },
   {
    "compressor": "native",
@@ -574,38 +574,38 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.78,
-   "decompress_mbps": 243.06
+   "compress_mbps": 38.49,
+   "decompress_mbps": 246.96
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 4,
-   "out_size": 145779,
-   "ratio": 0.3416,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 247.21
+   "out_size": 146072,
+   "ratio": 0.3423,
+   "compress_mbps": 31.99,
+   "decompress_mbps": 251.29
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 5,
-   "out_size": 145631,
-   "ratio": 0.3413,
-   "compress_mbps": 28.54,
-   "decompress_mbps": 251.0
+   "out_size": 145517,
+   "ratio": 0.341,
+   "compress_mbps": 26.47,
+   "decompress_mbps": 254.47
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 145374,
-   "ratio": 0.3407,
-   "compress_mbps": 26.66,
-   "decompress_mbps": 254.42
+   "out_size": 145245,
+   "ratio": 0.3403,
+   "compress_mbps": 24.19,
+   "decompress_mbps": 259.53
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.12,
-   "decompress_mbps": 255.63
+   "compress_mbps": 22.73,
+   "decompress_mbps": 261.55
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.92,
-   "decompress_mbps": 256.24
+   "compress_mbps": 10.07,
+   "decompress_mbps": 260.68
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.82,
-   "decompress_mbps": 255.5
+   "compress_mbps": 1.8,
+   "decompress_mbps": 261.0
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 38.78,
-   "decompress_mbps": 175.7
+   "compress_mbps": 40.04,
+   "decompress_mbps": 176.28
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 35.34,
-   "decompress_mbps": 195.44
+   "compress_mbps": 36.41,
+   "decompress_mbps": 196.01
   },
   {
    "compressor": "native",
@@ -664,38 +664,38 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.81,
-   "decompress_mbps": 214.63
+   "compress_mbps": 33.29,
+   "decompress_mbps": 215.95
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 4,
-   "out_size": 195796,
-   "ratio": 0.4063,
-   "compress_mbps": 23.35,
-   "decompress_mbps": 218.58
+   "out_size": 196419,
+   "ratio": 0.4076,
+   "compress_mbps": 25.58,
+   "decompress_mbps": 220.5
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 5,
-   "out_size": 195460,
-   "ratio": 0.4056,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 216.54
+   "out_size": 195405,
+   "ratio": 0.4055,
+   "compress_mbps": 21.55,
+   "decompress_mbps": 219.41
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 6,
-   "out_size": 194965,
-   "ratio": 0.4046,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 221.35
+   "out_size": 194902,
+   "ratio": 0.4045,
+   "compress_mbps": 19.69,
+   "decompress_mbps": 224.03
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.12,
-   "decompress_mbps": 221.41
+   "compress_mbps": 18.59,
+   "decompress_mbps": 224.73
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 222.59
+   "compress_mbps": 8.56,
+   "decompress_mbps": 224.79
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.75,
-   "decompress_mbps": 221.76
+   "compress_mbps": 1.76,
+   "decompress_mbps": 223.87
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 125.1,
-   "decompress_mbps": 482.42
+   "compress_mbps": 129.19,
+   "decompress_mbps": 493.83
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 110.69,
-   "decompress_mbps": 505.87
+   "compress_mbps": 114.14,
+   "decompress_mbps": 521.63
   },
   {
    "compressor": "native",
@@ -754,38 +754,38 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 95.36,
-   "decompress_mbps": 547.73
+   "compress_mbps": 98.08,
+   "decompress_mbps": 567.14
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 4,
-   "out_size": 55724,
-   "ratio": 0.1086,
-   "compress_mbps": 75.64,
-   "decompress_mbps": 464.63
+   "out_size": 55815,
+   "ratio": 0.1088,
+   "compress_mbps": 82.16,
+   "decompress_mbps": 480.76
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 5,
-   "out_size": 55673,
-   "ratio": 0.1085,
-   "compress_mbps": 73.03,
-   "decompress_mbps": 498.82
+   "out_size": 55497,
+   "ratio": 0.1081,
+   "compress_mbps": 70.39,
+   "decompress_mbps": 513.65
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55441,
-   "ratio": 0.108,
-   "compress_mbps": 65.45,
-   "decompress_mbps": 545.1
+   "out_size": 54751,
+   "ratio": 0.1067,
+   "compress_mbps": 54.0,
+   "decompress_mbps": 557.56
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 36.76,
-   "decompress_mbps": 578.87
+   "compress_mbps": 37.92,
+   "decompress_mbps": 601.42
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.67,
-   "decompress_mbps": 621.92
+   "compress_mbps": 16.87,
+   "decompress_mbps": 641.9
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 1.09,
-   "decompress_mbps": 640.94
+   "compress_mbps": 1.06,
+   "decompress_mbps": 655.33
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.51,
-   "decompress_mbps": 186.49
+   "compress_mbps": 26.79,
+   "decompress_mbps": 188.51
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.78,
-   "decompress_mbps": 191.31
+   "compress_mbps": 26.26,
+   "decompress_mbps": 193.62
   },
   {
    "compressor": "native",
@@ -844,38 +844,38 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 194.47
+   "compress_mbps": 25.61,
+   "decompress_mbps": 196.82
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 4,
-   "out_size": 13371,
-   "ratio": 0.3497,
-   "compress_mbps": 23.02,
-   "decompress_mbps": 201.79
+   "out_size": 13376,
+   "ratio": 0.3498,
+   "compress_mbps": 23.83,
+   "decompress_mbps": 203.2
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 5,
-   "out_size": 13366,
-   "ratio": 0.3495,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 211.36
+   "out_size": 13345,
+   "ratio": 0.349,
+   "compress_mbps": 21.68,
+   "decompress_mbps": 212.69
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 13369,
-   "ratio": 0.3496,
-   "compress_mbps": 21.32,
-   "decompress_mbps": 216.29
+   "out_size": 13347,
+   "ratio": 0.349,
+   "compress_mbps": 19.93,
+   "decompress_mbps": 217.89
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.34,
-   "decompress_mbps": 217.45
+   "compress_mbps": 17.52,
+   "decompress_mbps": 218.87
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.32,
-   "decompress_mbps": 219.13
+   "compress_mbps": 5.38,
+   "decompress_mbps": 220.99
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.84,
-   "decompress_mbps": 220.23
+   "compress_mbps": 1.81,
+   "decompress_mbps": 224.12
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 75.88
+   "compress_mbps": 13.09,
+   "decompress_mbps": 76.93
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 75.9
+   "compress_mbps": 13.03,
+   "decompress_mbps": 76.86
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.85,
-   "decompress_mbps": 75.96
+   "compress_mbps": 13.0,
+   "decompress_mbps": 76.73
   },
   {
    "compressor": "native",
@@ -944,28 +944,28 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 76.56
+   "compress_mbps": 12.82,
+   "decompress_mbps": 77.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 5,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 12.64,
-   "decompress_mbps": 76.5
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 12.71,
+   "decompress_mbps": 77.92
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 6,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 76.48
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 12.67,
+   "decompress_mbps": 77.77
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.47,
-   "decompress_mbps": 76.38
+   "compress_mbps": 12.67,
+   "decompress_mbps": 77.68
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 76.57
+   "compress_mbps": 4.22,
+   "decompress_mbps": 77.52
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.46,
-   "decompress_mbps": 76.55
+   "compress_mbps": 2.49,
+   "decompress_mbps": 77.85
   },
   {
    "compressor": "zlib",
@@ -1004,8 +1004,8 @@
    "level": 1,
    "out_size": 65130,
    "ratio": 0.4282,
-   "compress_mbps": 118.84,
-   "decompress_mbps": 399.29
+   "compress_mbps": 119.27,
+   "decompress_mbps": 394.92
   },
   {
    "compressor": "zlib",
@@ -1014,8 +1014,8 @@
    "level": 2,
    "out_size": 62270,
    "ratio": 0.4094,
-   "compress_mbps": 101.78,
-   "decompress_mbps": 418.8
+   "compress_mbps": 102.4,
+   "decompress_mbps": 413.89
   },
   {
    "compressor": "zlib",
@@ -1024,8 +1024,8 @@
    "level": 3,
    "out_size": 59488,
    "ratio": 0.3911,
-   "compress_mbps": 67.0,
-   "decompress_mbps": 435.28
+   "compress_mbps": 67.29,
+   "decompress_mbps": 427.91
   },
   {
    "compressor": "zlib",
@@ -1034,8 +1034,8 @@
    "level": 4,
    "out_size": 57679,
    "ratio": 0.3792,
-   "compress_mbps": 71.67,
-   "decompress_mbps": 414.35
+   "compress_mbps": 71.25,
+   "decompress_mbps": 406.64
   },
   {
    "compressor": "zlib",
@@ -1044,8 +1044,8 @@
    "level": 5,
    "out_size": 55616,
    "ratio": 0.3657,
-   "compress_mbps": 41.81,
-   "decompress_mbps": 408.93
+   "compress_mbps": 41.84,
+   "decompress_mbps": 399.69
   },
   {
    "compressor": "zlib",
@@ -1054,8 +1054,8 @@
    "level": 6,
    "out_size": 54398,
    "ratio": 0.3577,
-   "compress_mbps": 25.53,
-   "decompress_mbps": 421.51
+   "compress_mbps": 25.56,
+   "decompress_mbps": 413.78
   },
   {
    "compressor": "zlib",
@@ -1064,8 +1064,8 @@
    "level": 7,
    "out_size": 54253,
    "ratio": 0.3567,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 423.73
+   "compress_mbps": 21.48,
+   "decompress_mbps": 415.74
   },
   {
    "compressor": "zlib",
@@ -1074,8 +1074,8 @@
    "level": 8,
    "out_size": 54164,
    "ratio": 0.3561,
-   "compress_mbps": 16.99,
-   "decompress_mbps": 425.54
+   "compress_mbps": 17.04,
+   "decompress_mbps": 414.68
   },
   {
    "compressor": "zlib",
@@ -1084,8 +1084,8 @@
    "level": 9,
    "out_size": 54164,
    "ratio": 0.3561,
-   "compress_mbps": 16.98,
-   "decompress_mbps": 423.92
+   "compress_mbps": 17.01,
+   "decompress_mbps": 417.54
   },
   {
    "compressor": "zlib",
@@ -1094,8 +1094,8 @@
    "level": 1,
    "out_size": 56791,
    "ratio": 0.4537,
-   "compress_mbps": 115.6,
-   "decompress_mbps": 394.7
+   "compress_mbps": 115.66,
+   "decompress_mbps": 391.7
   },
   {
    "compressor": "zlib",
@@ -1104,8 +1104,8 @@
    "level": 2,
    "out_size": 54652,
    "ratio": 0.4366,
-   "compress_mbps": 97.78,
-   "decompress_mbps": 407.38
+   "compress_mbps": 98.46,
+   "decompress_mbps": 405.26
   },
   {
    "compressor": "zlib",
@@ -1114,8 +1114,8 @@
    "level": 3,
    "out_size": 52663,
    "ratio": 0.4207,
-   "compress_mbps": 62.36,
-   "decompress_mbps": 428.67
+   "compress_mbps": 62.73,
+   "decompress_mbps": 429.5
   },
   {
    "compressor": "zlib",
@@ -1124,8 +1124,8 @@
    "level": 4,
    "out_size": 51266,
    "ratio": 0.4095,
-   "compress_mbps": 67.4,
-   "decompress_mbps": 398.49
+   "compress_mbps": 65.01,
+   "decompress_mbps": 396.89
   },
   {
    "compressor": "zlib",
@@ -1134,8 +1134,8 @@
    "level": 5,
    "out_size": 49622,
    "ratio": 0.3964,
-   "compress_mbps": 37.32,
-   "decompress_mbps": 386.08
+   "compress_mbps": 37.25,
+   "decompress_mbps": 383.29
   },
   {
    "compressor": "zlib",
@@ -1145,7 +1145,7 @@
    "out_size": 48891,
    "ratio": 0.3906,
    "compress_mbps": 22.81,
-   "decompress_mbps": 395.49
+   "decompress_mbps": 391.09
   },
   {
    "compressor": "zlib",
@@ -1154,8 +1154,8 @@
    "level": 7,
    "out_size": 48801,
    "ratio": 0.3898,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 397.56
+   "compress_mbps": 20.05,
+   "decompress_mbps": 391.76
   },
   {
    "compressor": "zlib",
@@ -1164,8 +1164,8 @@
    "level": 8,
    "out_size": 48772,
    "ratio": 0.3896,
-   "compress_mbps": 18.15,
-   "decompress_mbps": 395.81
+   "compress_mbps": 18.16,
+   "decompress_mbps": 391.13
   },
   {
    "compressor": "zlib",
@@ -1174,8 +1174,8 @@
    "level": 9,
    "out_size": 48772,
    "ratio": 0.3896,
-   "compress_mbps": 18.14,
-   "decompress_mbps": 399.23
+   "compress_mbps": 18.11,
+   "decompress_mbps": 391.41
   },
   {
    "compressor": "zlib",
@@ -1184,8 +1184,8 @@
    "level": 1,
    "out_size": 9028,
    "ratio": 0.3669,
-   "compress_mbps": 414.75,
-   "decompress_mbps": 1058.33
+   "compress_mbps": 416.0,
+   "decompress_mbps": 1043.46
   },
   {
    "compressor": "zlib",
@@ -1194,8 +1194,8 @@
    "level": 2,
    "out_size": 8811,
    "ratio": 0.3581,
-   "compress_mbps": 218.08,
-   "decompress_mbps": 1085.71
+   "compress_mbps": 230.99,
+   "decompress_mbps": 1060.44
   },
   {
    "compressor": "zlib",
@@ -1204,8 +1204,8 @@
    "level": 3,
    "out_size": 8616,
    "ratio": 0.3502,
-   "compress_mbps": 163.26,
-   "decompress_mbps": 1104.41
+   "compress_mbps": 160.8,
+   "decompress_mbps": 1084.96
   },
   {
    "compressor": "zlib",
@@ -1214,8 +1214,8 @@
    "level": 4,
    "out_size": 8219,
    "ratio": 0.3341,
-   "compress_mbps": 116.35,
-   "decompress_mbps": 1113.96
+   "compress_mbps": 115.04,
+   "decompress_mbps": 1120.45
   },
   {
    "compressor": "zlib",
@@ -1224,8 +1224,8 @@
    "level": 5,
    "out_size": 8001,
    "ratio": 0.3252,
-   "compress_mbps": 84.93,
-   "decompress_mbps": 1146.67
+   "compress_mbps": 84.1,
+   "decompress_mbps": 1144.21
   },
   {
    "compressor": "zlib",
@@ -1234,8 +1234,8 @@
    "level": 6,
    "out_size": 7955,
    "ratio": 0.3233,
-   "compress_mbps": 68.91,
-   "decompress_mbps": 1156.51
+   "compress_mbps": 68.08,
+   "decompress_mbps": 1147.52
   },
   {
    "compressor": "zlib",
@@ -1244,8 +1244,8 @@
    "level": 7,
    "out_size": 7933,
    "ratio": 0.3224,
-   "compress_mbps": 62.88,
-   "decompress_mbps": 1159.42
+   "compress_mbps": 62.59,
+   "decompress_mbps": 1154.86
   },
   {
    "compressor": "zlib",
@@ -1254,8 +1254,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 58.08,
-   "decompress_mbps": 1161.26
+   "compress_mbps": 57.44,
+   "decompress_mbps": 1154.63
   },
   {
    "compressor": "zlib",
@@ -1264,8 +1264,8 @@
    "level": 9,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 58.09,
-   "decompress_mbps": 1160.11
+   "compress_mbps": 56.94,
+   "decompress_mbps": 1152.82
   },
   {
    "compressor": "zlib",
@@ -1274,8 +1274,8 @@
    "level": 1,
    "out_size": 3647,
    "ratio": 0.3271,
-   "compress_mbps": 426.79,
-   "decompress_mbps": 1073.55
+   "compress_mbps": 426.48,
+   "decompress_mbps": 1063.13
   },
   {
    "compressor": "zlib",
@@ -1284,8 +1284,8 @@
    "level": 2,
    "out_size": 3501,
    "ratio": 0.314,
-   "compress_mbps": 408.84,
-   "decompress_mbps": 1117.67
+   "compress_mbps": 410.48,
+   "decompress_mbps": 1109.04
   },
   {
    "compressor": "zlib",
@@ -1294,8 +1294,8 @@
    "level": 3,
    "out_size": 3393,
    "ratio": 0.3043,
-   "compress_mbps": 338.35,
-   "decompress_mbps": 1147.08
+   "compress_mbps": 339.1,
+   "decompress_mbps": 1139.34
   },
   {
    "compressor": "zlib",
@@ -1304,8 +1304,8 @@
    "level": 4,
    "out_size": 3215,
    "ratio": 0.2883,
-   "compress_mbps": 271.93,
-   "decompress_mbps": 1175.75
+   "compress_mbps": 275.4,
+   "decompress_mbps": 1171.47
   },
   {
    "compressor": "zlib",
@@ -1314,8 +1314,8 @@
    "level": 5,
    "out_size": 3140,
    "ratio": 0.2816,
-   "compress_mbps": 205.2,
-   "decompress_mbps": 1205.2
+   "compress_mbps": 206.72,
+   "decompress_mbps": 1198.41
   },
   {
    "compressor": "zlib",
@@ -1324,8 +1324,8 @@
    "level": 6,
    "out_size": 3116,
    "ratio": 0.2795,
-   "compress_mbps": 154.1,
-   "decompress_mbps": 1215.53
+   "compress_mbps": 154.49,
+   "decompress_mbps": 1210.83
   },
   {
    "compressor": "zlib",
@@ -1334,8 +1334,8 @@
    "level": 7,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 131.87,
-   "decompress_mbps": 1216.78
+   "compress_mbps": 132.22,
+   "decompress_mbps": 1212.48
   },
   {
    "compressor": "zlib",
@@ -1344,8 +1344,8 @@
    "level": 8,
    "out_size": 3109,
    "ratio": 0.2788,
-   "compress_mbps": 111.18,
-   "decompress_mbps": 1216.5
+   "compress_mbps": 111.14,
+   "decompress_mbps": 1219.29
   },
   {
    "compressor": "zlib",
@@ -1355,7 +1355,7 @@
    "out_size": 3109,
    "ratio": 0.2788,
    "compress_mbps": 110.92,
-   "decompress_mbps": 1220.83
+   "decompress_mbps": 1209.86
   },
   {
    "compressor": "zlib",
@@ -1364,8 +1364,8 @@
    "level": 1,
    "out_size": 1326,
    "ratio": 0.3564,
-   "compress_mbps": 317.29,
-   "decompress_mbps": 787.88
+   "compress_mbps": 318.12,
+   "decompress_mbps": 773.29
   },
   {
    "compressor": "zlib",
@@ -1374,8 +1374,8 @@
    "level": 2,
    "out_size": 1306,
    "ratio": 0.351,
-   "compress_mbps": 310.71,
-   "decompress_mbps": 796.73
+   "compress_mbps": 310.03,
+   "decompress_mbps": 781.46
   },
   {
    "compressor": "zlib",
@@ -1384,8 +1384,8 @@
    "level": 3,
    "out_size": 1301,
    "ratio": 0.3496,
-   "compress_mbps": 291.04,
-   "decompress_mbps": 799.42
+   "compress_mbps": 292.62,
+   "decompress_mbps": 783.01
   },
   {
    "compressor": "zlib",
@@ -1394,8 +1394,8 @@
    "level": 4,
    "out_size": 1228,
    "ratio": 0.33,
-   "compress_mbps": 233.69,
-   "decompress_mbps": 825.26
+   "compress_mbps": 234.03,
+   "decompress_mbps": 820.87
   },
   {
    "compressor": "zlib",
@@ -1404,8 +1404,8 @@
    "level": 5,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 198.9,
-   "decompress_mbps": 831.06
+   "compress_mbps": 199.05,
+   "decompress_mbps": 816.34
   },
   {
    "compressor": "zlib",
@@ -1414,8 +1414,8 @@
    "level": 6,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 177.77,
-   "decompress_mbps": 832.23
+   "compress_mbps": 177.61,
+   "decompress_mbps": 827.96
   },
   {
    "compressor": "zlib",
@@ -1424,8 +1424,8 @@
    "level": 7,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 170.71,
-   "decompress_mbps": 821.82
+   "compress_mbps": 171.46,
+   "decompress_mbps": 827.96
   },
   {
    "compressor": "zlib",
@@ -1434,8 +1434,8 @@
    "level": 8,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 167.8,
-   "decompress_mbps": 826.61
+   "compress_mbps": 168.37,
+   "decompress_mbps": 828.73
   },
   {
    "compressor": "zlib",
@@ -1444,8 +1444,8 @@
    "level": 9,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 168.26,
-   "decompress_mbps": 828.73
+   "compress_mbps": 168.14,
+   "decompress_mbps": 827.96
   },
   {
    "compressor": "zlib",
@@ -1454,8 +1454,8 @@
    "level": 1,
    "out_size": 242293,
    "ratio": 0.2353,
-   "compress_mbps": 261.91,
-   "decompress_mbps": 834.71
+   "compress_mbps": 261.23,
+   "decompress_mbps": 838.46
   },
   {
    "compressor": "zlib",
@@ -1464,8 +1464,8 @@
    "level": 2,
    "out_size": 233553,
    "ratio": 0.2268,
-   "compress_mbps": 248.46,
-   "decompress_mbps": 990.64
+   "compress_mbps": 248.23,
+   "decompress_mbps": 994.27
   },
   {
    "compressor": "zlib",
@@ -1474,8 +1474,8 @@
    "level": 3,
    "out_size": 228222,
    "ratio": 0.2216,
-   "compress_mbps": 195.71,
-   "decompress_mbps": 1047.56
+   "compress_mbps": 195.51,
+   "decompress_mbps": 1047.83
   },
   {
    "compressor": "zlib",
@@ -1484,8 +1484,8 @@
    "level": 4,
    "out_size": 223668,
    "ratio": 0.2172,
-   "compress_mbps": 177.25,
-   "decompress_mbps": 1079.08
+   "compress_mbps": 177.31,
+   "decompress_mbps": 1078.22
   },
   {
    "compressor": "zlib",
@@ -1494,8 +1494,8 @@
    "level": 5,
    "out_size": 205994,
    "ratio": 0.2,
-   "compress_mbps": 110.7,
-   "decompress_mbps": 1038.46
+   "compress_mbps": 110.54,
+   "decompress_mbps": 1034.17
   },
   {
    "compressor": "zlib",
@@ -1504,8 +1504,8 @@
    "level": 6,
    "out_size": 203986,
    "ratio": 0.1981,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1033.64
+   "compress_mbps": 50.05,
+   "decompress_mbps": 1038.06
   },
   {
    "compressor": "zlib",
@@ -1514,8 +1514,8 @@
    "level": 7,
    "out_size": 207681,
    "ratio": 0.2017,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 1027.99
+   "compress_mbps": 37.02,
+   "decompress_mbps": 1027.93
   },
   {
    "compressor": "zlib",
@@ -1525,7 +1525,7 @@
    "out_size": 206827,
    "ratio": 0.2009,
    "compress_mbps": 7.29,
-   "decompress_mbps": 1001.69
+   "decompress_mbps": 999.69
   },
   {
    "compressor": "zlib",
@@ -1534,8 +1534,8 @@
    "level": 9,
    "out_size": 207023,
    "ratio": 0.201,
-   "compress_mbps": 3.43,
-   "decompress_mbps": 1007.49
+   "compress_mbps": 3.42,
+   "decompress_mbps": 994.71
   },
   {
    "compressor": "zlib",
@@ -1544,8 +1544,8 @@
    "level": 1,
    "out_size": 174124,
    "ratio": 0.408,
-   "compress_mbps": 124.52,
-   "decompress_mbps": 403.49
+   "compress_mbps": 123.85,
+   "decompress_mbps": 393.9
   },
   {
    "compressor": "zlib",
@@ -1554,8 +1554,8 @@
    "level": 2,
    "out_size": 166150,
    "ratio": 0.3893,
-   "compress_mbps": 105.75,
-   "decompress_mbps": 410.83
+   "compress_mbps": 105.32,
+   "decompress_mbps": 406.36
   },
   {
    "compressor": "zlib",
@@ -1564,8 +1564,8 @@
    "level": 3,
    "out_size": 158784,
    "ratio": 0.3721,
-   "compress_mbps": 70.62,
-   "decompress_mbps": 431.19
+   "compress_mbps": 70.35,
+   "decompress_mbps": 419.02
   },
   {
    "compressor": "zlib",
@@ -1574,8 +1574,8 @@
    "level": 4,
    "out_size": 152782,
    "ratio": 0.358,
-   "compress_mbps": 74.37,
-   "decompress_mbps": 417.63
+   "compress_mbps": 73.27,
+   "decompress_mbps": 405.96
   },
   {
    "compressor": "zlib",
@@ -1584,8 +1584,8 @@
    "level": 5,
    "out_size": 147196,
    "ratio": 0.3449,
-   "compress_mbps": 43.69,
-   "decompress_mbps": 412.43
+   "compress_mbps": 43.15,
+   "decompress_mbps": 400.66
   },
   {
    "compressor": "zlib",
@@ -1594,8 +1594,8 @@
    "level": 6,
    "out_size": 144898,
    "ratio": 0.3395,
-   "compress_mbps": 26.54,
-   "decompress_mbps": 422.22
+   "compress_mbps": 26.3,
+   "decompress_mbps": 411.78
   },
   {
    "compressor": "zlib",
@@ -1604,8 +1604,8 @@
    "level": 7,
    "out_size": 144589,
    "ratio": 0.3388,
-   "compress_mbps": 23.0,
-   "decompress_mbps": 422.54
+   "compress_mbps": 22.83,
+   "decompress_mbps": 415.4
   },
   {
    "compressor": "zlib",
@@ -1614,8 +1614,8 @@
    "level": 8,
    "out_size": 144436,
    "ratio": 0.3385,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 426.62
+   "compress_mbps": 19.63,
+   "decompress_mbps": 413.63
   },
   {
    "compressor": "zlib",
@@ -1624,8 +1624,8 @@
    "level": 9,
    "out_size": 144433,
    "ratio": 0.3384,
-   "compress_mbps": 19.7,
-   "decompress_mbps": 427.06
+   "compress_mbps": 19.59,
+   "decompress_mbps": 412.86
   },
   {
    "compressor": "zlib",
@@ -1634,8 +1634,8 @@
    "level": 1,
    "out_size": 228883,
    "ratio": 0.475,
-   "compress_mbps": 108.85,
-   "decompress_mbps": 379.18
+   "compress_mbps": 108.04,
+   "decompress_mbps": 370.71
   },
   {
    "compressor": "zlib",
@@ -1644,8 +1644,8 @@
    "level": 2,
    "out_size": 219047,
    "ratio": 0.4546,
-   "compress_mbps": 91.35,
-   "decompress_mbps": 396.75
+   "compress_mbps": 90.78,
+   "decompress_mbps": 387.31
   },
   {
    "compressor": "zlib",
@@ -1654,8 +1654,8 @@
    "level": 3,
    "out_size": 209408,
    "ratio": 0.4346,
-   "compress_mbps": 55.73,
-   "decompress_mbps": 408.77
+   "compress_mbps": 55.5,
+   "decompress_mbps": 404.82
   },
   {
    "compressor": "zlib",
@@ -1664,8 +1664,8 @@
    "level": 4,
    "out_size": 205916,
    "ratio": 0.4273,
-   "compress_mbps": 62.79,
-   "decompress_mbps": 384.06
+   "compress_mbps": 61.73,
+   "decompress_mbps": 372.43
   },
   {
    "compressor": "zlib",
@@ -1674,8 +1674,8 @@
    "level": 5,
    "out_size": 199188,
    "ratio": 0.4134,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 365.25
+   "compress_mbps": 32.8,
+   "decompress_mbps": 352.78
   },
   {
    "compressor": "zlib",
@@ -1684,8 +1684,8 @@
    "level": 6,
    "out_size": 195255,
    "ratio": 0.4052,
-   "compress_mbps": 19.51,
-   "decompress_mbps": 371.54
+   "compress_mbps": 19.33,
+   "decompress_mbps": 362.4
   },
   {
    "compressor": "zlib",
@@ -1694,8 +1694,8 @@
    "level": 7,
    "out_size": 194657,
    "ratio": 0.404,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 368.04
+   "compress_mbps": 16.38,
+   "decompress_mbps": 366.0
   },
   {
    "compressor": "zlib",
@@ -1704,8 +1704,8 @@
    "level": 8,
    "out_size": 194326,
    "ratio": 0.4033,
-   "compress_mbps": 13.04,
-   "decompress_mbps": 372.62
+   "compress_mbps": 12.95,
+   "decompress_mbps": 367.53
   },
   {
    "compressor": "zlib",
@@ -1714,8 +1714,8 @@
    "level": 9,
    "out_size": 194326,
    "ratio": 0.4033,
-   "compress_mbps": 13.03,
-   "decompress_mbps": 376.86
+   "compress_mbps": 12.95,
+   "decompress_mbps": 367.82
   },
   {
    "compressor": "zlib",
@@ -1724,8 +1724,8 @@
    "level": 1,
    "out_size": 65553,
    "ratio": 0.1277,
-   "compress_mbps": 277.05,
-   "decompress_mbps": 898.35
+   "compress_mbps": 274.81,
+   "decompress_mbps": 888.06
   },
   {
    "compressor": "zlib",
@@ -1734,8 +1734,8 @@
    "level": 2,
    "out_size": 63891,
    "ratio": 0.1245,
-   "compress_mbps": 249.81,
-   "decompress_mbps": 925.37
+   "compress_mbps": 247.07,
+   "decompress_mbps": 912.92
   },
   {
    "compressor": "zlib",
@@ -1744,8 +1744,8 @@
    "level": 3,
    "out_size": 62515,
    "ratio": 0.1218,
-   "compress_mbps": 196.22,
-   "decompress_mbps": 996.47
+   "compress_mbps": 193.85,
+   "decompress_mbps": 973.69
   },
   {
    "compressor": "zlib",
@@ -1754,8 +1754,8 @@
    "level": 4,
    "out_size": 58451,
    "ratio": 0.1139,
-   "compress_mbps": 170.56,
-   "decompress_mbps": 705.74
+   "compress_mbps": 167.3,
+   "decompress_mbps": 693.88
   },
   {
    "compressor": "zlib",
@@ -1764,8 +1764,8 @@
    "level": 5,
    "out_size": 57410,
    "ratio": 0.1119,
-   "compress_mbps": 131.27,
-   "decompress_mbps": 733.83
+   "compress_mbps": 129.08,
+   "decompress_mbps": 727.56
   },
   {
    "compressor": "zlib",
@@ -1774,8 +1774,8 @@
    "level": 6,
    "out_size": 56459,
    "ratio": 0.11,
-   "compress_mbps": 77.73,
-   "decompress_mbps": 785.69
+   "compress_mbps": 76.89,
+   "decompress_mbps": 780.11
   },
   {
    "compressor": "zlib",
@@ -1784,8 +1784,8 @@
    "level": 7,
    "out_size": 55358,
    "ratio": 0.1079,
-   "compress_mbps": 60.89,
-   "decompress_mbps": 824.41
+   "compress_mbps": 60.24,
+   "decompress_mbps": 811.26
   },
   {
    "compressor": "zlib",
@@ -1794,8 +1794,8 @@
    "level": 8,
    "out_size": 52991,
    "ratio": 0.1033,
-   "compress_mbps": 27.8,
-   "decompress_mbps": 878.92
+   "compress_mbps": 27.54,
+   "decompress_mbps": 865.12
   },
   {
    "compressor": "zlib",
@@ -1804,8 +1804,8 @@
    "level": 9,
    "out_size": 52215,
    "ratio": 0.1017,
-   "compress_mbps": 9.91,
-   "decompress_mbps": 892.75
+   "compress_mbps": 9.82,
+   "decompress_mbps": 882.15
   },
   {
    "compressor": "zlib",
@@ -1814,8 +1814,8 @@
    "level": 1,
    "out_size": 14112,
    "ratio": 0.369,
-   "compress_mbps": 130.36,
-   "decompress_mbps": 944.12
+   "compress_mbps": 129.51,
+   "decompress_mbps": 925.6
   },
   {
    "compressor": "zlib",
@@ -1824,8 +1824,8 @@
    "level": 2,
    "out_size": 13815,
    "ratio": 0.3613,
-   "compress_mbps": 110.11,
-   "decompress_mbps": 978.68
+   "compress_mbps": 108.93,
+   "decompress_mbps": 964.14
   },
   {
    "compressor": "zlib",
@@ -1834,8 +1834,8 @@
    "level": 3,
    "out_size": 13795,
    "ratio": 0.3607,
-   "compress_mbps": 79.64,
-   "decompress_mbps": 1014.48
+   "compress_mbps": 78.79,
+   "decompress_mbps": 1005.22
   },
   {
    "compressor": "zlib",
@@ -1844,8 +1844,8 @@
    "level": 4,
    "out_size": 13375,
    "ratio": 0.3498,
-   "compress_mbps": 81.09,
-   "decompress_mbps": 997.82
+   "compress_mbps": 79.72,
+   "decompress_mbps": 993.67
   },
   {
    "compressor": "zlib",
@@ -1854,8 +1854,8 @@
    "level": 5,
    "out_size": 13062,
    "ratio": 0.3416,
-   "compress_mbps": 56.15,
-   "decompress_mbps": 1040.2
+   "compress_mbps": 54.93,
+   "decompress_mbps": 1029.43
   },
   {
    "compressor": "zlib",
@@ -1864,8 +1864,8 @@
    "level": 6,
    "out_size": 12984,
    "ratio": 0.3395,
-   "compress_mbps": 33.24,
-   "decompress_mbps": 1062.14
+   "compress_mbps": 32.74,
+   "decompress_mbps": 1049.21
   },
   {
    "compressor": "zlib",
@@ -1874,8 +1874,8 @@
    "level": 7,
    "out_size": 12949,
    "ratio": 0.3386,
-   "compress_mbps": 25.62,
-   "decompress_mbps": 1070.49
+   "compress_mbps": 25.17,
+   "decompress_mbps": 1050.42
   },
   {
    "compressor": "zlib",
@@ -1884,8 +1884,8 @@
    "level": 8,
    "out_size": 12894,
    "ratio": 0.3372,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 1080.36
+   "compress_mbps": 11.02,
+   "decompress_mbps": 1065.8
   },
   {
    "compressor": "zlib",
@@ -1894,8 +1894,8 @@
    "level": 9,
    "out_size": 12832,
    "ratio": 0.3356,
-   "compress_mbps": 5.1,
-   "decompress_mbps": 1081.93
+   "compress_mbps": 5.07,
+   "decompress_mbps": 1069.55
   },
   {
    "compressor": "zlib",
@@ -1904,8 +1904,8 @@
    "level": 1,
    "out_size": 1846,
    "ratio": 0.4367,
-   "compress_mbps": 290.31,
-   "decompress_mbps": 710.34
+   "compress_mbps": 291.69,
+   "decompress_mbps": 702.3
   },
   {
    "compressor": "zlib",
@@ -1914,8 +1914,8 @@
    "level": 2,
    "out_size": 1820,
    "ratio": 0.4306,
-   "compress_mbps": 284.39,
-   "decompress_mbps": 723.73
+   "compress_mbps": 286.69,
+   "decompress_mbps": 716.78
   },
   {
    "compressor": "zlib",
@@ -1924,8 +1924,8 @@
    "level": 3,
    "out_size": 1808,
    "ratio": 0.4277,
-   "compress_mbps": 272.54,
-   "decompress_mbps": 726.34
+   "compress_mbps": 274.01,
+   "decompress_mbps": 722.3
   },
   {
    "compressor": "zlib",
@@ -1934,8 +1934,8 @@
    "level": 4,
    "out_size": 1749,
    "ratio": 0.4138,
-   "compress_mbps": 226.28,
-   "decompress_mbps": 749.43
+   "compress_mbps": 228.5,
+   "decompress_mbps": 737.5
   },
   {
    "compressor": "zlib",
@@ -1944,8 +1944,8 @@
    "level": 5,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 202.59,
-   "decompress_mbps": 753.91
+   "compress_mbps": 203.69,
+   "decompress_mbps": 736.69
   },
   {
    "compressor": "zlib",
@@ -1954,8 +1954,8 @@
    "level": 6,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 199.81,
-   "decompress_mbps": 754.2
+   "compress_mbps": 200.99,
+   "decompress_mbps": 745.41
   },
   {
    "compressor": "zlib",
@@ -1964,8 +1964,8 @@
    "level": 7,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 196.62,
-   "decompress_mbps": 753.91
+   "compress_mbps": 198.34,
+   "decompress_mbps": 742.53
   },
   {
    "compressor": "zlib",
@@ -1974,8 +1974,8 @@
    "level": 8,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 197.1,
-   "decompress_mbps": 754.2
+   "compress_mbps": 198.34,
+   "decompress_mbps": 744.72
   },
   {
    "compressor": "zlib",
@@ -1984,8 +1984,8 @@
    "level": 9,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 197.89,
-   "decompress_mbps": 752.93
+   "compress_mbps": 198.46,
+   "decompress_mbps": 744.58
   },
   {
    "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
    "level": 1,
    "out_size": 76470,
    "ratio": 0.5028,
-   "compress_mbps": 156.81,
-   "decompress_mbps": 442.0
+   "compress_mbps": 156.74,
+   "decompress_mbps": 456.71
   },
   {
    "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
    "level": 2,
    "out_size": 62765,
    "ratio": 0.4127,
-   "compress_mbps": 133.14,
-   "decompress_mbps": 491.57
+   "compress_mbps": 133.4,
+   "decompress_mbps": 508.42
   },
   {
    "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
    "level": 3,
    "out_size": 57162,
    "ratio": 0.3758,
-   "compress_mbps": 72.46,
-   "decompress_mbps": 549.38
+   "compress_mbps": 72.53,
+   "decompress_mbps": 561.81
   },
   {
    "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
    "level": 4,
    "out_size": 56826,
    "ratio": 0.3736,
-   "compress_mbps": 64.54,
-   "decompress_mbps": 540.99
+   "compress_mbps": 64.53,
+   "decompress_mbps": 546.66
   },
   {
    "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
    "level": 5,
    "out_size": 55696,
    "ratio": 0.3662,
-   "compress_mbps": 46.93,
-   "decompress_mbps": 528.35
+   "compress_mbps": 47.03,
+   "decompress_mbps": 538.57
   },
   {
    "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
    "level": 6,
    "out_size": 54440,
    "ratio": 0.3579,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 545.39
+   "compress_mbps": 26.63,
+   "decompress_mbps": 555.61
   },
   {
    "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
    "level": 7,
    "out_size": 54283,
    "ratio": 0.3569,
-   "compress_mbps": 22.46,
-   "decompress_mbps": 546.21
+   "compress_mbps": 22.47,
+   "decompress_mbps": 550.92
   },
   {
    "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
    "level": 8,
    "out_size": 54221,
    "ratio": 0.3565,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 546.31
+   "compress_mbps": 19.76,
+   "decompress_mbps": 550.84
   },
   {
    "compressor": "miniz_oxide",
@@ -2075,7 +2075,7 @@
    "out_size": 54217,
    "ratio": 0.3565,
    "compress_mbps": 19.52,
-   "decompress_mbps": 546.07
+   "decompress_mbps": 552.89
   },
   {
    "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
    "level": 1,
    "out_size": 64926,
    "ratio": 0.5187,
-   "compress_mbps": 150.76,
-   "decompress_mbps": 420.61
+   "compress_mbps": 149.44,
+   "decompress_mbps": 436.31
   },
   {
    "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
    "level": 2,
    "out_size": 54985,
    "ratio": 0.4393,
-   "compress_mbps": 124.87,
-   "decompress_mbps": 468.91
+   "compress_mbps": 125.56,
+   "decompress_mbps": 483.78
   },
   {
    "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
    "level": 3,
    "out_size": 51148,
    "ratio": 0.4086,
-   "compress_mbps": 67.28,
-   "decompress_mbps": 536.64
+   "compress_mbps": 67.54,
+   "decompress_mbps": 548.32
   },
   {
    "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
    "level": 4,
    "out_size": 50599,
    "ratio": 0.4042,
-   "compress_mbps": 59.25,
-   "decompress_mbps": 526.29
+   "compress_mbps": 59.29,
+   "decompress_mbps": 535.19
   },
   {
    "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
    "level": 5,
    "out_size": 49775,
    "ratio": 0.3976,
-   "compress_mbps": 42.72,
-   "decompress_mbps": 513.76
+   "compress_mbps": 42.81,
+   "decompress_mbps": 516.56
   },
   {
    "compressor": "miniz_oxide",
@@ -2135,7 +2135,7 @@
    "out_size": 48967,
    "ratio": 0.3912,
    "compress_mbps": 25.03,
-   "decompress_mbps": 524.3
+   "decompress_mbps": 529.17
   },
   {
    "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
    "level": 7,
    "out_size": 48870,
    "ratio": 0.3904,
-   "compress_mbps": 22.21,
-   "decompress_mbps": 523.8
+   "compress_mbps": 22.23,
+   "decompress_mbps": 531.97
   },
   {
    "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
    "level": 8,
    "out_size": 48845,
    "ratio": 0.3902,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 522.13
+   "compress_mbps": 20.96,
+   "decompress_mbps": 530.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2165,7 +2165,7 @@
    "out_size": 48845,
    "ratio": 0.3902,
    "compress_mbps": 20.95,
-   "decompress_mbps": 524.0
+   "decompress_mbps": 532.37
   },
   {
    "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
    "level": 1,
    "out_size": 10024,
    "ratio": 0.4074,
-   "compress_mbps": 568.72,
-   "decompress_mbps": 906.86
+   "compress_mbps": 568.96,
+   "decompress_mbps": 899.91
   },
   {
    "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
    "level": 2,
    "out_size": 8577,
    "ratio": 0.3486,
-   "compress_mbps": 269.07,
-   "decompress_mbps": 929.83
+   "compress_mbps": 261.52,
+   "decompress_mbps": 924.55
   },
   {
    "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
    "level": 3,
    "out_size": 8168,
    "ratio": 0.332,
-   "compress_mbps": 155.49,
-   "decompress_mbps": 951.35
+   "compress_mbps": 155.17,
+   "decompress_mbps": 952.4
   },
   {
    "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
    "level": 4,
    "out_size": 8069,
    "ratio": 0.328,
-   "compress_mbps": 116.17,
-   "decompress_mbps": 969.68
+   "compress_mbps": 116.8,
+   "decompress_mbps": 970.72
   },
   {
    "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
    "level": 5,
    "out_size": 7997,
    "ratio": 0.325,
-   "compress_mbps": 100.13,
-   "decompress_mbps": 1001.46
+   "compress_mbps": 101.23,
+   "decompress_mbps": 999.63
   },
   {
    "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
    "level": 6,
    "out_size": 7952,
    "ratio": 0.3232,
-   "compress_mbps": 74.99,
-   "decompress_mbps": 1003.47
+   "compress_mbps": 75.62,
+   "decompress_mbps": 1005.02
   },
   {
    "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
    "level": 7,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 72.24,
-   "decompress_mbps": 1009.09
+   "compress_mbps": 72.76,
+   "decompress_mbps": 1010.13
   },
   {
    "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
    "level": 8,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 71.2,
-   "decompress_mbps": 1009.52
+   "compress_mbps": 71.86,
+   "decompress_mbps": 1012.92
   },
   {
    "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
    "level": 9,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 70.94,
-   "decompress_mbps": 1010.39
+   "compress_mbps": 71.52,
+   "decompress_mbps": 1013.18
   },
   {
    "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
    "level": 1,
    "out_size": 4061,
    "ratio": 0.3642,
-   "compress_mbps": 505.27,
-   "decompress_mbps": 857.33
+   "compress_mbps": 507.66,
+   "decompress_mbps": 856.5
   },
   {
    "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
    "level": 2,
    "out_size": 3446,
    "ratio": 0.3091,
-   "compress_mbps": 303.09,
-   "decompress_mbps": 902.14
+   "compress_mbps": 305.8,
+   "decompress_mbps": 896.28
   },
   {
    "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
    "level": 3,
    "out_size": 3201,
    "ratio": 0.2871,
-   "compress_mbps": 235.32,
-   "decompress_mbps": 933.5
+   "compress_mbps": 235.17,
+   "decompress_mbps": 928.77
   },
   {
    "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
    "level": 4,
    "out_size": 3168,
    "ratio": 0.2841,
-   "compress_mbps": 196.56,
-   "decompress_mbps": 955.13
+   "compress_mbps": 194.23,
+   "decompress_mbps": 952.82
   },
   {
    "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
    "level": 5,
    "out_size": 3139,
    "ratio": 0.2815,
-   "compress_mbps": 162.35,
-   "decompress_mbps": 979.95
+   "compress_mbps": 162.87,
+   "decompress_mbps": 977.61
   },
   {
    "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
    "level": 6,
    "out_size": 3115,
    "ratio": 0.2794,
-   "compress_mbps": 116.87,
-   "decompress_mbps": 990.27
+   "compress_mbps": 116.14,
+   "decompress_mbps": 983.76
   },
   {
    "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
    "level": 7,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 106.87,
-   "decompress_mbps": 991.47
+   "compress_mbps": 106.51,
+   "decompress_mbps": 988.42
   },
   {
    "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
    "level": 8,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 103.44,
-   "decompress_mbps": 992.11
+   "compress_mbps": 103.17,
+   "decompress_mbps": 989.62
   },
   {
    "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
    "level": 9,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 103.35,
-   "decompress_mbps": 992.21
+   "compress_mbps": 103.08,
+   "decompress_mbps": 990.36
   },
   {
    "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
    "level": 1,
    "out_size": 1410,
    "ratio": 0.3789,
-   "compress_mbps": 365.35,
-   "decompress_mbps": 595.71
+   "compress_mbps": 367.09,
+   "decompress_mbps": 599.13
   },
   {
    "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
    "level": 2,
    "out_size": 1262,
    "ratio": 0.3392,
-   "compress_mbps": 234.59,
-   "decompress_mbps": 602.38
+   "compress_mbps": 238.29,
+   "decompress_mbps": 607.22
   },
   {
    "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
    "level": 3,
    "out_size": 1238,
    "ratio": 0.3327,
-   "compress_mbps": 206.3,
-   "decompress_mbps": 606.19
+   "compress_mbps": 207.05,
+   "decompress_mbps": 610.67
   },
   {
    "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
    "level": 4,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 178.27,
-   "decompress_mbps": 624.32
+   "compress_mbps": 178.03,
+   "decompress_mbps": 629.97
   },
   {
    "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
    "level": 5,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 163.31,
-   "decompress_mbps": 633.68
+   "compress_mbps": 162.51,
+   "decompress_mbps": 635.5
   },
   {
    "compressor": "miniz_oxide",
@@ -2404,8 +2404,8 @@
    "level": 6,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 631.88
+   "compress_mbps": 147.52,
+   "decompress_mbps": 637.55
   },
   {
    "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
    "level": 7,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.05,
-   "decompress_mbps": 632.21
+   "compress_mbps": 147.18,
+   "decompress_mbps": 633.68
   },
   {
    "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
    "level": 8,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.52,
-   "decompress_mbps": 634.82
+   "compress_mbps": 147.25,
+   "decompress_mbps": 634.59
   },
   {
    "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
    "level": 9,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.39,
-   "decompress_mbps": 634.93
+   "compress_mbps": 146.58,
+   "decompress_mbps": 637.1
   },
   {
    "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
    "level": 1,
    "out_size": 274412,
    "ratio": 0.2665,
-   "compress_mbps": 452.12,
-   "decompress_mbps": 796.51
+   "compress_mbps": 450.45,
+   "decompress_mbps": 802.78
   },
   {
    "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
    "level": 2,
    "out_size": 213239,
    "ratio": 0.2071,
-   "compress_mbps": 274.72,
-   "decompress_mbps": 895.56
+   "compress_mbps": 276.41,
+   "decompress_mbps": 903.69
   },
   {
    "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
    "level": 3,
    "out_size": 232107,
    "ratio": 0.2254,
-   "compress_mbps": 137.22,
-   "decompress_mbps": 936.66
+   "compress_mbps": 137.08,
+   "decompress_mbps": 945.7
   },
   {
    "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
    "level": 4,
    "out_size": 202733,
    "ratio": 0.1969,
-   "compress_mbps": 130.42,
-   "decompress_mbps": 942.52
+   "compress_mbps": 130.26,
+   "decompress_mbps": 951.33
   },
   {
    "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
    "level": 5,
    "out_size": 207803,
    "ratio": 0.2018,
-   "compress_mbps": 84.44,
-   "decompress_mbps": 954.1
+   "compress_mbps": 84.26,
+   "decompress_mbps": 962.54
   },
   {
    "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
    "level": 6,
    "out_size": 205270,
    "ratio": 0.1993,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 981.19
+   "compress_mbps": 27.31,
+   "decompress_mbps": 991.77
   },
   {
    "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
    "level": 7,
    "out_size": 209951,
    "ratio": 0.2039,
-   "compress_mbps": 19.33,
-   "decompress_mbps": 997.67
+   "compress_mbps": 19.31,
+   "decompress_mbps": 1006.13
   },
   {
    "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
    "level": 8,
    "out_size": 209656,
    "ratio": 0.2036,
-   "compress_mbps": 12.25,
-   "decompress_mbps": 1008.86
+   "compress_mbps": 12.22,
+   "decompress_mbps": 1014.34
   },
   {
    "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
    "level": 9,
    "out_size": 209189,
    "ratio": 0.2031,
-   "compress_mbps": 8.96,
-   "decompress_mbps": 1009.49
+   "compress_mbps": 8.95,
+   "decompress_mbps": 1017.41
   },
   {
    "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
    "level": 1,
    "out_size": 208640,
    "ratio": 0.4889,
-   "compress_mbps": 157.34,
-   "decompress_mbps": 424.83
+   "compress_mbps": 156.34,
+   "decompress_mbps": 441.79
   },
   {
    "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
    "level": 2,
    "out_size": 167329,
    "ratio": 0.3921,
-   "compress_mbps": 138.54,
-   "decompress_mbps": 464.58
+   "compress_mbps": 138.63,
+   "decompress_mbps": 479.96
   },
   {
    "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
    "level": 3,
    "out_size": 151097,
    "ratio": 0.3541,
-   "compress_mbps": 73.57,
-   "decompress_mbps": 510.84
+   "compress_mbps": 73.95,
+   "decompress_mbps": 525.61
   },
   {
    "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
    "level": 4,
    "out_size": 150035,
    "ratio": 0.3516,
-   "compress_mbps": 66.59,
-   "decompress_mbps": 511.35
+   "compress_mbps": 66.65,
+   "decompress_mbps": 520.19
   },
   {
    "compressor": "miniz_oxide",
@@ -2574,8 +2574,8 @@
    "level": 5,
    "out_size": 147375,
    "ratio": 0.3453,
-   "compress_mbps": 48.11,
-   "decompress_mbps": 508.07
+   "compress_mbps": 48.3,
+   "decompress_mbps": 514.71
   },
   {
    "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
    "level": 6,
    "out_size": 144908,
    "ratio": 0.3396,
-   "compress_mbps": 28.06,
-   "decompress_mbps": 519.16
+   "compress_mbps": 28.08,
+   "decompress_mbps": 526.18
   },
   {
    "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
    "level": 7,
    "out_size": 144562,
    "ratio": 0.3387,
-   "compress_mbps": 24.64,
-   "decompress_mbps": 517.99
+   "compress_mbps": 24.67,
+   "decompress_mbps": 528.84
   },
   {
    "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
    "level": 8,
    "out_size": 144449,
    "ratio": 0.3385,
-   "compress_mbps": 22.41,
-   "decompress_mbps": 518.6
+   "compress_mbps": 22.44,
+   "decompress_mbps": 527.92
   },
   {
    "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
    "level": 9,
    "out_size": 144438,
    "ratio": 0.3385,
-   "compress_mbps": 22.31,
-   "decompress_mbps": 518.95
+   "compress_mbps": 22.35,
+   "decompress_mbps": 528.8
   },
   {
    "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
    "level": 1,
    "out_size": 264549,
    "ratio": 0.549,
-   "compress_mbps": 135.43,
-   "decompress_mbps": 376.95
+   "compress_mbps": 134.97,
+   "decompress_mbps": 391.06
   },
   {
    "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
    "level": 2,
    "out_size": 223724,
    "ratio": 0.4643,
-   "compress_mbps": 118.93,
-   "decompress_mbps": 422.83
+   "compress_mbps": 118.66,
+   "decompress_mbps": 436.09
   },
   {
    "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
    "level": 3,
    "out_size": 204825,
    "ratio": 0.4251,
-   "compress_mbps": 60.63,
-   "decompress_mbps": 478.39
+   "compress_mbps": 60.74,
+   "decompress_mbps": 489.56
   },
   {
    "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
    "level": 4,
    "out_size": 203945,
    "ratio": 0.4232,
-   "compress_mbps": 53.94,
-   "decompress_mbps": 474.47
+   "compress_mbps": 54.26,
+   "decompress_mbps": 479.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
    "level": 5,
    "out_size": 199780,
    "ratio": 0.4146,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 457.62
+   "compress_mbps": 38.01,
+   "decompress_mbps": 462.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2675,7 +2675,7 @@
    "out_size": 195417,
    "ratio": 0.4055,
    "compress_mbps": 21.2,
-   "decompress_mbps": 468.93
+   "decompress_mbps": 474.8
   },
   {
    "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
    "level": 7,
    "out_size": 194796,
    "ratio": 0.4043,
-   "compress_mbps": 17.9,
-   "decompress_mbps": 467.61
+   "compress_mbps": 17.92,
+   "decompress_mbps": 474.18
   },
   {
    "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
    "level": 8,
    "out_size": 194543,
    "ratio": 0.4037,
-   "compress_mbps": 15.72,
-   "decompress_mbps": 467.24
+   "compress_mbps": 15.7,
+   "decompress_mbps": 473.91
   },
   {
    "compressor": "miniz_oxide",
@@ -2705,7 +2705,7 @@
    "out_size": 194460,
    "ratio": 0.4036,
    "compress_mbps": 15.05,
-   "decompress_mbps": 468.35
+   "decompress_mbps": 473.1
   },
   {
    "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
    "level": 1,
    "out_size": 67436,
    "ratio": 0.1314,
-   "compress_mbps": 627.54,
-   "decompress_mbps": 1004.41
+   "compress_mbps": 628.2,
+   "decompress_mbps": 1026.94
   },
   {
    "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
    "level": 2,
    "out_size": 59257,
    "ratio": 0.1155,
-   "compress_mbps": 278.61,
-   "decompress_mbps": 1060.4
+   "compress_mbps": 279.4,
+   "decompress_mbps": 1090.2
   },
   {
    "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
    "level": 3,
    "out_size": 58316,
    "ratio": 0.1136,
-   "compress_mbps": 181.72,
-   "decompress_mbps": 1145.04
+   "compress_mbps": 181.6,
+   "decompress_mbps": 1177.62
   },
   {
    "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
    "level": 4,
    "out_size": 56291,
    "ratio": 0.1097,
-   "compress_mbps": 185.03,
-   "decompress_mbps": 1154.82
+   "compress_mbps": 184.61,
+   "decompress_mbps": 1183.59
   },
   {
    "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
    "level": 5,
    "out_size": 56220,
    "ratio": 0.1095,
-   "compress_mbps": 146.23,
-   "decompress_mbps": 1207.72
+   "compress_mbps": 146.02,
+   "decompress_mbps": 1241.85
   },
   {
    "compressor": "miniz_oxide",
@@ -2765,7 +2765,7 @@
    "out_size": 55972,
    "ratio": 0.1091,
    "compress_mbps": 74.5,
-   "decompress_mbps": 1263.85
+   "decompress_mbps": 1301.52
   },
   {
    "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
    "level": 7,
    "out_size": 55121,
    "ratio": 0.1074,
-   "compress_mbps": 52.14,
-   "decompress_mbps": 1305.51
+   "compress_mbps": 52.18,
+   "decompress_mbps": 1330.95
   },
   {
    "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
    "level": 8,
    "out_size": 54124,
    "ratio": 0.1055,
-   "compress_mbps": 36.7,
-   "decompress_mbps": 1378.02
+   "compress_mbps": 36.64,
+   "decompress_mbps": 1423.12
   },
   {
    "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
    "level": 9,
    "out_size": 53699,
    "ratio": 0.1046,
-   "compress_mbps": 28.66,
-   "decompress_mbps": 1411.67
+   "compress_mbps": 28.67,
+   "decompress_mbps": 1451.78
   },
   {
    "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
    "level": 1,
    "out_size": 15612,
    "ratio": 0.4083,
-   "compress_mbps": 502.51,
-   "decompress_mbps": 850.6
+   "compress_mbps": 503.12,
+   "decompress_mbps": 863.94
   },
   {
    "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
    "level": 2,
    "out_size": 14133,
    "ratio": 0.3696,
-   "compress_mbps": 145.19,
-   "decompress_mbps": 890.56
+   "compress_mbps": 146.85,
+   "decompress_mbps": 888.44
   },
   {
    "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
    "level": 3,
    "out_size": 13341,
    "ratio": 0.3489,
-   "compress_mbps": 88.72,
-   "decompress_mbps": 911.51
+   "compress_mbps": 88.97,
+   "decompress_mbps": 925.01
   },
   {
    "compressor": "miniz_oxide",
@@ -2834,8 +2834,8 @@
    "level": 4,
    "out_size": 13289,
    "ratio": 0.3475,
-   "compress_mbps": 83.64,
-   "decompress_mbps": 941.29
+   "compress_mbps": 84.18,
+   "decompress_mbps": 951.26
   },
   {
    "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
    "level": 5,
    "out_size": 13052,
    "ratio": 0.3413,
-   "compress_mbps": 66.83,
-   "decompress_mbps": 973.4
+   "compress_mbps": 67.06,
+   "decompress_mbps": 978.65
   },
   {
    "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
    "level": 6,
    "out_size": 12996,
    "ratio": 0.3399,
-   "compress_mbps": 37.14,
-   "decompress_mbps": 986.7
+   "compress_mbps": 37.16,
+   "decompress_mbps": 992.45
   },
   {
    "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
    "level": 7,
    "out_size": 12972,
    "ratio": 0.3392,
-   "compress_mbps": 27.2,
-   "decompress_mbps": 990.88
+   "compress_mbps": 27.29,
+   "decompress_mbps": 994.89
   },
   {
    "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
    "level": 8,
    "out_size": 12951,
    "ratio": 0.3387,
-   "compress_mbps": 19.04,
-   "decompress_mbps": 996.63
+   "compress_mbps": 19.06,
+   "decompress_mbps": 1005.28
   },
   {
    "compressor": "miniz_oxide",
@@ -2885,7 +2885,7 @@
    "out_size": 12933,
    "ratio": 0.3382,
    "compress_mbps": 14.86,
-   "decompress_mbps": 1010.18
+   "decompress_mbps": 1010.91
   },
   {
    "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
    "level": 1,
    "out_size": 1988,
    "ratio": 0.4703,
-   "compress_mbps": 340.18,
-   "decompress_mbps": 548.09
+   "compress_mbps": 341.08,
+   "decompress_mbps": 545.27
   },
   {
    "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
    "level": 2,
    "out_size": 1802,
    "ratio": 0.4263,
-   "compress_mbps": 218.94,
-   "decompress_mbps": 554.27
+   "compress_mbps": 215.54,
+   "decompress_mbps": 557.18
   },
   {
    "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
    "level": 3,
    "out_size": 1760,
    "ratio": 0.4164,
-   "compress_mbps": 205.58,
-   "decompress_mbps": 558.57
+   "compress_mbps": 204.97,
+   "decompress_mbps": 560.74
   },
   {
    "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 171.81,
-   "decompress_mbps": 573.34
+   "compress_mbps": 170.35,
+   "decompress_mbps": 575.88
   },
   {
    "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
    "level": 5,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 167.66,
-   "decompress_mbps": 582.37
+   "compress_mbps": 166.56,
+   "decompress_mbps": 585.16
   },
   {
    "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
    "level": 6,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 166.66,
-   "decompress_mbps": 582.62
+   "compress_mbps": 165.5,
+   "decompress_mbps": 585.33
   },
   {
    "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
    "level": 7,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 166.44,
-   "decompress_mbps": 580.03
+   "compress_mbps": 165.48,
+   "decompress_mbps": 579.78
   },
   {
    "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
    "level": 8,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 167.1,
-   "decompress_mbps": 579.86
+   "compress_mbps": 165.74,
+   "decompress_mbps": 578.28
   },
   {
    "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
    "level": 9,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 166.8,
-   "decompress_mbps": 579.36
+   "compress_mbps": 165.37,
+   "decompress_mbps": 581.36
   },
   {
    "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
    "level": 1,
    "out_size": 59790,
    "ratio": 0.3931,
-   "compress_mbps": 262.72,
-   "decompress_mbps": 1002.92
+   "compress_mbps": 261.58,
+   "decompress_mbps": 1002.74
   },
   {
    "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
    "level": 2,
    "out_size": 57173,
    "ratio": 0.3759,
-   "compress_mbps": 181.24,
-   "decompress_mbps": 1076.37
+   "compress_mbps": 180.1,
+   "decompress_mbps": 1070.05
   },
   {
    "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
    "level": 3,
    "out_size": 56189,
    "ratio": 0.3694,
-   "compress_mbps": 150.83,
-   "decompress_mbps": 1150.52
+   "compress_mbps": 150.68,
+   "decompress_mbps": 1144.88
   },
   {
    "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
    "level": 4,
    "out_size": 55816,
    "ratio": 0.367,
-   "compress_mbps": 138.22,
-   "decompress_mbps": 1189.04
+   "compress_mbps": 137.87,
+   "decompress_mbps": 1177.27
   },
   {
    "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
    "level": 5,
    "out_size": 54758,
    "ratio": 0.36,
-   "compress_mbps": 109.12,
-   "decompress_mbps": 1241.07
+   "compress_mbps": 108.69,
+   "decompress_mbps": 1239.88
   },
   {
    "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
    "level": 6,
    "out_size": 54220,
    "ratio": 0.3565,
-   "compress_mbps": 84.01,
-   "decompress_mbps": 1281.1
+   "compress_mbps": 84.29,
+   "decompress_mbps": 1278.39
   },
   {
    "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
    "level": 7,
    "out_size": 53801,
    "ratio": 0.3537,
-   "compress_mbps": 61.34,
-   "decompress_mbps": 1284.1
+   "compress_mbps": 61.29,
+   "decompress_mbps": 1281.95
   },
   {
    "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
    "level": 8,
    "out_size": 53573,
    "ratio": 0.3522,
-   "compress_mbps": 38.99,
-   "decompress_mbps": 1281.45
+   "compress_mbps": 39.02,
+   "decompress_mbps": 1289.14
   },
   {
    "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
    "level": 9,
    "out_size": 53546,
    "ratio": 0.3521,
-   "compress_mbps": 34.49,
-   "decompress_mbps": 1286.38
+   "compress_mbps": 34.44,
+   "decompress_mbps": 1276.41
   },
   {
    "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
    "level": 1,
    "out_size": 52276,
    "ratio": 0.4176,
-   "compress_mbps": 244.27,
-   "decompress_mbps": 941.62
+   "compress_mbps": 243.62,
+   "decompress_mbps": 941.79
   },
   {
    "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
    "level": 2,
    "out_size": 50534,
    "ratio": 0.4037,
-   "compress_mbps": 169.26,
-   "decompress_mbps": 994.53
+   "compress_mbps": 168.7,
+   "decompress_mbps": 989.86
   },
   {
    "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
    "level": 3,
    "out_size": 49919,
    "ratio": 0.3988,
-   "compress_mbps": 142.29,
-   "decompress_mbps": 1056.87
+   "compress_mbps": 141.42,
+   "decompress_mbps": 1054.24
   },
   {
    "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
    "level": 4,
    "out_size": 49715,
    "ratio": 0.3972,
-   "compress_mbps": 131.62,
-   "decompress_mbps": 1092.43
+   "compress_mbps": 130.9,
+   "decompress_mbps": 1092.13
   },
   {
    "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
    "level": 5,
    "out_size": 48735,
    "ratio": 0.3893,
-   "compress_mbps": 101.28,
-   "decompress_mbps": 1138.39
+   "compress_mbps": 100.69,
+   "decompress_mbps": 1135.49
   },
   {
    "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
    "level": 6,
    "out_size": 48422,
    "ratio": 0.3868,
-   "compress_mbps": 79.56,
-   "decompress_mbps": 1159.77
+   "compress_mbps": 79.43,
+   "decompress_mbps": 1165.58
   },
   {
    "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
    "level": 7,
    "out_size": 48249,
    "ratio": 0.3854,
-   "compress_mbps": 61.42,
-   "decompress_mbps": 1167.2
+   "compress_mbps": 61.19,
+   "decompress_mbps": 1166.61
   },
   {
    "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
    "level": 8,
    "out_size": 47977,
    "ratio": 0.3833,
-   "compress_mbps": 43.01,
-   "decompress_mbps": 1163.26
+   "compress_mbps": 43.07,
+   "decompress_mbps": 1170.03
   },
   {
    "compressor": "libdeflate",
@@ -3154,8 +3154,8 @@
    "level": 9,
    "out_size": 47971,
    "ratio": 0.3832,
-   "compress_mbps": 41.05,
-   "decompress_mbps": 1168.97
+   "compress_mbps": 41.16,
+   "decompress_mbps": 1171.53
   },
   {
    "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
    "level": 1,
    "out_size": 8385,
    "ratio": 0.3408,
-   "compress_mbps": 694.12,
-   "decompress_mbps": 956.86
+   "compress_mbps": 685.0,
+   "decompress_mbps": 949.28
   },
   {
    "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
    "level": 2,
    "out_size": 8380,
    "ratio": 0.3406,
-   "compress_mbps": 439.72,
-   "decompress_mbps": 974.59
+   "compress_mbps": 443.41,
+   "decompress_mbps": 974.79
   },
   {
    "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
    "level": 3,
    "out_size": 8286,
    "ratio": 0.3368,
-   "compress_mbps": 403.73,
-   "decompress_mbps": 993.24
+   "compress_mbps": 398.3,
+   "decompress_mbps": 988.3
   },
   {
    "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
    "level": 4,
    "out_size": 8163,
    "ratio": 0.3318,
-   "compress_mbps": 378.68,
-   "decompress_mbps": 1003.78
+   "compress_mbps": 378.04,
+   "decompress_mbps": 998.39
   },
   {
    "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
    "level": 5,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 335.07,
-   "decompress_mbps": 1027.69
+   "compress_mbps": 339.26,
+   "decompress_mbps": 1019.56
   },
   {
    "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
    "level": 6,
    "out_size": 7986,
    "ratio": 0.3246,
-   "compress_mbps": 277.67,
-   "decompress_mbps": 1035.81
+   "compress_mbps": 276.0,
+   "decompress_mbps": 1031.31
   },
   {
    "compressor": "libdeflate",
@@ -3224,8 +3224,8 @@
    "level": 7,
    "out_size": 7954,
    "ratio": 0.3233,
-   "compress_mbps": 191.05,
-   "decompress_mbps": 1026.12
+   "compress_mbps": 186.79,
+   "decompress_mbps": 1029.54
   },
   {
    "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
    "level": 8,
    "out_size": 7916,
    "ratio": 0.3217,
-   "compress_mbps": 129.56,
-   "decompress_mbps": 1035.17
+   "compress_mbps": 130.23,
+   "decompress_mbps": 1034.58
   },
   {
    "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
    "level": 9,
    "out_size": 7916,
    "ratio": 0.3217,
-   "compress_mbps": 125.42,
-   "decompress_mbps": 1013.27
+   "compress_mbps": 122.22,
+   "decompress_mbps": 1032.8
   },
   {
    "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
    "level": 1,
    "out_size": 3401,
    "ratio": 0.305,
-   "compress_mbps": 586.93,
-   "decompress_mbps": 768.98
+   "compress_mbps": 588.04,
+   "decompress_mbps": 769.87
   },
   {
    "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
    "level": 2,
    "out_size": 3307,
    "ratio": 0.2966,
-   "compress_mbps": 398.24,
-   "decompress_mbps": 792.95
+   "compress_mbps": 397.57,
+   "decompress_mbps": 791.89
   },
   {
    "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
    "level": 3,
    "out_size": 3242,
    "ratio": 0.2908,
-   "compress_mbps": 371.5,
-   "decompress_mbps": 810.66
+   "compress_mbps": 369.72,
+   "decompress_mbps": 801.32
   },
   {
    "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
    "level": 4,
    "out_size": 3205,
    "ratio": 0.2874,
-   "compress_mbps": 349.62,
-   "decompress_mbps": 821.62
+   "compress_mbps": 344.57,
+   "decompress_mbps": 808.94
   },
   {
    "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
    "level": 5,
    "out_size": 3150,
    "ratio": 0.2825,
-   "compress_mbps": 313.81,
-   "decompress_mbps": 837.48
+   "compress_mbps": 314.82,
+   "decompress_mbps": 823.41
   },
   {
    "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
    "level": 6,
    "out_size": 3126,
    "ratio": 0.2804,
-   "compress_mbps": 267.83,
-   "decompress_mbps": 842.46
+   "compress_mbps": 267.37,
+   "decompress_mbps": 828.54
   },
   {
    "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
    "level": 7,
    "out_size": 3106,
    "ratio": 0.2786,
-   "compress_mbps": 206.71,
-   "decompress_mbps": 846.01
+   "compress_mbps": 207.15,
+   "decompress_mbps": 829.06
   },
   {
    "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
    "level": 8,
    "out_size": 3102,
    "ratio": 0.2782,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 842.39
+   "compress_mbps": 147.63,
+   "decompress_mbps": 827.83
   },
   {
    "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
    "level": 9,
    "out_size": 3102,
    "ratio": 0.2782,
-   "compress_mbps": 140.39,
-   "decompress_mbps": 846.34
+   "compress_mbps": 140.54,
+   "decompress_mbps": 832.89
   },
   {
    "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
    "level": 1,
    "out_size": 1251,
    "ratio": 0.3362,
-   "compress_mbps": 377.39,
-   "decompress_mbps": 426.98
+   "compress_mbps": 378.8,
+   "decompress_mbps": 428.06
   },
   {
    "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
    "level": 2,
    "out_size": 1228,
    "ratio": 0.33,
-   "compress_mbps": 267.66,
-   "decompress_mbps": 433.76
+   "compress_mbps": 266.39,
+   "decompress_mbps": 433.02
   },
   {
    "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
    "level": 3,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 258.72,
-   "decompress_mbps": 433.23
+   "compress_mbps": 260.45,
+   "decompress_mbps": 433.45
   },
   {
    "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
    "level": 4,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 253.94,
-   "decompress_mbps": 439.29
+   "compress_mbps": 254.82,
+   "decompress_mbps": 437.72
   },
   {
    "compressor": "libdeflate",
@@ -3385,7 +3385,7 @@
    "out_size": 1207,
    "ratio": 0.3244,
    "compress_mbps": 240.44,
-   "decompress_mbps": 443.8
+   "decompress_mbps": 440.0
   },
   {
    "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
    "level": 6,
    "out_size": 1207,
    "ratio": 0.3244,
-   "compress_mbps": 222.65,
-   "decompress_mbps": 441.15
+   "compress_mbps": 222.75,
+   "decompress_mbps": 444.86
   },
   {
    "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
    "level": 7,
    "out_size": 1207,
    "ratio": 0.3244,
-   "compress_mbps": 203.53,
-   "decompress_mbps": 438.86
+   "compress_mbps": 202.29,
+   "decompress_mbps": 439.95
   },
   {
    "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
    "level": 8,
    "out_size": 1204,
    "ratio": 0.3236,
-   "compress_mbps": 169.68,
-   "decompress_mbps": 444.08
+   "compress_mbps": 169.21,
+   "decompress_mbps": 446.42
   },
   {
    "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
    "level": 9,
    "out_size": 1204,
    "ratio": 0.3236,
-   "compress_mbps": 169.88,
-   "decompress_mbps": 438.1
+   "compress_mbps": 168.75,
+   "decompress_mbps": 442.25
   },
   {
    "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
    "level": 1,
    "out_size": 221813,
    "ratio": 0.2154,
-   "compress_mbps": 593.83,
-   "decompress_mbps": 1009.94
+   "compress_mbps": 594.42,
+   "decompress_mbps": 1008.22
   },
   {
    "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
    "level": 2,
    "out_size": 199825,
    "ratio": 0.1941,
-   "compress_mbps": 409.25,
-   "decompress_mbps": 1460.57
+   "compress_mbps": 408.68,
+   "decompress_mbps": 1459.98
   },
   {
    "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
    "level": 3,
    "out_size": 195675,
    "ratio": 0.19,
-   "compress_mbps": 283.23,
-   "decompress_mbps": 1526.64
+   "compress_mbps": 283.3,
+   "decompress_mbps": 1528.81
   },
   {
    "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
    "level": 4,
    "out_size": 195664,
    "ratio": 0.19,
-   "compress_mbps": 279.77,
-   "decompress_mbps": 1536.83
+   "compress_mbps": 280.32,
+   "decompress_mbps": 1537.22
   },
   {
    "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
    "level": 5,
    "out_size": 198900,
    "ratio": 0.1932,
-   "compress_mbps": 239.94,
-   "decompress_mbps": 1127.82
+   "compress_mbps": 239.62,
+   "decompress_mbps": 1123.69
   },
   {
    "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
    "level": 6,
    "out_size": 199347,
    "ratio": 0.1936,
-   "compress_mbps": 204.69,
-   "decompress_mbps": 1130.61
+   "compress_mbps": 204.91,
+   "decompress_mbps": 1126.57
   },
   {
    "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
    "level": 7,
    "out_size": 199777,
    "ratio": 0.194,
-   "compress_mbps": 123.53,
-   "decompress_mbps": 1190.54
+   "compress_mbps": 123.79,
+   "decompress_mbps": 1186.42
   },
   {
    "compressor": "libdeflate",
@@ -3504,8 +3504,8 @@
    "level": 8,
    "out_size": 182094,
    "ratio": 0.1768,
-   "compress_mbps": 25.66,
-   "decompress_mbps": 1169.78
+   "compress_mbps": 25.62,
+   "decompress_mbps": 1170.24
   },
   {
    "compressor": "libdeflate",
@@ -3515,7 +3515,7 @@
    "out_size": 181451,
    "ratio": 0.1762,
    "compress_mbps": 13.61,
-   "decompress_mbps": 1173.47
+   "decompress_mbps": 1171.37
   },
   {
    "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
    "level": 1,
    "out_size": 159063,
    "ratio": 0.3727,
-   "compress_mbps": 263.86,
-   "decompress_mbps": 1029.34
+   "compress_mbps": 265.67,
+   "decompress_mbps": 1023.0
   },
   {
    "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
    "level": 2,
    "out_size": 152115,
    "ratio": 0.3564,
-   "compress_mbps": 187.44,
-   "decompress_mbps": 1105.52
+   "compress_mbps": 186.3,
+   "decompress_mbps": 1099.27
   },
   {
    "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
    "level": 3,
    "out_size": 149162,
    "ratio": 0.3495,
-   "compress_mbps": 156.82,
-   "decompress_mbps": 1189.07
+   "compress_mbps": 156.77,
+   "decompress_mbps": 1163.92
   },
   {
    "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
    "level": 4,
    "out_size": 148359,
    "ratio": 0.3476,
-   "compress_mbps": 142.61,
-   "decompress_mbps": 1033.04
+   "compress_mbps": 143.02,
+   "decompress_mbps": 1039.64
   },
   {
    "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
    "level": 5,
    "out_size": 145353,
    "ratio": 0.3406,
-   "compress_mbps": 113.35,
-   "decompress_mbps": 997.15
+   "compress_mbps": 113.79,
+   "decompress_mbps": 999.42
   },
   {
    "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
    "level": 6,
    "out_size": 144209,
    "ratio": 0.3379,
-   "compress_mbps": 87.48,
-   "decompress_mbps": 1037.45
+   "compress_mbps": 88.15,
+   "decompress_mbps": 1052.19
   },
   {
    "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
    "level": 7,
    "out_size": 143604,
    "ratio": 0.3365,
-   "compress_mbps": 66.64,
-   "decompress_mbps": 1039.31
+   "compress_mbps": 66.96,
+   "decompress_mbps": 1064.53
   },
   {
    "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
    "level": 8,
    "out_size": 142086,
    "ratio": 0.3329,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 1035.21
+   "compress_mbps": 44.17,
+   "decompress_mbps": 1064.02
   },
   {
    "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
    "level": 9,
    "out_size": 142027,
    "ratio": 0.3328,
-   "compress_mbps": 40.46,
-   "decompress_mbps": 1038.75
+   "compress_mbps": 40.44,
+   "decompress_mbps": 1066.17
   },
   {
    "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
    "level": 1,
    "out_size": 210662,
    "ratio": 0.4372,
-   "compress_mbps": 228.71,
-   "decompress_mbps": 869.83
+   "compress_mbps": 231.44,
+   "decompress_mbps": 869.95
   },
   {
    "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
    "level": 2,
    "out_size": 202881,
    "ratio": 0.421,
-   "compress_mbps": 158.66,
-   "decompress_mbps": 939.95
+   "compress_mbps": 159.16,
+   "decompress_mbps": 938.49
   },
   {
    "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
    "level": 3,
    "out_size": 200409,
    "ratio": 0.4159,
-   "compress_mbps": 132.96,
-   "decompress_mbps": 1019.12
+   "compress_mbps": 133.54,
+   "decompress_mbps": 1014.47
   },
   {
    "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
    "level": 4,
    "out_size": 199678,
    "ratio": 0.4144,
-   "compress_mbps": 122.96,
-   "decompress_mbps": 839.63
+   "compress_mbps": 123.16,
+   "decompress_mbps": 853.04
   },
   {
    "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
    "level": 5,
    "out_size": 195798,
    "ratio": 0.4063,
-   "compress_mbps": 93.4,
-   "decompress_mbps": 789.36
+   "compress_mbps": 93.28,
+   "decompress_mbps": 807.42
   },
   {
    "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
    "level": 6,
    "out_size": 194029,
    "ratio": 0.4027,
-   "compress_mbps": 71.6,
-   "decompress_mbps": 813.1
+   "compress_mbps": 71.87,
+   "decompress_mbps": 835.39
   },
   {
    "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
    "level": 7,
    "out_size": 192773,
    "ratio": 0.4001,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 835.88
+   "compress_mbps": 51.44,
+   "decompress_mbps": 834.09
   },
   {
    "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
    "level": 8,
    "out_size": 191739,
    "ratio": 0.3979,
-   "compress_mbps": 33.69,
-   "decompress_mbps": 841.06
+   "compress_mbps": 33.61,
+   "decompress_mbps": 842.45
   },
   {
    "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
    "level": 9,
    "out_size": 191676,
    "ratio": 0.3978,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 839.65
+   "compress_mbps": 31.06,
+   "decompress_mbps": 838.75
   },
   {
    "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
    "level": 1,
    "out_size": 58079,
    "ratio": 0.1132,
-   "compress_mbps": 373.38,
-   "decompress_mbps": 1687.98
+   "compress_mbps": 373.36,
+   "decompress_mbps": 1691.97
   },
   {
    "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
    "level": 2,
    "out_size": 57838,
    "ratio": 0.1127,
-   "compress_mbps": 413.69,
-   "decompress_mbps": 1800.72
+   "compress_mbps": 414.76,
+   "decompress_mbps": 1795.95
   },
   {
    "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
    "level": 3,
    "out_size": 57554,
    "ratio": 0.1121,
-   "compress_mbps": 394.76,
-   "decompress_mbps": 1899.42
+   "compress_mbps": 394.8,
+   "decompress_mbps": 1870.22
   },
   {
    "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
    "level": 4,
    "out_size": 57064,
    "ratio": 0.1112,
-   "compress_mbps": 374.05,
-   "decompress_mbps": 1741.26
+   "compress_mbps": 374.46,
+   "decompress_mbps": 1739.61
   },
   {
    "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
    "level": 5,
    "out_size": 55743,
    "ratio": 0.1086,
-   "compress_mbps": 343.45,
-   "decompress_mbps": 1793.36
+   "compress_mbps": 344.61,
+   "decompress_mbps": 1788.7
   },
   {
    "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
    "level": 6,
    "out_size": 55102,
    "ratio": 0.1074,
-   "compress_mbps": 285.08,
-   "decompress_mbps": 1869.89
+   "compress_mbps": 285.57,
+   "decompress_mbps": 1859.22
   },
   {
    "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
    "level": 7,
    "out_size": 54742,
    "ratio": 0.1067,
-   "compress_mbps": 193.03,
-   "decompress_mbps": 1929.26
+   "compress_mbps": 193.66,
+   "decompress_mbps": 1935.78
   },
   {
    "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
    "level": 8,
    "out_size": 53133,
    "ratio": 0.1035,
-   "compress_mbps": 102.77,
-   "decompress_mbps": 1996.36
+   "compress_mbps": 102.57,
+   "decompress_mbps": 2006.93
   },
   {
    "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
    "level": 9,
    "out_size": 52186,
    "ratio": 0.1017,
-   "compress_mbps": 72.32,
-   "decompress_mbps": 2031.74
+   "compress_mbps": 72.01,
+   "decompress_mbps": 2024.21
   },
   {
    "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
    "level": 1,
    "out_size": 14122,
    "ratio": 0.3693,
-   "compress_mbps": 648.66,
-   "decompress_mbps": 823.66
+   "compress_mbps": 642.78,
+   "decompress_mbps": 823.24
   },
   {
    "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
    "level": 2,
    "out_size": 13374,
    "ratio": 0.3497,
-   "compress_mbps": 338.62,
-   "decompress_mbps": 879.23
+   "compress_mbps": 333.81,
+   "decompress_mbps": 879.33
   },
   {
    "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
    "level": 3,
    "out_size": 13293,
    "ratio": 0.3476,
-   "compress_mbps": 257.73,
-   "decompress_mbps": 960.76
+   "compress_mbps": 272.85,
+   "decompress_mbps": 953.05
   },
   {
    "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
    "level": 4,
    "out_size": 13259,
    "ratio": 0.3467,
-   "compress_mbps": 263.83,
-   "decompress_mbps": 960.86
+   "compress_mbps": 268.63,
+   "decompress_mbps": 953.25
   },
   {
    "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
    "level": 5,
    "out_size": 12641,
    "ratio": 0.3306,
-   "compress_mbps": 190.13,
-   "decompress_mbps": 990.29
+   "compress_mbps": 190.14,
+   "decompress_mbps": 991.77
   },
   {
    "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
    "level": 6,
    "out_size": 12432,
    "ratio": 0.3251,
-   "compress_mbps": 164.05,
-   "decompress_mbps": 1006.67
+   "compress_mbps": 164.22,
+   "decompress_mbps": 1009.37
   },
   {
    "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
    "level": 7,
    "out_size": 12439,
    "ratio": 0.3253,
-   "compress_mbps": 122.43,
-   "decompress_mbps": 1013.21
+   "compress_mbps": 123.67,
+   "decompress_mbps": 1015.64
   },
   {
    "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
    "level": 8,
    "out_size": 12579,
    "ratio": 0.3289,
-   "compress_mbps": 67.61,
-   "decompress_mbps": 1025.92
+   "compress_mbps": 67.6,
+   "decompress_mbps": 1031.38
   },
   {
    "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
    "level": 9,
    "out_size": 12574,
    "ratio": 0.3288,
-   "compress_mbps": 47.47,
-   "decompress_mbps": 1031.58
+   "compress_mbps": 47.54,
+   "decompress_mbps": 1024.05
   },
   {
    "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
    "level": 1,
    "out_size": 1777,
    "ratio": 0.4204,
-   "compress_mbps": 386.35,
-   "decompress_mbps": 403.24
+   "compress_mbps": 386.31,
+   "decompress_mbps": 397.24
   },
   {
    "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
    "level": 2,
    "out_size": 1756,
    "ratio": 0.4154,
-   "compress_mbps": 260.77,
-   "decompress_mbps": 408.51
+   "compress_mbps": 260.8,
+   "decompress_mbps": 406.57
   },
   {
    "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
    "level": 3,
    "out_size": 1746,
    "ratio": 0.4131,
-   "compress_mbps": 257.14,
-   "decompress_mbps": 410.93
+   "compress_mbps": 258.87,
+   "decompress_mbps": 403.89
   },
   {
    "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
    "level": 4,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 254.99,
-   "decompress_mbps": 414.73
+   "compress_mbps": 254.82,
+   "decompress_mbps": 414.22
   },
   {
    "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 240.47,
-   "decompress_mbps": 415.2
+   "compress_mbps": 240.52,
+   "decompress_mbps": 413.88
   },
   {
    "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
    "level": 6,
    "out_size": 1721,
    "ratio": 0.4071,
-   "compress_mbps": 235.91,
-   "decompress_mbps": 415.29
+   "compress_mbps": 236.5,
+   "decompress_mbps": 412.1
   },
   {
    "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
    "level": 7,
    "out_size": 1720,
    "ratio": 0.4069,
-   "compress_mbps": 234.75,
-   "decompress_mbps": 415.41
+   "compress_mbps": 232.67,
+   "decompress_mbps": 414.77
   },
   {
    "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
    "level": 8,
    "out_size": 1717,
    "ratio": 0.4062,
-   "compress_mbps": 217.57,
-   "decompress_mbps": 417.83
+   "compress_mbps": 216.09,
+   "decompress_mbps": 413.5
   },
   {
    "compressor": "libdeflate",
@@ -3964,8 +3964,8 @@
    "level": 9,
    "out_size": 1717,
    "ratio": 0.4062,
-   "compress_mbps": 216.75,
-   "decompress_mbps": 416.19
+   "compress_mbps": 216.66,
+   "decompress_mbps": 416.14
   },
   {
    "compressor": "native",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 40.66,
-   "decompress_mbps": 180.47
+   "compress_mbps": 41.97,
+   "decompress_mbps": 182.79
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 36.48,
-   "decompress_mbps": 195.0
+   "compress_mbps": 37.31,
+   "decompress_mbps": 198.11
   },
   {
    "compressor": "native",
@@ -3994,38 +3994,38 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.53,
-   "decompress_mbps": 213.45
+   "compress_mbps": 34.71,
+   "decompress_mbps": 218.28
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 4,
-   "out_size": 3888008,
-   "ratio": 0.3815,
-   "compress_mbps": 25.56,
-   "decompress_mbps": 218.22
+   "out_size": 3899313,
+   "ratio": 0.3826,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 220.94
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 5,
-   "out_size": 3882303,
-   "ratio": 0.3809,
-   "compress_mbps": 25.22,
-   "decompress_mbps": 219.64
+   "out_size": 3879945,
+   "ratio": 0.3807,
+   "compress_mbps": 23.62,
+   "decompress_mbps": 220.51
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3873339,
-   "ratio": 0.38,
-   "compress_mbps": 23.27,
-   "decompress_mbps": 223.75
+   "out_size": 3870984,
+   "ratio": 0.3798,
+   "compress_mbps": 20.82,
+   "decompress_mbps": 225.34
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 19.57,
-   "decompress_mbps": 223.21
+   "compress_mbps": 19.91,
+   "decompress_mbps": 225.56
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.91,
-   "decompress_mbps": 231.11
+   "compress_mbps": 9.08,
+   "decompress_mbps": 236.62
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.75,
-   "decompress_mbps": 232.17
+   "compress_mbps": 1.76,
+   "decompress_mbps": 235.45
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 53.27,
-   "decompress_mbps": 195.05
+   "compress_mbps": 55.25,
+   "decompress_mbps": 195.8
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 50.2,
-   "decompress_mbps": 205.62
+   "compress_mbps": 51.59,
+   "decompress_mbps": 210.49
   },
   {
    "compressor": "native",
@@ -4084,38 +4084,38 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 46.84,
-   "decompress_mbps": 211.89
+   "compress_mbps": 48.19,
+   "decompress_mbps": 215.87
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 4,
-   "out_size": 20408622,
-   "ratio": 0.3984,
-   "compress_mbps": 38.72,
-   "decompress_mbps": 219.95
+   "out_size": 20433451,
+   "ratio": 0.3989,
+   "compress_mbps": 42.2,
+   "decompress_mbps": 221.98
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 5,
-   "out_size": 20393572,
-   "ratio": 0.3982,
-   "compress_mbps": 37.03,
-   "decompress_mbps": 225.91
+   "out_size": 20294124,
+   "ratio": 0.3962,
+   "compress_mbps": 34.31,
+   "decompress_mbps": 230.1
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 20370310,
-   "ratio": 0.3977,
-   "compress_mbps": 32.44,
-   "decompress_mbps": 230.44
+   "out_size": 20262849,
+   "ratio": 0.3956,
+   "compress_mbps": 27.72,
+   "decompress_mbps": 236.06
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 21.64,
-   "decompress_mbps": 229.74
+   "compress_mbps": 22.23,
+   "decompress_mbps": 236.5
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.75,
-   "decompress_mbps": 223.14
+   "compress_mbps": 6.93,
+   "decompress_mbps": 237.36
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.63,
-   "decompress_mbps": 231.46
+   "compress_mbps": 1.62,
+   "decompress_mbps": 236.19
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 54.1,
-   "decompress_mbps": 211.59
+   "compress_mbps": 55.31,
+   "decompress_mbps": 211.9
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 220.82
+   "compress_mbps": 50.77,
+   "decompress_mbps": 222.21
   },
   {
    "compressor": "native",
@@ -4174,38 +4174,38 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 43.42,
-   "decompress_mbps": 229.54
+   "compress_mbps": 44.42,
+   "decompress_mbps": 234.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 4,
-   "out_size": 3713154,
-   "ratio": 0.3724,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 213.18
+   "out_size": 3724222,
+   "ratio": 0.3735,
+   "compress_mbps": 34.84,
+   "decompress_mbps": 225.23
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 5,
-   "out_size": 3707604,
-   "ratio": 0.3719,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 210.22
+   "out_size": 3712209,
+   "ratio": 0.3723,
+   "compress_mbps": 28.09,
+   "decompress_mbps": 211.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3701198,
-   "ratio": 0.3712,
-   "compress_mbps": 27.19,
-   "decompress_mbps": 216.34
+   "out_size": 3706391,
+   "ratio": 0.3717,
+   "compress_mbps": 24.25,
+   "decompress_mbps": 221.62
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 219.72
+   "compress_mbps": 21.18,
+   "decompress_mbps": 221.51
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.12,
-   "decompress_mbps": 223.44
+   "compress_mbps": 8.29,
+   "decompress_mbps": 224.98
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 1.26,
-   "decompress_mbps": 233.75
+   "compress_mbps": 1.25,
+   "decompress_mbps": 233.81
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 134.78,
-   "decompress_mbps": 616.51
+   "compress_mbps": 137.56,
+   "decompress_mbps": 576.31
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 113.36,
-   "decompress_mbps": 687.31
+   "compress_mbps": 118.92,
+   "decompress_mbps": 695.19
   },
   {
    "compressor": "native",
@@ -4264,38 +4264,38 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 98.15,
-   "decompress_mbps": 762.76
+   "compress_mbps": 100.27,
+   "decompress_mbps": 775.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 4,
-   "out_size": 3233721,
-   "ratio": 0.0964,
-   "compress_mbps": 85.08,
-   "decompress_mbps": 747.53
+   "out_size": 3247791,
+   "ratio": 0.0968,
+   "compress_mbps": 49.61,
+   "decompress_mbps": 667.63
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 5,
-   "out_size": 3225450,
-   "ratio": 0.0961,
-   "compress_mbps": 82.49,
-   "decompress_mbps": 846.2
+   "out_size": 3195839,
+   "ratio": 0.0952,
+   "compress_mbps": 79.57,
+   "decompress_mbps": 861.5
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3207256,
-   "ratio": 0.0956,
-   "compress_mbps": 74.86,
-   "decompress_mbps": 902.75
+   "out_size": 3136283,
+   "ratio": 0.0935,
+   "compress_mbps": 56.61,
+   "decompress_mbps": 917.34
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 42.64,
-   "decompress_mbps": 922.1
+   "compress_mbps": 43.65,
+   "decompress_mbps": 933.48
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 903.63
+   "compress_mbps": 22.63,
+   "decompress_mbps": 880.8
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.89,
-   "decompress_mbps": 882.21
+   "compress_mbps": 0.88,
+   "decompress_mbps": 940.62
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 39.17,
-   "decompress_mbps": 131.95
+   "compress_mbps": 40.58,
+   "decompress_mbps": 135.91
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.14,
-   "decompress_mbps": 136.55
+   "compress_mbps": 37.5,
+   "decompress_mbps": 138.35
   },
   {
    "compressor": "native",
@@ -4354,38 +4354,38 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 37.1,
-   "decompress_mbps": 140.32
+   "compress_mbps": 37.8,
+   "decompress_mbps": 143.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 4,
-   "out_size": 3238141,
-   "ratio": 0.5263,
-   "compress_mbps": 30.38,
-   "decompress_mbps": 150.33
+   "out_size": 3240147,
+   "ratio": 0.5267,
+   "compress_mbps": 32.2,
+   "decompress_mbps": 151.27
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 5,
-   "out_size": 3237094,
-   "ratio": 0.5262,
-   "compress_mbps": 29.95,
-   "decompress_mbps": 155.7
+   "out_size": 3235406,
+   "ratio": 0.5259,
+   "compress_mbps": 29.57,
+   "decompress_mbps": 157.16
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3235481,
-   "ratio": 0.5259,
-   "compress_mbps": 28.79,
-   "decompress_mbps": 156.3
+   "out_size": 3233528,
+   "ratio": 0.5256,
+   "compress_mbps": 27.58,
+   "decompress_mbps": 161.3
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 25.51,
-   "decompress_mbps": 155.89
+   "compress_mbps": 26.06,
+   "decompress_mbps": 161.53
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.82,
-   "decompress_mbps": 160.83
+   "compress_mbps": 6.95,
+   "decompress_mbps": 167.31
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 2.28,
-   "decompress_mbps": 161.36
+   "compress_mbps": 2.3,
+   "decompress_mbps": 168.14
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 56.32,
-   "decompress_mbps": 236.5
+   "compress_mbps": 58.07,
+   "decompress_mbps": 226.26
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 52.83,
-   "decompress_mbps": 245.48
+   "compress_mbps": 55.23,
+   "decompress_mbps": 230.45
   },
   {
    "compressor": "native",
@@ -4444,38 +4444,38 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 52.31,
-   "decompress_mbps": 253.06
+   "compress_mbps": 53.52,
+   "decompress_mbps": 238.02
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 4,
-   "out_size": 3707210,
-   "ratio": 0.3676,
-   "compress_mbps": 47.42,
-   "decompress_mbps": 261.01
+   "out_size": 3708181,
+   "ratio": 0.3677,
+   "compress_mbps": 48.92,
+   "decompress_mbps": 249.87
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 5,
-   "out_size": 3706928,
+   "out_size": 3706960,
    "ratio": 0.3675,
-   "compress_mbps": 46.83,
-   "decompress_mbps": 264.95
+   "compress_mbps": 47.77,
+   "decompress_mbps": 251.61
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3706877,
+   "out_size": 3706772,
    "ratio": 0.3675,
-   "compress_mbps": 47.21,
-   "decompress_mbps": 258.13
+   "compress_mbps": 45.37,
+   "decompress_mbps": 262.4
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 261.55
+   "compress_mbps": 45.08,
+   "decompress_mbps": 263.39
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.27,
-   "decompress_mbps": 273.33
+   "compress_mbps": 12.32,
+   "decompress_mbps": 276.65
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 2.7,
-   "decompress_mbps": 273.21
+   "compress_mbps": 2.73,
+   "decompress_mbps": 279.58
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 48.77,
-   "decompress_mbps": 231.07
+   "compress_mbps": 49.64,
+   "decompress_mbps": 229.29
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 43.47,
-   "decompress_mbps": 243.08
+   "compress_mbps": 44.56,
+   "decompress_mbps": 245.65
   },
   {
    "compressor": "native",
@@ -4534,38 +4534,38 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 37.34,
-   "decompress_mbps": 276.1
+   "compress_mbps": 38.06,
+   "decompress_mbps": 279.54
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 4,
-   "out_size": 1911442,
-   "ratio": 0.2884,
-   "compress_mbps": 26.55,
-   "decompress_mbps": 270.09
+   "out_size": 1929091,
+   "ratio": 0.2911,
+   "compress_mbps": 30.34,
+   "decompress_mbps": 272.65
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1901081,
-   "ratio": 0.2869,
-   "compress_mbps": 24.46,
-   "decompress_mbps": 284.01
+   "out_size": 1894173,
+   "ratio": 0.2858,
+   "compress_mbps": 20.72,
+   "decompress_mbps": 285.6
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1883325,
-   "ratio": 0.2842,
-   "compress_mbps": 20.11,
-   "decompress_mbps": 282.6
+   "out_size": 1874808,
+   "ratio": 0.2829,
+   "compress_mbps": 15.52,
+   "decompress_mbps": 285.27
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 13.02,
-   "decompress_mbps": 301.65
+   "compress_mbps": 13.2,
+   "decompress_mbps": 289.1
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.56,
-   "decompress_mbps": 292.39
+   "compress_mbps": 7.73,
+   "decompress_mbps": 310.88
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 1.14,
-   "decompress_mbps": 289.62
+   "decompress_mbps": 292.04
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 71.7,
-   "decompress_mbps": 303.43
+   "compress_mbps": 73.17,
+   "decompress_mbps": 305.43
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 64.43,
-   "decompress_mbps": 322.75
+   "compress_mbps": 66.04,
+   "decompress_mbps": 325.43
   },
   {
    "compressor": "native",
@@ -4624,38 +4624,38 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 58.1,
-   "decompress_mbps": 336.85
+   "compress_mbps": 60.24,
+   "decompress_mbps": 342.4
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 4,
-   "out_size": 5886640,
-   "ratio": 0.2724,
-   "compress_mbps": 48.52,
-   "decompress_mbps": 344.17
+   "out_size": 5897051,
+   "ratio": 0.2729,
+   "compress_mbps": 52.48,
+   "decompress_mbps": 351.34
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 5,
-   "out_size": 5880979,
-   "ratio": 0.2722,
-   "compress_mbps": 47.04,
-   "decompress_mbps": 354.7
+   "out_size": 5867943,
+   "ratio": 0.2716,
+   "compress_mbps": 44.01,
+   "decompress_mbps": 359.66
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5873572,
-   "ratio": 0.2718,
-   "compress_mbps": 43.81,
-   "decompress_mbps": 361.6
+   "out_size": 5834524,
+   "ratio": 0.27,
+   "compress_mbps": 36.99,
+   "decompress_mbps": 368.13
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 32.57,
-   "decompress_mbps": 361.9
+   "compress_mbps": 33.16,
+   "decompress_mbps": 371.36
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.83,
-   "decompress_mbps": 336.69
+   "compress_mbps": 12.8,
+   "decompress_mbps": 366.35
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5169629,
    "ratio": 0.2393,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 361.43
+   "compress_mbps": 1.63,
+   "decompress_mbps": 373.56
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 34.52,
-   "decompress_mbps": 134.13
+   "compress_mbps": 35.55,
+   "decompress_mbps": 135.97
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 134.68
+   "compress_mbps": 33.27,
+   "decompress_mbps": 137.69
   },
   {
    "compressor": "native",
@@ -4714,38 +4714,38 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 141.89
+   "compress_mbps": 31.53,
+   "decompress_mbps": 143.68
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 4,
-   "out_size": 5500073,
-   "ratio": 0.7584,
-   "compress_mbps": 25.83,
-   "decompress_mbps": 144.02
+   "out_size": 5503217,
+   "ratio": 0.7589,
+   "compress_mbps": 27.5,
+   "decompress_mbps": 144.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 5,
-   "out_size": 5498823,
-   "ratio": 0.7583,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 141.78
+   "out_size": 5498280,
+   "ratio": 0.7582,
+   "compress_mbps": 25.7,
+   "decompress_mbps": 146.06
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 6,
-   "out_size": 5497402,
-   "ratio": 0.7581,
-   "compress_mbps": 24.76,
-   "decompress_mbps": 143.17
+   "out_size": 5496802,
+   "ratio": 0.758,
+   "compress_mbps": 24.71,
+   "decompress_mbps": 144.99
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 23.49,
-   "decompress_mbps": 141.88
+   "compress_mbps": 24.31,
+   "decompress_mbps": 147.39
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.26,
-   "decompress_mbps": 145.86
+   "compress_mbps": 6.28,
+   "decompress_mbps": 146.39
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.6,
-   "decompress_mbps": 143.38
+   "compress_mbps": 2.58,
+   "decompress_mbps": 146.82
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 53.09,
-   "decompress_mbps": 229.8
+   "compress_mbps": 54.0,
+   "decompress_mbps": 232.53
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 48.01,
-   "decompress_mbps": 248.49
+   "compress_mbps": 49.23,
+   "decompress_mbps": 253.68
   },
   {
    "compressor": "native",
@@ -4804,38 +4804,38 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 44.97,
-   "decompress_mbps": 267.59
+   "compress_mbps": 45.83,
+   "decompress_mbps": 271.96
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 4,
-   "out_size": 12257878,
-   "ratio": 0.2957,
-   "compress_mbps": 36.65,
-   "decompress_mbps": 274.82
+   "out_size": 12306822,
+   "ratio": 0.2968,
+   "compress_mbps": 39.32,
+   "decompress_mbps": 273.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12229398,
-   "ratio": 0.295,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 278.7
+   "out_size": 12197500,
+   "ratio": 0.2942,
+   "compress_mbps": 32.76,
+   "decompress_mbps": 260.2
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12184501,
-   "ratio": 0.2939,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 286.61
+   "out_size": 12123617,
+   "ratio": 0.2924,
+   "compress_mbps": 27.05,
+   "decompress_mbps": 290.15
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.54,
-   "decompress_mbps": 287.26
+   "compress_mbps": 24.99,
+   "decompress_mbps": 293.06
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.44,
-   "decompress_mbps": 288.01
+   "compress_mbps": 11.64,
+   "decompress_mbps": 293.8
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.6,
-   "decompress_mbps": 290.11
+   "compress_mbps": 1.59,
+   "decompress_mbps": 293.99
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 34.91,
-   "decompress_mbps": 128.68
+   "compress_mbps": 35.02,
+   "decompress_mbps": 130.09
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 35.06,
-   "decompress_mbps": 129.81
+   "compress_mbps": 34.81,
+   "decompress_mbps": 131.36
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 131.85
+   "compress_mbps": 34.75,
+   "decompress_mbps": 132.66
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 32.91,
-   "decompress_mbps": 119.71
+   "compress_mbps": 33.43,
+   "decompress_mbps": 121.87
   },
   {
    "compressor": "native",
@@ -4914,18 +4914,18 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 32.98,
-   "decompress_mbps": 121.67
+   "compress_mbps": 33.44,
+   "decompress_mbps": 123.1
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 6,
-   "out_size": 6368719,
+   "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 32.25,
-   "decompress_mbps": 122.06
+   "compress_mbps": 33.35,
+   "decompress_mbps": 119.71
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 122.35
+   "compress_mbps": 33.36,
+   "decompress_mbps": 123.26
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.74,
-   "decompress_mbps": 123.53
+   "compress_mbps": 4.82,
+   "decompress_mbps": 125.43
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.42,
-   "decompress_mbps": 124.58
+   "compress_mbps": 3.49,
+   "decompress_mbps": 126.77
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 106.02,
-   "decompress_mbps": 424.57
+   "compress_mbps": 110.48,
+   "decompress_mbps": 469.89
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 95.42,
-   "decompress_mbps": 481.81
+   "compress_mbps": 97.88,
+   "decompress_mbps": 531.38
   },
   {
    "compressor": "native",
@@ -4984,38 +4984,38 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 84.48,
-   "decompress_mbps": 523.46
+   "compress_mbps": 86.21,
+   "decompress_mbps": 591.08
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 4,
-   "out_size": 725534,
-   "ratio": 0.1357,
-   "compress_mbps": 68.78,
-   "decompress_mbps": 521.72
+   "out_size": 732159,
+   "ratio": 0.137,
+   "compress_mbps": 73.27,
+   "decompress_mbps": 581.31
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 721655,
-   "ratio": 0.135,
-   "compress_mbps": 66.0,
-   "decompress_mbps": 569.86
+   "out_size": 719019,
+   "ratio": 0.1345,
+   "compress_mbps": 63.44,
+   "decompress_mbps": 638.12
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 715547,
-   "ratio": 0.1339,
-   "compress_mbps": 60.6,
-   "decompress_mbps": 629.92
+   "out_size": 705644,
+   "ratio": 0.132,
+   "compress_mbps": 49.3,
+   "decompress_mbps": 686.92
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 40.71,
-   "decompress_mbps": 682.83
+   "compress_mbps": 41.9,
+   "decompress_mbps": 695.79
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.49,
-   "decompress_mbps": 610.52
+   "compress_mbps": 20.74,
+   "decompress_mbps": 623.69
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 1.17,
-   "decompress_mbps": 667.34
+   "decompress_mbps": 693.44
   },
   {
    "compressor": "zlib",
@@ -5054,8 +5054,8 @@
    "level": 1,
    "out_size": 4585612,
    "ratio": 0.4499,
-   "compress_mbps": 113.67,
-   "decompress_mbps": 354.82
+   "compress_mbps": 112.69,
+   "decompress_mbps": 349.66
   },
   {
    "compressor": "zlib",
@@ -5064,8 +5064,8 @@
    "level": 2,
    "out_size": 4389474,
    "ratio": 0.4307,
-   "compress_mbps": 96.07,
-   "decompress_mbps": 375.93
+   "compress_mbps": 95.82,
+   "decompress_mbps": 375.71
   },
   {
    "compressor": "zlib",
@@ -5074,8 +5074,8 @@
    "level": 3,
    "out_size": 4192079,
    "ratio": 0.4113,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 412.28
+   "compress_mbps": 59.33,
+   "decompress_mbps": 410.29
   },
   {
    "compressor": "zlib",
@@ -5084,8 +5084,8 @@
    "level": 4,
    "out_size": 4095021,
    "ratio": 0.4018,
-   "compress_mbps": 66.19,
-   "decompress_mbps": 389.42
+   "compress_mbps": 65.14,
+   "decompress_mbps": 386.42
   },
   {
    "compressor": "zlib",
@@ -5094,8 +5094,8 @@
    "level": 5,
    "out_size": 3949169,
    "ratio": 0.3875,
-   "compress_mbps": 35.97,
-   "decompress_mbps": 376.93
+   "compress_mbps": 35.66,
+   "decompress_mbps": 369.99
   },
   {
    "compressor": "zlib",
@@ -5104,8 +5104,8 @@
    "level": 6,
    "out_size": 3871628,
    "ratio": 0.3799,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 384.89
+   "compress_mbps": 21.15,
+   "decompress_mbps": 378.6
   },
   {
    "compressor": "zlib",
@@ -5114,8 +5114,8 @@
    "level": 7,
    "out_size": 3858876,
    "ratio": 0.3786,
-   "compress_mbps": 17.58,
-   "decompress_mbps": 387.13
+   "compress_mbps": 17.71,
+   "decompress_mbps": 379.92
   },
   {
    "compressor": "zlib",
@@ -5125,7 +5125,7 @@
    "out_size": 3854729,
    "ratio": 0.3782,
    "compress_mbps": 15.07,
-   "decompress_mbps": 385.46
+   "decompress_mbps": 382.01
   },
   {
    "compressor": "zlib",
@@ -5135,7 +5135,7 @@
    "out_size": 3854729,
    "ratio": 0.3782,
    "compress_mbps": 15.07,
-   "decompress_mbps": 391.3
+   "decompress_mbps": 382.31
   },
   {
    "compressor": "zlib",
@@ -5144,8 +5144,8 @@
    "level": 1,
    "out_size": 20577220,
    "ratio": 0.4017,
-   "compress_mbps": 113.25,
-   "decompress_mbps": 364.49
+   "compress_mbps": 112.73,
+   "decompress_mbps": 353.79
   },
   {
    "compressor": "zlib",
@@ -5154,8 +5154,8 @@
    "level": 2,
    "out_size": 20247697,
    "ratio": 0.3953,
-   "compress_mbps": 100.51,
-   "decompress_mbps": 370.0
+   "compress_mbps": 100.68,
+   "decompress_mbps": 367.48
   },
   {
    "compressor": "zlib",
@@ -5164,8 +5164,8 @@
    "level": 3,
    "out_size": 19987880,
    "ratio": 0.3902,
-   "compress_mbps": 75.64,
-   "decompress_mbps": 340.24
+   "compress_mbps": 76.55,
+   "decompress_mbps": 376.23
   },
   {
    "compressor": "zlib",
@@ -5174,8 +5174,8 @@
    "level": 4,
    "out_size": 19512665,
    "ratio": 0.381,
-   "compress_mbps": 71.76,
-   "decompress_mbps": 363.34
+   "compress_mbps": 74.6,
+   "decompress_mbps": 363.45
   },
   {
    "compressor": "zlib",
@@ -5184,8 +5184,8 @@
    "level": 5,
    "out_size": 19213507,
    "ratio": 0.3751,
-   "compress_mbps": 51.35,
-   "decompress_mbps": 370.37
+   "compress_mbps": 52.87,
+   "decompress_mbps": 368.3
   },
   {
    "compressor": "zlib",
@@ -5194,8 +5194,8 @@
    "level": 6,
    "out_size": 19089118,
    "ratio": 0.3727,
-   "compress_mbps": 33.44,
-   "decompress_mbps": 376.59
+   "compress_mbps": 34.32,
+   "decompress_mbps": 379.3
   },
   {
    "compressor": "zlib",
@@ -5204,8 +5204,8 @@
    "level": 7,
    "out_size": 19061204,
    "ratio": 0.3721,
-   "compress_mbps": 27.31,
-   "decompress_mbps": 380.14
+   "compress_mbps": 27.3,
+   "decompress_mbps": 379.88
   },
   {
    "compressor": "zlib",
@@ -5214,8 +5214,8 @@
    "level": 8,
    "out_size": 19040998,
    "ratio": 0.3717,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 379.76
+   "compress_mbps": 15.35,
+   "decompress_mbps": 380.17
   },
   {
    "compressor": "zlib",
@@ -5224,8 +5224,8 @@
    "level": 9,
    "out_size": 19044390,
    "ratio": 0.3718,
-   "compress_mbps": 9.54,
-   "decompress_mbps": 385.45
+   "compress_mbps": 7.8,
+   "decompress_mbps": 261.42
   },
   {
    "compressor": "zlib",
@@ -5234,8 +5234,8 @@
    "level": 1,
    "out_size": 3828360,
    "ratio": 0.384,
-   "compress_mbps": 144.91,
-   "decompress_mbps": 453.29
+   "compress_mbps": 85.57,
+   "decompress_mbps": 305.39
   },
   {
    "compressor": "zlib",
@@ -5244,8 +5244,8 @@
    "level": 2,
    "out_size": 3798539,
    "ratio": 0.381,
-   "compress_mbps": 128.29,
-   "decompress_mbps": 497.36
+   "compress_mbps": 76.41,
+   "decompress_mbps": 315.91
   },
   {
    "compressor": "zlib",
@@ -5254,8 +5254,8 @@
    "level": 3,
    "out_size": 3674568,
    "ratio": 0.3685,
-   "compress_mbps": 80.47,
-   "decompress_mbps": 515.99
+   "compress_mbps": 50.01,
+   "decompress_mbps": 331.43
   },
   {
    "compressor": "zlib",
@@ -5264,8 +5264,8 @@
    "level": 4,
    "out_size": 3680923,
    "ratio": 0.3692,
-   "compress_mbps": 89.36,
-   "decompress_mbps": 457.6
+   "compress_mbps": 52.23,
+   "decompress_mbps": 306.09
   },
   {
    "compressor": "zlib",
@@ -5274,8 +5274,8 @@
    "level": 5,
    "out_size": 3698707,
    "ratio": 0.371,
-   "compress_mbps": 48.13,
-   "decompress_mbps": 427.63
+   "compress_mbps": 29.98,
+   "decompress_mbps": 281.33
   },
   {
    "compressor": "zlib",
@@ -5284,8 +5284,8 @@
    "level": 6,
    "out_size": 3675935,
    "ratio": 0.3687,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 437.75
+   "compress_mbps": 17.53,
+   "decompress_mbps": 291.32
   },
   {
    "compressor": "zlib",
@@ -5294,8 +5294,8 @@
    "level": 7,
    "out_size": 3670281,
    "ratio": 0.3681,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 444.31
+   "compress_mbps": 13.82,
+   "decompress_mbps": 292.43
   },
   {
    "compressor": "zlib",
@@ -5304,8 +5304,8 @@
    "level": 8,
    "out_size": 3661103,
    "ratio": 0.3672,
-   "compress_mbps": 10.94,
-   "decompress_mbps": 458.18
+   "compress_mbps": 7.74,
+   "decompress_mbps": 302.09
   },
   {
    "compressor": "zlib",
@@ -5314,8 +5314,8 @@
    "level": 9,
    "out_size": 3660788,
    "ratio": 0.3672,
-   "compress_mbps": 9.47,
-   "decompress_mbps": 459.79
+   "compress_mbps": 6.8,
+   "decompress_mbps": 413.64
   },
   {
    "compressor": "zlib",
@@ -5324,8 +5324,8 @@
    "level": 1,
    "out_size": 4624591,
    "ratio": 0.1378,
-   "compress_mbps": 332.0,
-   "decompress_mbps": 831.27
+   "compress_mbps": 314.07,
+   "decompress_mbps": 785.63
   },
   {
    "compressor": "zlib",
@@ -5334,8 +5334,8 @@
    "level": 2,
    "out_size": 4303176,
    "ratio": 0.1282,
-   "compress_mbps": 310.37,
-   "decompress_mbps": 841.9
+   "compress_mbps": 303.32,
+   "decompress_mbps": 821.05
   },
   {
    "compressor": "zlib",
@@ -5344,8 +5344,8 @@
    "level": 3,
    "out_size": 4010156,
    "ratio": 0.1195,
-   "compress_mbps": 257.47,
-   "decompress_mbps": 926.52
+   "compress_mbps": 255.31,
+   "decompress_mbps": 910.48
   },
   {
    "compressor": "zlib",
@@ -5354,8 +5354,8 @@
    "level": 4,
    "out_size": 3713866,
    "ratio": 0.1107,
-   "compress_mbps": 212.08,
-   "decompress_mbps": 896.37
+   "compress_mbps": 209.2,
+   "decompress_mbps": 884.1
   },
   {
    "compressor": "zlib",
@@ -5364,8 +5364,8 @@
    "level": 5,
    "out_size": 3378136,
    "ratio": 0.1007,
-   "compress_mbps": 166.1,
-   "decompress_mbps": 954.98
+   "compress_mbps": 163.51,
+   "decompress_mbps": 928.6
   },
   {
    "compressor": "zlib",
@@ -5374,8 +5374,8 @@
    "level": 6,
    "out_size": 3200182,
    "ratio": 0.0954,
-   "compress_mbps": 113.17,
-   "decompress_mbps": 986.8
+   "compress_mbps": 112.88,
+   "decompress_mbps": 980.24
   },
   {
    "compressor": "zlib",
@@ -5384,8 +5384,8 @@
    "level": 7,
    "out_size": 3141278,
    "ratio": 0.0936,
-   "compress_mbps": 90.33,
-   "decompress_mbps": 999.02
+   "compress_mbps": 89.57,
+   "decompress_mbps": 996.19
   },
   {
    "compressor": "zlib",
@@ -5394,8 +5394,8 @@
    "level": 8,
    "out_size": 3031199,
    "ratio": 0.0903,
-   "compress_mbps": 39.16,
-   "decompress_mbps": 1017.12
+   "compress_mbps": 39.14,
+   "decompress_mbps": 648.34
   },
   {
    "compressor": "zlib",
@@ -5404,8 +5404,8 @@
    "level": 9,
    "out_size": 2987995,
    "ratio": 0.0891,
-   "compress_mbps": 21.44,
-   "decompress_mbps": 1033.52
+   "compress_mbps": 21.49,
+   "decompress_mbps": 1005.35
   },
   {
    "compressor": "zlib",
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 3290526,
    "ratio": 0.5349,
-   "compress_mbps": 79.06,
-   "decompress_mbps": 257.16
+   "compress_mbps": 79.17,
+   "decompress_mbps": 250.05
   },
   {
    "compressor": "zlib",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 3238282,
    "ratio": 0.5264,
-   "compress_mbps": 72.38,
-   "decompress_mbps": 263.21
+   "compress_mbps": 71.92,
+   "decompress_mbps": 254.59
   },
   {
    "compressor": "zlib",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 3193366,
    "ratio": 0.5191,
-   "compress_mbps": 57.0,
-   "decompress_mbps": 265.33
+   "compress_mbps": 56.71,
+   "decompress_mbps": 261.97
   },
   {
    "compressor": "zlib",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 3158012,
    "ratio": 0.5133,
-   "compress_mbps": 55.65,
-   "decompress_mbps": 268.5
+   "compress_mbps": 54.37,
+   "decompress_mbps": 265.77
   },
   {
    "compressor": "zlib",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 3115309,
    "ratio": 0.5064,
-   "compress_mbps": 39.25,
-   "decompress_mbps": 269.0
+   "compress_mbps": 38.52,
+   "decompress_mbps": 267.62
   },
   {
    "compressor": "zlib",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 3097288,
    "ratio": 0.5034,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 264.86
+   "compress_mbps": 26.22,
+   "decompress_mbps": 273.48
   },
   {
    "compressor": "zlib",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 3094363,
    "ratio": 0.503,
-   "compress_mbps": 21.86,
-   "decompress_mbps": 268.09
+   "compress_mbps": 21.88,
+   "decompress_mbps": 274.51
   },
   {
    "compressor": "zlib",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 3093026,
    "ratio": 0.5028,
-   "compress_mbps": 16.97,
-   "decompress_mbps": 270.33
+   "compress_mbps": 17.09,
+   "decompress_mbps": 273.88
   },
   {
    "compressor": "zlib",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 3092920,
    "ratio": 0.5027,
-   "compress_mbps": 15.53,
-   "decompress_mbps": 269.1
+   "compress_mbps": 15.5,
+   "decompress_mbps": 271.47
   },
   {
    "compressor": "zlib",
@@ -5504,8 +5504,8 @@
    "level": 1,
    "out_size": 4076385,
    "ratio": 0.4042,
-   "compress_mbps": 125.81,
-   "decompress_mbps": 474.99
+   "compress_mbps": 127.3,
+   "decompress_mbps": 471.5
   },
   {
    "compressor": "zlib",
@@ -5514,8 +5514,8 @@
    "level": 2,
    "out_size": 3991014,
    "ratio": 0.3957,
-   "compress_mbps": 117.17,
-   "decompress_mbps": 494.44
+   "compress_mbps": 118.45,
+   "decompress_mbps": 494.37
   },
   {
    "compressor": "zlib",
@@ -5524,8 +5524,8 @@
    "level": 3,
    "out_size": 3934055,
    "ratio": 0.3901,
-   "compress_mbps": 93.6,
-   "decompress_mbps": 511.59
+   "compress_mbps": 94.4,
+   "decompress_mbps": 450.65
   },
   {
    "compressor": "zlib",
@@ -5534,8 +5534,8 @@
    "level": 4,
    "out_size": 3825092,
    "ratio": 0.3793,
-   "compress_mbps": 85.49,
-   "decompress_mbps": 513.7
+   "compress_mbps": 84.27,
+   "decompress_mbps": 505.46
   },
   {
    "compressor": "zlib",
@@ -5544,8 +5544,8 @@
    "level": 5,
    "out_size": 3752932,
    "ratio": 0.3721,
-   "compress_mbps": 64.41,
-   "decompress_mbps": 496.1
+   "compress_mbps": 64.28,
+   "decompress_mbps": 495.8
   },
   {
    "compressor": "zlib",
@@ -5554,8 +5554,8 @@
    "level": 6,
    "out_size": 3695164,
    "ratio": 0.3664,
-   "compress_mbps": 49.22,
-   "decompress_mbps": 507.36
+   "compress_mbps": 49.11,
+   "decompress_mbps": 504.7
   },
   {
    "compressor": "zlib",
@@ -5564,8 +5564,8 @@
    "level": 7,
    "out_size": 3676881,
    "ratio": 0.3646,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 515.91
+   "compress_mbps": 25.82,
+   "decompress_mbps": 349.14
   },
   {
    "compressor": "zlib",
@@ -5574,8 +5574,8 @@
    "level": 8,
    "out_size": 3673171,
    "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.6
+   "compress_mbps": 22.19,
+   "decompress_mbps": 350.85
   },
   {
    "compressor": "zlib",
@@ -5584,8 +5584,8 @@
    "level": 9,
    "out_size": 3673171,
    "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.23
+   "compress_mbps": 28.74,
+   "decompress_mbps": 517.06
   },
   {
    "compressor": "zlib",
@@ -5594,8 +5594,8 @@
    "level": 1,
    "out_size": 2376424,
    "ratio": 0.3586,
-   "compress_mbps": 130.38,
-   "decompress_mbps": 393.75
+   "compress_mbps": 130.12,
+   "decompress_mbps": 391.2
   },
   {
    "compressor": "zlib",
@@ -5604,8 +5604,8 @@
    "level": 2,
    "out_size": 2259060,
    "ratio": 0.3409,
-   "compress_mbps": 112.03,
-   "decompress_mbps": 411.76
+   "compress_mbps": 110.87,
+   "decompress_mbps": 402.43
   },
   {
    "compressor": "zlib",
@@ -5614,8 +5614,8 @@
    "level": 3,
    "out_size": 2135664,
    "ratio": 0.3223,
-   "compress_mbps": 72.25,
-   "decompress_mbps": 435.29
+   "compress_mbps": 72.28,
+   "decompress_mbps": 421.31
   },
   {
    "compressor": "zlib",
@@ -5624,8 +5624,8 @@
    "level": 4,
    "out_size": 2052793,
    "ratio": 0.3098,
-   "compress_mbps": 81.67,
-   "decompress_mbps": 430.73
+   "compress_mbps": 80.86,
+   "decompress_mbps": 404.65
   },
   {
    "compressor": "zlib",
@@ -5634,8 +5634,8 @@
    "level": 5,
    "out_size": 1932127,
    "ratio": 0.2915,
-   "compress_mbps": 45.23,
-   "decompress_mbps": 432.43
+   "compress_mbps": 44.79,
+   "decompress_mbps": 403.44
   },
   {
    "compressor": "zlib",
@@ -5644,8 +5644,8 @@
    "level": 6,
    "out_size": 1860865,
    "ratio": 0.2808,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 440.25
+   "compress_mbps": 22.77,
+   "decompress_mbps": 420.37
   },
   {
    "compressor": "zlib",
@@ -5654,8 +5654,8 @@
    "level": 7,
    "out_size": 1838671,
    "ratio": 0.2774,
-   "compress_mbps": 15.96,
-   "decompress_mbps": 441.72
+   "compress_mbps": 15.93,
+   "decompress_mbps": 430.46
   },
   {
    "compressor": "zlib",
@@ -5664,8 +5664,8 @@
    "level": 8,
    "out_size": 1823235,
    "ratio": 0.2751,
-   "compress_mbps": 8.12,
-   "decompress_mbps": 436.13
+   "compress_mbps": 8.14,
+   "decompress_mbps": 429.52
   },
   {
    "compressor": "zlib",
@@ -5674,8 +5674,8 @@
    "level": 9,
    "out_size": 1823190,
    "ratio": 0.2751,
-   "compress_mbps": 8.15,
-   "decompress_mbps": 439.5
+   "compress_mbps": 8.1,
+   "decompress_mbps": 430.15
   },
   {
    "compressor": "zlib",
@@ -5684,8 +5684,8 @@
    "level": 1,
    "out_size": 6329449,
    "ratio": 0.2929,
-   "compress_mbps": 169.74,
-   "decompress_mbps": 460.79
+   "compress_mbps": 168.72,
+   "decompress_mbps": 457.62
   },
   {
    "compressor": "zlib",
@@ -5694,8 +5694,8 @@
    "level": 2,
    "out_size": 6128866,
    "ratio": 0.2837,
-   "compress_mbps": 155.55,
-   "decompress_mbps": 557.06
+   "compress_mbps": 155.34,
+   "decompress_mbps": 541.78
   },
   {
    "compressor": "zlib",
@@ -5704,8 +5704,8 @@
    "level": 3,
    "out_size": 5982546,
    "ratio": 0.2769,
-   "compress_mbps": 125.39,
-   "decompress_mbps": 581.02
+   "compress_mbps": 124.93,
+   "decompress_mbps": 575.8
   },
   {
    "compressor": "zlib",
@@ -5714,8 +5714,8 @@
    "level": 4,
    "out_size": 5656400,
    "ratio": 0.2618,
-   "compress_mbps": 116.92,
-   "decompress_mbps": 576.69
+   "compress_mbps": 115.42,
+   "decompress_mbps": 572.55
   },
   {
    "compressor": "zlib",
@@ -5724,8 +5724,8 @@
    "level": 5,
    "out_size": 5511352,
    "ratio": 0.2551,
-   "compress_mbps": 82.58,
-   "decompress_mbps": 587.65
+   "compress_mbps": 81.2,
+   "decompress_mbps": 577.84
   },
   {
    "compressor": "zlib",
@@ -5734,8 +5734,8 @@
    "level": 6,
    "out_size": 5451399,
    "ratio": 0.2523,
-   "compress_mbps": 56.59,
-   "decompress_mbps": 593.88
+   "compress_mbps": 56.11,
+   "decompress_mbps": 588.84
   },
   {
    "compressor": "zlib",
@@ -5744,8 +5744,8 @@
    "level": 7,
    "out_size": 5417123,
    "ratio": 0.2507,
-   "compress_mbps": 46.71,
-   "decompress_mbps": 596.81
+   "compress_mbps": 45.85,
+   "decompress_mbps": 591.28
   },
   {
    "compressor": "zlib",
@@ -5754,8 +5754,8 @@
    "level": 8,
    "out_size": 5404364,
    "ratio": 0.2501,
-   "compress_mbps": 32.73,
-   "decompress_mbps": 602.78
+   "compress_mbps": 32.44,
+   "decompress_mbps": 594.2
   },
   {
    "compressor": "zlib",
@@ -5764,8 +5764,8 @@
    "level": 9,
    "out_size": 5402704,
    "ratio": 0.2501,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 390.04
+   "compress_mbps": 29.67,
+   "decompress_mbps": 590.36
   },
   {
    "compressor": "zlib",
@@ -5774,8 +5774,8 @@
    "level": 1,
    "out_size": 5567768,
    "ratio": 0.7678,
-   "compress_mbps": 32.89,
-   "decompress_mbps": 211.48
+   "compress_mbps": 61.63,
+   "decompress_mbps": 309.6
   },
   {
    "compressor": "zlib",
@@ -5784,8 +5784,8 @@
    "level": 2,
    "out_size": 5504009,
    "ratio": 0.759,
-   "compress_mbps": 38.32,
-   "decompress_mbps": 168.63
+   "compress_mbps": 58.46,
+   "decompress_mbps": 320.33
   },
   {
    "compressor": "zlib",
@@ -5794,8 +5794,8 @@
    "level": 3,
    "out_size": 5439339,
    "ratio": 0.7501,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 230.72
+   "compress_mbps": 46.31,
+   "decompress_mbps": 325.68
   },
   {
    "compressor": "zlib",
@@ -5804,8 +5804,8 @@
    "level": 4,
    "out_size": 5394604,
    "ratio": 0.7439,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 256.53
+   "compress_mbps": 47.07,
+   "decompress_mbps": 340.22
   },
   {
    "compressor": "zlib",
@@ -5814,8 +5814,8 @@
    "level": 5,
    "out_size": 5370116,
    "ratio": 0.7405,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 312.67
+   "compress_mbps": 32.66,
+   "decompress_mbps": 330.69
   },
   {
    "compressor": "zlib",
@@ -5824,8 +5824,8 @@
    "level": 6,
    "out_size": 5331793,
    "ratio": 0.7352,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 329.4
+   "compress_mbps": 22.62,
+   "decompress_mbps": 341.1
   },
   {
    "compressor": "zlib",
@@ -5834,8 +5834,8 @@
    "level": 7,
    "out_size": 5327677,
    "ratio": 0.7347,
-   "compress_mbps": 21.16,
-   "decompress_mbps": 348.44
+   "compress_mbps": 21.0,
+   "decompress_mbps": 338.51
   },
   {
    "compressor": "zlib",
@@ -5844,8 +5844,8 @@
    "level": 8,
    "out_size": 5325914,
    "ratio": 0.7344,
-   "compress_mbps": 18.96,
-   "decompress_mbps": 349.29
+   "compress_mbps": 18.77,
+   "decompress_mbps": 343.12
   },
   {
    "compressor": "zlib",
@@ -5854,8 +5854,8 @@
    "level": 9,
    "out_size": 5325914,
    "ratio": 0.7344,
-   "compress_mbps": 18.95,
-   "decompress_mbps": 346.98
+   "compress_mbps": 18.39,
+   "decompress_mbps": 342.69
   },
   {
    "compressor": "zlib",
@@ -5864,8 +5864,8 @@
    "level": 1,
    "out_size": 14991236,
    "ratio": 0.3616,
-   "compress_mbps": 136.65,
-   "decompress_mbps": 380.3
+   "compress_mbps": 135.9,
+   "decompress_mbps": 359.54
   },
   {
    "compressor": "zlib",
@@ -5874,8 +5874,8 @@
    "level": 2,
    "out_size": 14249692,
    "ratio": 0.3437,
-   "compress_mbps": 120.34,
-   "decompress_mbps": 401.81
+   "compress_mbps": 119.46,
+   "decompress_mbps": 380.69
   },
   {
    "compressor": "zlib",
@@ -5884,8 +5884,8 @@
    "level": 3,
    "out_size": 13627761,
    "ratio": 0.3287,
-   "compress_mbps": 87.73,
-   "decompress_mbps": 414.55
+   "compress_mbps": 86.51,
+   "decompress_mbps": 358.77
   },
   {
    "compressor": "zlib",
@@ -5894,8 +5894,8 @@
    "level": 4,
    "out_size": 13001990,
    "ratio": 0.3136,
-   "compress_mbps": 85.4,
-   "decompress_mbps": 395.8
+   "compress_mbps": 74.2,
+   "decompress_mbps": 347.03
   },
   {
    "compressor": "zlib",
@@ -5904,8 +5904,8 @@
    "level": 5,
    "out_size": 12445991,
    "ratio": 0.3002,
-   "compress_mbps": 55.03,
-   "decompress_mbps": 392.94
+   "compress_mbps": 54.12,
+   "decompress_mbps": 319.52
   },
   {
    "compressor": "zlib",
@@ -5914,8 +5914,8 @@
    "level": 6,
    "out_size": 12213941,
    "ratio": 0.2946,
-   "compress_mbps": 36.53,
-   "decompress_mbps": 400.31
+   "compress_mbps": 35.05,
+   "decompress_mbps": 304.98
   },
   {
    "compressor": "zlib",
@@ -5924,8 +5924,8 @@
    "level": 7,
    "out_size": 12130416,
    "ratio": 0.2926,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 401.43
+   "compress_mbps": 28.32,
+   "decompress_mbps": 325.55
   },
   {
    "compressor": "zlib",
@@ -5934,8 +5934,8 @@
    "level": 8,
    "out_size": 12073697,
    "ratio": 0.2912,
-   "compress_mbps": 21.5,
-   "decompress_mbps": 403.07
+   "compress_mbps": 20.51,
+   "decompress_mbps": 369.84
   },
   {
    "compressor": "zlib",
@@ -5944,8 +5944,8 @@
    "level": 9,
    "out_size": 12073469,
    "ratio": 0.2912,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 403.44
+   "compress_mbps": 21.11,
+   "decompress_mbps": 341.55
   },
   {
    "compressor": "zlib",
@@ -5954,8 +5954,8 @@
    "level": 1,
    "out_size": 6033926,
    "ratio": 0.712,
-   "compress_mbps": 75.49,
-   "decompress_mbps": 294.33
+   "compress_mbps": 69.95,
+   "decompress_mbps": 281.25
   },
   {
    "compressor": "zlib",
@@ -5964,8 +5964,8 @@
    "level": 2,
    "out_size": 5997474,
    "ratio": 0.7077,
-   "compress_mbps": 68.78,
-   "decompress_mbps": 305.32
+   "compress_mbps": 67.17,
+   "decompress_mbps": 292.77
   },
   {
    "compressor": "zlib",
@@ -5974,8 +5974,8 @@
    "level": 3,
    "out_size": 5966621,
    "ratio": 0.7041,
-   "compress_mbps": 55.63,
-   "decompress_mbps": 312.38
+   "compress_mbps": 50.62,
+   "decompress_mbps": 294.15
   },
   {
    "compressor": "zlib",
@@ -5984,8 +5984,8 @@
    "level": 4,
    "out_size": 6091108,
    "ratio": 0.7188,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 267.15
+   "compress_mbps": 44.52,
+   "decompress_mbps": 255.65
   },
   {
    "compressor": "zlib",
@@ -5994,8 +5994,8 @@
    "level": 5,
    "out_size": 6053566,
    "ratio": 0.7143,
-   "compress_mbps": 37.26,
-   "decompress_mbps": 274.93
+   "compress_mbps": 33.74,
+   "decompress_mbps": 262.53
   },
   {
    "compressor": "zlib",
@@ -6004,8 +6004,8 @@
    "level": 6,
    "out_size": 6045111,
    "ratio": 0.7134,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 276.79
+   "compress_mbps": 33.82,
+   "decompress_mbps": 267.47
   },
   {
    "compressor": "zlib",
@@ -6014,8 +6014,8 @@
    "level": 7,
    "out_size": 6045034,
    "ratio": 0.7133,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 278.07
+   "compress_mbps": 32.14,
+   "decompress_mbps": 257.08
   },
   {
    "compressor": "zlib",
@@ -6024,8 +6024,8 @@
    "level": 8,
    "out_size": 6045032,
    "ratio": 0.7133,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 277.28
+   "compress_mbps": 33.98,
+   "decompress_mbps": 273.98
   },
   {
    "compressor": "zlib",
@@ -6034,8 +6034,8 @@
    "level": 9,
    "out_size": 6045032,
    "ratio": 0.7133,
-   "compress_mbps": 34.94,
-   "decompress_mbps": 277.39
+   "compress_mbps": 30.76,
+   "decompress_mbps": 267.61
   },
   {
    "compressor": "zlib",
@@ -6044,8 +6044,8 @@
    "level": 1,
    "out_size": 965242,
    "ratio": 0.1806,
-   "compress_mbps": 264.31,
-   "decompress_mbps": 697.56
+   "compress_mbps": 246.67,
+   "decompress_mbps": 577.6
   },
   {
    "compressor": "zlib",
@@ -6054,8 +6054,8 @@
    "level": 2,
    "out_size": 887265,
    "ratio": 0.166,
-   "compress_mbps": 246.22,
-   "decompress_mbps": 752.4
+   "compress_mbps": 228.81,
+   "decompress_mbps": 674.48
   },
   {
    "compressor": "zlib",
@@ -6064,8 +6064,8 @@
    "level": 3,
    "out_size": 822167,
    "ratio": 0.1538,
-   "compress_mbps": 191.48,
-   "decompress_mbps": 797.39
+   "compress_mbps": 174.12,
+   "decompress_mbps": 707.84
   },
   {
    "compressor": "zlib",
@@ -6074,8 +6074,8 @@
    "level": 4,
    "out_size": 807518,
    "ratio": 0.1511,
-   "compress_mbps": 169.01,
-   "decompress_mbps": 768.34
+   "compress_mbps": 156.97,
+   "decompress_mbps": 647.93
   },
   {
    "compressor": "zlib",
@@ -6084,8 +6084,8 @@
    "level": 5,
    "out_size": 730574,
    "ratio": 0.1367,
-   "compress_mbps": 121.75,
-   "decompress_mbps": 815.59
+   "compress_mbps": 114.18,
+   "decompress_mbps": 680.19
   },
   {
    "compressor": "zlib",
@@ -6094,8 +6094,8 @@
    "level": 6,
    "out_size": 687991,
    "ratio": 0.1287,
-   "compress_mbps": 79.31,
-   "decompress_mbps": 872.54
+   "compress_mbps": 71.86,
+   "decompress_mbps": 755.47
   },
   {
    "compressor": "zlib",
@@ -6104,8 +6104,8 @@
    "level": 7,
    "out_size": 673933,
    "ratio": 0.1261,
-   "compress_mbps": 64.99,
-   "decompress_mbps": 887.93
+   "compress_mbps": 58.88,
+   "decompress_mbps": 718.82
   },
   {
    "compressor": "zlib",
@@ -6114,8 +6114,8 @@
    "level": 8,
    "out_size": 659518,
    "ratio": 0.1234,
-   "compress_mbps": 43.0,
-   "decompress_mbps": 884.96
+   "compress_mbps": 39.19,
+   "decompress_mbps": 795.96
   },
   {
    "compressor": "zlib",
@@ -6124,8 +6124,8 @@
    "level": 9,
    "out_size": 658899,
    "ratio": 0.1233,
-   "compress_mbps": 39.85,
-   "decompress_mbps": 896.88
+   "compress_mbps": 37.78,
+   "decompress_mbps": 756.71
   },
   {
    "compressor": "miniz_oxide",
@@ -6134,8 +6134,8 @@
    "level": 1,
    "out_size": 5363862,
    "ratio": 0.5263,
-   "compress_mbps": 141.65,
-   "decompress_mbps": 389.91
+   "compress_mbps": 124.52,
+   "decompress_mbps": 340.19
   },
   {
    "compressor": "miniz_oxide",
@@ -6144,8 +6144,8 @@
    "level": 2,
    "out_size": 4438205,
    "ratio": 0.4354,
-   "compress_mbps": 128.9,
-   "decompress_mbps": 428.47
+   "compress_mbps": 120.4,
+   "decompress_mbps": 401.79
   },
   {
    "compressor": "miniz_oxide",
@@ -6154,8 +6154,8 @@
    "level": 3,
    "out_size": 4054333,
    "ratio": 0.3978,
-   "compress_mbps": 63.86,
-   "decompress_mbps": 475.64
+   "compress_mbps": 61.22,
+   "decompress_mbps": 443.06
   },
   {
    "compressor": "miniz_oxide",
@@ -6164,8 +6164,8 @@
    "level": 4,
    "out_size": 4038550,
    "ratio": 0.3962,
-   "compress_mbps": 57.76,
-   "decompress_mbps": 469.09
+   "compress_mbps": 54.31,
+   "decompress_mbps": 417.13
   },
   {
    "compressor": "miniz_oxide",
@@ -6174,8 +6174,8 @@
    "level": 5,
    "out_size": 3954920,
    "ratio": 0.388,
-   "compress_mbps": 40.27,
-   "decompress_mbps": 462.21
+   "compress_mbps": 38.44,
+   "decompress_mbps": 324.55
   },
   {
    "compressor": "miniz_oxide",
@@ -6184,8 +6184,8 @@
    "level": 6,
    "out_size": 3872874,
    "ratio": 0.38,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 470.25
+   "compress_mbps": 21.18,
+   "decompress_mbps": 430.51
   },
   {
    "compressor": "miniz_oxide",
@@ -6194,8 +6194,8 @@
    "level": 7,
    "out_size": 3859937,
    "ratio": 0.3787,
-   "compress_mbps": 18.83,
-   "decompress_mbps": 472.38
+   "compress_mbps": 18.36,
+   "decompress_mbps": 439.82
   },
   {
    "compressor": "miniz_oxide",
@@ -6204,8 +6204,8 @@
    "level": 8,
    "out_size": 3855935,
    "ratio": 0.3783,
-   "compress_mbps": 17.07,
-   "decompress_mbps": 469.47
+   "compress_mbps": 16.87,
+   "decompress_mbps": 458.79
   },
   {
    "compressor": "miniz_oxide",
@@ -6214,8 +6214,8 @@
    "level": 9,
    "out_size": 3855791,
    "ratio": 0.3783,
-   "compress_mbps": 17.01,
-   "decompress_mbps": 470.52
+   "compress_mbps": 16.9,
+   "decompress_mbps": 456.13
   },
   {
    "compressor": "miniz_oxide",
@@ -6224,8 +6224,8 @@
    "level": 1,
    "out_size": 22334882,
    "ratio": 0.4361,
-   "compress_mbps": 233.89,
-   "decompress_mbps": 370.0
+   "compress_mbps": 228.27,
+   "decompress_mbps": 305.99
   },
   {
    "compressor": "miniz_oxide",
@@ -6234,8 +6234,8 @@
    "level": 2,
    "out_size": 20150366,
    "ratio": 0.3934,
-   "compress_mbps": 119.97,
-   "decompress_mbps": 375.66
+   "compress_mbps": 111.9,
+   "decompress_mbps": 359.11
   },
   {
    "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
    "level": 3,
    "out_size": 19495014,
    "ratio": 0.3806,
-   "compress_mbps": 70.13,
-   "decompress_mbps": 389.58
+   "compress_mbps": 62.54,
+   "decompress_mbps": 338.66
   },
   {
    "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
    "level": 4,
    "out_size": 19424978,
    "ratio": 0.3792,
-   "compress_mbps": 71.02,
-   "decompress_mbps": 402.97
+   "compress_mbps": 64.41,
+   "decompress_mbps": 318.23
   },
   {
    "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
    "level": 5,
    "out_size": 19298736,
    "ratio": 0.3768,
-   "compress_mbps": 54.1,
-   "decompress_mbps": 393.93
+   "compress_mbps": 46.78,
+   "decompress_mbps": 372.89
   },
   {
    "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
    "level": 6,
    "out_size": 19179167,
    "ratio": 0.3744,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 422.35
+   "compress_mbps": 26.04,
+   "decompress_mbps": 317.5
   },
   {
    "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
    "level": 7,
    "out_size": 19151324,
    "ratio": 0.3739,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 422.25
+   "compress_mbps": 20.24,
+   "decompress_mbps": 352.17
   },
   {
    "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
    "level": 8,
    "out_size": 19144373,
    "ratio": 0.3738,
-   "compress_mbps": 16.59,
-   "decompress_mbps": 407.62
+   "compress_mbps": 16.33,
+   "decompress_mbps": 382.91
   },
   {
    "compressor": "miniz_oxide",
@@ -6304,8 +6304,8 @@
    "level": 9,
    "out_size": 19141383,
    "ratio": 0.3737,
-   "compress_mbps": 14.17,
-   "decompress_mbps": 420.85
+   "compress_mbps": 14.14,
+   "decompress_mbps": 389.52
   },
   {
    "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
    "level": 1,
    "out_size": 4249731,
    "ratio": 0.4262,
-   "compress_mbps": 313.35,
-   "decompress_mbps": 528.94
+   "compress_mbps": 303.18,
+   "decompress_mbps": 522.98
   },
   {
    "compressor": "miniz_oxide",
@@ -6324,8 +6324,8 @@
    "level": 2,
    "out_size": 3775479,
    "ratio": 0.3787,
-   "compress_mbps": 156.84,
-   "decompress_mbps": 517.84
+   "compress_mbps": 156.7,
+   "decompress_mbps": 546.68
   },
   {
    "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
    "level": 3,
    "out_size": 3656966,
    "ratio": 0.3668,
-   "compress_mbps": 79.84,
-   "decompress_mbps": 574.15
+   "compress_mbps": 79.9,
+   "decompress_mbps": 561.3
   },
   {
    "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
    "level": 4,
    "out_size": 3740378,
    "ratio": 0.3751,
-   "compress_mbps": 67.57,
-   "decompress_mbps": 534.79
+   "compress_mbps": 67.37,
+   "decompress_mbps": 529.49
   },
   {
    "compressor": "miniz_oxide",
@@ -6354,8 +6354,8 @@
    "level": 5,
    "out_size": 3713604,
    "ratio": 0.3725,
-   "compress_mbps": 48.45,
-   "decompress_mbps": 501.84
+   "compress_mbps": 47.9,
+   "decompress_mbps": 489.84
   },
   {
    "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
    "level": 6,
    "out_size": 3683556,
    "ratio": 0.3694,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 515.42
+   "compress_mbps": 23.1,
+   "decompress_mbps": 491.69
   },
   {
    "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
    "level": 7,
    "out_size": 3683797,
    "ratio": 0.3695,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 521.98
+   "compress_mbps": 18.4,
+   "decompress_mbps": 525.27
   },
   {
    "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
    "level": 8,
    "out_size": 3684477,
    "ratio": 0.3695,
-   "compress_mbps": 14.34,
-   "decompress_mbps": 540.16
+   "compress_mbps": 13.97,
+   "decompress_mbps": 494.28
   },
   {
    "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
    "level": 9,
    "out_size": 3679414,
    "ratio": 0.369,
-   "compress_mbps": 12.34,
-   "decompress_mbps": 542.45
+   "compress_mbps": 10.43,
+   "decompress_mbps": 474.34
   },
   {
    "compressor": "miniz_oxide",
@@ -6404,8 +6404,8 @@
    "level": 1,
    "out_size": 5594622,
    "ratio": 0.1667,
-   "compress_mbps": 433.55,
-   "decompress_mbps": 834.3
+   "compress_mbps": 356.49,
+   "decompress_mbps": 618.37
   },
   {
    "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
    "level": 2,
    "out_size": 4179532,
    "ratio": 0.1246,
-   "compress_mbps": 327.38,
-   "decompress_mbps": 926.24
+   "compress_mbps": 260.75,
+   "decompress_mbps": 806.35
   },
   {
    "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
    "level": 3,
    "out_size": 3542329,
    "ratio": 0.1056,
-   "compress_mbps": 211.33,
-   "decompress_mbps": 842.8
+   "compress_mbps": 174.2,
+   "decompress_mbps": 681.48
   },
   {
    "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
    "level": 4,
    "out_size": 3323363,
    "ratio": 0.099,
-   "compress_mbps": 197.38,
-   "decompress_mbps": 872.41
+   "compress_mbps": 181.51,
+   "decompress_mbps": 674.09
   },
   {
    "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
    "level": 5,
    "out_size": 3230343,
    "ratio": 0.0963,
-   "compress_mbps": 161.61,
-   "decompress_mbps": 952.97
+   "compress_mbps": 150.97,
+   "decompress_mbps": 741.56
   },
   {
    "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
    "level": 6,
    "out_size": 3123421,
    "ratio": 0.0931,
-   "compress_mbps": 95.69,
-   "decompress_mbps": 997.1
+   "compress_mbps": 87.1,
+   "decompress_mbps": 831.56
   },
   {
    "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
    "level": 7,
    "out_size": 3093778,
    "ratio": 0.0922,
-   "compress_mbps": 70.53,
-   "decompress_mbps": 972.37
+   "compress_mbps": 61.69,
+   "decompress_mbps": 692.88
   },
   {
    "compressor": "miniz_oxide",
@@ -6474,8 +6474,8 @@
    "level": 8,
    "out_size": 3067318,
    "ratio": 0.0914,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1013.07
+   "compress_mbps": 44.06,
+   "decompress_mbps": 791.96
   },
   {
    "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
    "level": 9,
    "out_size": 3050695,
    "ratio": 0.0909,
-   "compress_mbps": 41.98,
-   "decompress_mbps": 1022.82
+   "compress_mbps": 41.86,
+   "decompress_mbps": 808.76
   },
   {
    "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
    "level": 1,
    "out_size": 3543611,
    "ratio": 0.576,
-   "compress_mbps": 169.2,
-   "decompress_mbps": 269.98
+   "compress_mbps": 161.46,
+   "decompress_mbps": 252.6
   },
   {
    "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
    "level": 2,
    "out_size": 3226818,
    "ratio": 0.5245,
-   "compress_mbps": 86.03,
-   "decompress_mbps": 287.07
+   "compress_mbps": 82.84,
+   "decompress_mbps": 283.04
   },
   {
    "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
    "level": 3,
    "out_size": 3144140,
    "ratio": 0.5111,
-   "compress_mbps": 52.6,
-   "decompress_mbps": 297.45
+   "compress_mbps": 51.17,
+   "decompress_mbps": 268.51
   },
   {
    "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
    "level": 4,
    "out_size": 3129833,
    "ratio": 0.5087,
-   "compress_mbps": 51.39,
-   "decompress_mbps": 324.03
+   "compress_mbps": 49.39,
+   "decompress_mbps": 311.49
   },
   {
    "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
    "level": 5,
    "out_size": 3114809,
    "ratio": 0.5063,
-   "compress_mbps": 40.29,
-   "decompress_mbps": 338.27
+   "compress_mbps": 38.01,
+   "decompress_mbps": 266.12
   },
   {
    "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
    "level": 6,
    "out_size": 3095705,
    "ratio": 0.5032,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 345.03
+   "compress_mbps": 23.52,
+   "decompress_mbps": 336.87
   },
   {
    "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
    "level": 7,
    "out_size": 3090055,
    "ratio": 0.5023,
-   "compress_mbps": 20.39,
-   "decompress_mbps": 345.41
+   "compress_mbps": 20.12,
+   "decompress_mbps": 346.08
   },
   {
    "compressor": "miniz_oxide",
@@ -6564,8 +6564,8 @@
    "level": 8,
    "out_size": 3087665,
    "ratio": 0.5019,
-   "compress_mbps": 17.41,
-   "decompress_mbps": 345.4
+   "compress_mbps": 17.45,
+   "decompress_mbps": 353.74
   },
   {
    "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
    "level": 9,
    "out_size": 3087158,
    "ratio": 0.5018,
-   "compress_mbps": 16.29,
-   "decompress_mbps": 345.8
+   "compress_mbps": 16.39,
+   "decompress_mbps": 351.11
   },
   {
    "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
    "level": 1,
    "out_size": 5419510,
    "ratio": 0.5373,
-   "compress_mbps": 243.36,
-   "decompress_mbps": 535.63
+   "compress_mbps": 243.15,
+   "decompress_mbps": 507.99
   },
   {
    "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
    "level": 2,
    "out_size": 3982547,
    "ratio": 0.3949,
-   "compress_mbps": 122.38,
-   "decompress_mbps": 550.66
+   "compress_mbps": 124.42,
+   "decompress_mbps": 532.45
   },
   {
    "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
    "level": 3,
    "out_size": 3806102,
    "ratio": 0.3774,
-   "compress_mbps": 80.86,
-   "decompress_mbps": 568.24
+   "compress_mbps": 81.86,
+   "decompress_mbps": 544.44
   },
   {
    "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
    "level": 4,
    "out_size": 3761477,
    "ratio": 0.373,
-   "compress_mbps": 78.11,
-   "decompress_mbps": 603.06
+   "compress_mbps": 78.93,
+   "decompress_mbps": 587.7
   },
   {
    "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
    "level": 5,
    "out_size": 3740298,
    "ratio": 0.3709,
-   "compress_mbps": 67.07,
-   "decompress_mbps": 611.24
+   "compress_mbps": 67.43,
+   "decompress_mbps": 586.11
   },
   {
    "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
    "level": 6,
    "out_size": 3686116,
    "ratio": 0.3655,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 637.82
+   "compress_mbps": 49.16,
+   "decompress_mbps": 614.73
   },
   {
    "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
    "level": 7,
    "out_size": 3668442,
    "ratio": 0.3637,
-   "compress_mbps": 38.85,
-   "decompress_mbps": 662.0
+   "compress_mbps": 38.8,
+   "decompress_mbps": 634.31
   },
   {
    "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
    "level": 8,
    "out_size": 3665072,
    "ratio": 0.3634,
-   "compress_mbps": 33.15,
-   "decompress_mbps": 657.03
+   "compress_mbps": 33.22,
+   "decompress_mbps": 642.24
   },
   {
    "compressor": "miniz_oxide",
@@ -6664,8 +6664,8 @@
    "level": 9,
    "out_size": 3665057,
    "ratio": 0.3634,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 653.51
+   "compress_mbps": 33.08,
+   "decompress_mbps": 629.06
   },
   {
    "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
    "level": 1,
    "out_size": 2842321,
    "ratio": 0.4289,
-   "compress_mbps": 193.08,
-   "decompress_mbps": 443.97
+   "compress_mbps": 189.23,
+   "decompress_mbps": 441.91
   },
   {
    "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
    "level": 2,
    "out_size": 2232180,
    "ratio": 0.3368,
-   "compress_mbps": 151.04,
-   "decompress_mbps": 514.91
+   "compress_mbps": 152.94,
+   "decompress_mbps": 502.42
   },
   {
    "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
    "level": 3,
    "out_size": 2003056,
    "ratio": 0.3022,
-   "compress_mbps": 81.92,
-   "decompress_mbps": 551.48
+   "compress_mbps": 82.57,
+   "decompress_mbps": 536.7
   },
   {
    "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
    "level": 4,
    "out_size": 1985375,
    "ratio": 0.2996,
-   "compress_mbps": 74.08,
-   "decompress_mbps": 566.46
+   "compress_mbps": 74.27,
+   "decompress_mbps": 542.74
   },
   {
    "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
    "level": 5,
    "out_size": 1933775,
    "ratio": 0.2918,
-   "compress_mbps": 51.93,
-   "decompress_mbps": 538.73
+   "compress_mbps": 52.04,
+   "decompress_mbps": 523.21
   },
   {
    "compressor": "miniz_oxide",
@@ -6725,7 +6725,7 @@
    "out_size": 1858103,
    "ratio": 0.2804,
    "compress_mbps": 22.05,
-   "decompress_mbps": 541.6
+   "decompress_mbps": 537.6
   },
   {
    "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
    "level": 7,
    "out_size": 1840414,
    "ratio": 0.2777,
-   "compress_mbps": 15.15,
-   "decompress_mbps": 550.69
+   "compress_mbps": 15.1,
+   "decompress_mbps": 529.77
   },
   {
    "compressor": "miniz_oxide",
@@ -6744,8 +6744,8 @@
    "level": 8,
    "out_size": 1831679,
    "ratio": 0.2764,
-   "compress_mbps": 11.76,
-   "decompress_mbps": 543.82
+   "compress_mbps": 11.41,
+   "decompress_mbps": 522.16
   },
   {
    "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
    "level": 9,
    "out_size": 1827137,
    "ratio": 0.2757,
-   "compress_mbps": 10.16,
-   "decompress_mbps": 544.36
+   "compress_mbps": 10.13,
+   "decompress_mbps": 529.47
   },
   {
    "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
    "level": 1,
    "out_size": 7089759,
    "ratio": 0.3281,
-   "compress_mbps": 290.79,
-   "decompress_mbps": 557.71
+   "compress_mbps": 286.69,
+   "decompress_mbps": 564.29
   },
   {
    "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
    "level": 2,
    "out_size": 5966231,
    "ratio": 0.2761,
-   "compress_mbps": 174.66,
-   "decompress_mbps": 619.46
+   "compress_mbps": 173.98,
+   "decompress_mbps": 603.53
   },
   {
    "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
    "level": 3,
    "out_size": 5611838,
    "ratio": 0.2597,
-   "compress_mbps": 111.67,
-   "decompress_mbps": 648.0
+   "compress_mbps": 111.15,
+   "decompress_mbps": 630.46
   },
   {
    "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
    "level": 4,
    "out_size": 5535436,
    "ratio": 0.2562,
-   "compress_mbps": 105.54,
-   "decompress_mbps": 672.27
+   "compress_mbps": 105.14,
+   "decompress_mbps": 650.46
   },
   {
    "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
    "level": 5,
    "out_size": 5480971,
    "ratio": 0.2537,
-   "compress_mbps": 81.52,
-   "decompress_mbps": 680.77
+   "compress_mbps": 81.25,
+   "decompress_mbps": 657.48
   },
   {
    "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
    "level": 6,
    "out_size": 5437556,
    "ratio": 0.2517,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 697.31
+   "compress_mbps": 47.9,
+   "decompress_mbps": 678.47
   },
   {
    "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
    "level": 7,
    "out_size": 5432108,
    "ratio": 0.2514,
-   "compress_mbps": 40.48,
-   "decompress_mbps": 694.27
+   "compress_mbps": 40.44,
+   "decompress_mbps": 686.14
   },
   {
    "compressor": "miniz_oxide",
@@ -6834,8 +6834,8 @@
    "level": 8,
    "out_size": 5428571,
    "ratio": 0.2512,
-   "compress_mbps": 33.62,
-   "decompress_mbps": 700.3
+   "compress_mbps": 33.7,
+   "decompress_mbps": 698.47
   },
   {
    "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
    "level": 9,
    "out_size": 5425526,
    "ratio": 0.2511,
-   "compress_mbps": 30.51,
-   "decompress_mbps": 703.33
+   "compress_mbps": 30.52,
+   "decompress_mbps": 664.36
   },
   {
    "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
    "level": 1,
    "out_size": 5900800,
    "ratio": 0.8137,
-   "compress_mbps": 188.47,
-   "decompress_mbps": 324.35
+   "compress_mbps": 182.66,
+   "decompress_mbps": 328.37
   },
   {
    "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
    "level": 2,
    "out_size": 5523611,
    "ratio": 0.7617,
-   "compress_mbps": 69.45,
-   "decompress_mbps": 340.66
+   "compress_mbps": 68.12,
+   "decompress_mbps": 333.57
   },
   {
    "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
    "level": 3,
    "out_size": 5393086,
    "ratio": 0.7437,
-   "compress_mbps": 40.33,
-   "decompress_mbps": 351.21
+   "compress_mbps": 40.45,
+   "decompress_mbps": 349.73
   },
   {
    "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
    "level": 4,
    "out_size": 5401582,
    "ratio": 0.7448,
-   "compress_mbps": 40.72,
-   "decompress_mbps": 367.5
+   "compress_mbps": 40.75,
+   "decompress_mbps": 365.34
   },
   {
    "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
    "level": 5,
    "out_size": 5371274,
    "ratio": 0.7407,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 358.37
+   "compress_mbps": 31.35,
+   "decompress_mbps": 355.98
   },
   {
    "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
    "level": 6,
    "out_size": 5330096,
    "ratio": 0.735,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 365.39
+   "compress_mbps": 20.78,
+   "decompress_mbps": 361.78
   },
   {
    "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
    "level": 7,
    "out_size": 5325437,
    "ratio": 0.7343,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 366.05
+   "compress_mbps": 18.82,
+   "decompress_mbps": 359.85
   },
   {
    "compressor": "miniz_oxide",
@@ -6925,7 +6925,7 @@
    "out_size": 5323934,
    "ratio": 0.7341,
    "compress_mbps": 18.05,
-   "decompress_mbps": 364.0
+   "decompress_mbps": 364.33
   },
   {
    "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
    "level": 9,
    "out_size": 5323621,
    "ratio": 0.7341,
-   "compress_mbps": 17.67,
-   "decompress_mbps": 364.02
+   "compress_mbps": 17.56,
+   "decompress_mbps": 361.16
   },
   {
    "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
    "level": 1,
    "out_size": 17587173,
    "ratio": 0.4242,
-   "compress_mbps": 185.73,
-   "decompress_mbps": 379.13
+   "compress_mbps": 182.29,
+   "decompress_mbps": 386.82
   },
   {
    "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
    "level": 2,
    "out_size": 14171707,
    "ratio": 0.3418,
-   "compress_mbps": 149.15,
-   "decompress_mbps": 409.08
+   "compress_mbps": 149.75,
+   "decompress_mbps": 421.23
   },
   {
    "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
    "level": 3,
    "out_size": 12774851,
    "ratio": 0.3081,
-   "compress_mbps": 85.71,
-   "decompress_mbps": 440.79
+   "compress_mbps": 86.21,
+   "decompress_mbps": 444.5
   },
   {
    "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
    "level": 4,
    "out_size": 12612554,
    "ratio": 0.3042,
-   "compress_mbps": 76.13,
-   "decompress_mbps": 444.75
+   "compress_mbps": 76.37,
+   "decompress_mbps": 439.87
   },
   {
    "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
    "level": 5,
    "out_size": 12392339,
    "ratio": 0.2989,
-   "compress_mbps": 58.1,
-   "decompress_mbps": 457.17
+   "compress_mbps": 58.23,
+   "decompress_mbps": 410.54
   },
   {
    "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
    "level": 6,
    "out_size": 12158314,
    "ratio": 0.2933,
-   "compress_mbps": 34.41,
-   "decompress_mbps": 463.08
+   "compress_mbps": 30.97,
+   "decompress_mbps": 408.74
   },
   {
    "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
    "level": 7,
    "out_size": 12107840,
    "ratio": 0.292,
-   "compress_mbps": 27.64,
-   "decompress_mbps": 466.33
+   "compress_mbps": 24.76,
+   "decompress_mbps": 409.74
   },
   {
    "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
    "level": 8,
    "out_size": 12081311,
    "ratio": 0.2914,
-   "compress_mbps": 22.88,
-   "decompress_mbps": 462.63
+   "compress_mbps": 21.46,
+   "decompress_mbps": 444.75
   },
   {
    "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
    "level": 9,
    "out_size": 12081011,
    "ratio": 0.2914,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 460.01
+   "compress_mbps": 21.79,
+   "decompress_mbps": 452.08
   },
   {
    "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
    "level": 1,
    "out_size": 6527324,
    "ratio": 0.7703,
-   "compress_mbps": 238.95,
-   "decompress_mbps": 330.7
+   "compress_mbps": 233.52,
+   "decompress_mbps": 331.12
   },
   {
    "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
    "level": 2,
    "out_size": 6051483,
    "ratio": 0.7141,
-   "compress_mbps": 75.62,
-   "decompress_mbps": 332.39
+   "compress_mbps": 75.28,
+   "decompress_mbps": 328.01
   },
   {
    "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
    "level": 3,
    "out_size": 6010123,
    "ratio": 0.7092,
-   "compress_mbps": 52.06,
-   "decompress_mbps": 334.45
+   "compress_mbps": 49.25,
+   "decompress_mbps": 330.1
   },
   {
    "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
    "level": 4,
    "out_size": 6024815,
    "ratio": 0.711,
-   "compress_mbps": 44.63,
-   "decompress_mbps": 286.25
+   "compress_mbps": 44.66,
+   "decompress_mbps": 283.34
   },
   {
    "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
    "level": 5,
    "out_size": 6005181,
    "ratio": 0.7086,
-   "compress_mbps": 40.44,
-   "decompress_mbps": 293.0
+   "compress_mbps": 40.09,
+   "decompress_mbps": 289.5
   },
   {
    "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
    "level": 6,
    "out_size": 5997508,
    "ratio": 0.7077,
-   "compress_mbps": 37.97,
-   "decompress_mbps": 295.42
+   "compress_mbps": 34.67,
+   "decompress_mbps": 291.23
   },
   {
    "compressor": "miniz_oxide",
@@ -7095,7 +7095,7 @@
    "out_size": 5997403,
    "ratio": 0.7077,
    "compress_mbps": 37.87,
-   "decompress_mbps": 295.69
+   "decompress_mbps": 295.3
   },
   {
    "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
    "level": 8,
    "out_size": 5997403,
    "ratio": 0.7077,
-   "compress_mbps": 37.82,
-   "decompress_mbps": 295.45
+   "compress_mbps": 36.83,
+   "decompress_mbps": 281.09
   },
   {
    "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
    "level": 9,
    "out_size": 5997403,
    "ratio": 0.7077,
-   "compress_mbps": 37.76,
-   "decompress_mbps": 292.96
+   "compress_mbps": 35.64,
+   "decompress_mbps": 279.08
   },
   {
    "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
    "level": 1,
    "out_size": 1147652,
    "ratio": 0.2147,
-   "compress_mbps": 388.67,
-   "decompress_mbps": 761.65
+   "compress_mbps": 362.02,
+   "decompress_mbps": 680.02
   },
   {
    "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
    "level": 2,
    "out_size": 919639,
    "ratio": 0.172,
-   "compress_mbps": 262.86,
-   "decompress_mbps": 956.95
+   "compress_mbps": 242.66,
+   "decompress_mbps": 891.83
   },
   {
    "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
    "level": 3,
    "out_size": 752341,
    "ratio": 0.1407,
-   "compress_mbps": 167.46,
-   "decompress_mbps": 1057.51
+   "compress_mbps": 162.76,
+   "decompress_mbps": 995.92
   },
   {
    "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
    "level": 4,
    "out_size": 735537,
    "ratio": 0.1376,
-   "compress_mbps": 161.37,
-   "decompress_mbps": 1037.21
+   "compress_mbps": 154.9,
+   "decompress_mbps": 963.48
   },
   {
    "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
    "level": 5,
    "out_size": 706789,
    "ratio": 0.1322,
-   "compress_mbps": 123.5,
-   "decompress_mbps": 1129.34
+   "compress_mbps": 118.46,
+   "decompress_mbps": 1016.91
   },
   {
    "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
    "level": 6,
    "out_size": 676279,
    "ratio": 0.1265,
-   "compress_mbps": 69.53,
-   "decompress_mbps": 1219.4
+   "compress_mbps": 65.75,
+   "decompress_mbps": 1122.45
   },
   {
    "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
    "level": 7,
    "out_size": 668772,
    "ratio": 0.1251,
-   "compress_mbps": 55.97,
-   "decompress_mbps": 1208.21
+   "compress_mbps": 52.71,
+   "decompress_mbps": 1098.67
   },
   {
    "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
    "level": 8,
    "out_size": 665340,
    "ratio": 0.1245,
-   "compress_mbps": 47.61,
-   "decompress_mbps": 1208.14
+   "compress_mbps": 43.87,
+   "decompress_mbps": 1053.52
   },
   {
    "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
    "level": 9,
    "out_size": 664273,
    "ratio": 0.1243,
-   "compress_mbps": 45.85,
-   "decompress_mbps": 1218.11
+   "compress_mbps": 38.75,
+   "decompress_mbps": 1075.79
   },
   {
    "compressor": "libdeflate",
@@ -7214,8 +7214,8 @@
    "level": 1,
    "out_size": 4217525,
    "ratio": 0.4138,
-   "compress_mbps": 243.85,
-   "decompress_mbps": 801.13
+   "compress_mbps": 228.94,
+   "decompress_mbps": 659.3
   },
   {
    "compressor": "libdeflate",
@@ -7224,8 +7224,8 @@
    "level": 2,
    "out_size": 4053259,
    "ratio": 0.3977,
-   "compress_mbps": 170.19,
-   "decompress_mbps": 864.66
+   "compress_mbps": 159.6,
+   "decompress_mbps": 744.15
   },
   {
    "compressor": "libdeflate",
@@ -7234,8 +7234,8 @@
    "level": 3,
    "out_size": 3989875,
    "ratio": 0.3915,
-   "compress_mbps": 140.0,
-   "decompress_mbps": 934.98
+   "compress_mbps": 132.32,
+   "decompress_mbps": 811.96
   },
   {
    "compressor": "libdeflate",
@@ -7244,8 +7244,8 @@
    "level": 4,
    "out_size": 3972869,
    "ratio": 0.3898,
-   "compress_mbps": 127.83,
-   "decompress_mbps": 825.71
+   "compress_mbps": 113.27,
+   "decompress_mbps": 593.25
   },
   {
    "compressor": "libdeflate",
@@ -7254,8 +7254,8 @@
    "level": 5,
    "out_size": 3894026,
    "ratio": 0.3821,
-   "compress_mbps": 99.29,
-   "decompress_mbps": 791.29
+   "compress_mbps": 93.86,
+   "decompress_mbps": 571.61
   },
   {
    "compressor": "libdeflate",
@@ -7264,8 +7264,8 @@
    "level": 6,
    "out_size": 3859436,
    "ratio": 0.3787,
-   "compress_mbps": 75.65,
-   "decompress_mbps": 819.18
+   "compress_mbps": 72.67,
+   "decompress_mbps": 650.88
   },
   {
    "compressor": "libdeflate",
@@ -7274,8 +7274,8 @@
    "level": 7,
    "out_size": 3837515,
    "ratio": 0.3765,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 796.16
+   "compress_mbps": 53.13,
+   "decompress_mbps": 735.01
   },
   {
    "compressor": "libdeflate",
@@ -7284,8 +7284,8 @@
    "level": 8,
    "out_size": 3811467,
    "ratio": 0.374,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 816.32
+   "compress_mbps": 35.76,
+   "decompress_mbps": 707.33
   },
   {
    "compressor": "libdeflate",
@@ -7294,8 +7294,8 @@
    "level": 9,
    "out_size": 3810354,
    "ratio": 0.3738,
-   "compress_mbps": 32.76,
-   "decompress_mbps": 816.68
+   "compress_mbps": 32.56,
+   "decompress_mbps": 731.43
   },
   {
    "compressor": "libdeflate",
@@ -7304,8 +7304,8 @@
    "level": 1,
    "out_size": 20192961,
    "ratio": 0.3942,
-   "compress_mbps": 242.16,
-   "decompress_mbps": 676.2
+   "compress_mbps": 240.87,
+   "decompress_mbps": 645.44
   },
   {
    "compressor": "libdeflate",
@@ -7314,8 +7314,8 @@
    "level": 2,
    "out_size": 19374226,
    "ratio": 0.3783,
-   "compress_mbps": 185.69,
-   "decompress_mbps": 710.78
+   "compress_mbps": 186.01,
+   "decompress_mbps": 705.65
   },
   {
    "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
    "level": 3,
    "out_size": 19234937,
    "ratio": 0.3755,
-   "compress_mbps": 173.04,
-   "decompress_mbps": 727.76
+   "compress_mbps": 173.23,
+   "decompress_mbps": 716.11
   },
   {
    "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
    "level": 4,
    "out_size": 19145385,
    "ratio": 0.3738,
-   "compress_mbps": 162.62,
-   "decompress_mbps": 728.74
+   "compress_mbps": 162.22,
+   "decompress_mbps": 715.71
   },
   {
    "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
    "level": 5,
    "out_size": 18878875,
    "ratio": 0.3686,
-   "compress_mbps": 142.62,
-   "decompress_mbps": 741.83
+   "compress_mbps": 142.92,
+   "decompress_mbps": 735.94
   },
   {
    "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
    "level": 6,
    "out_size": 18805391,
    "ratio": 0.3671,
-   "compress_mbps": 117.71,
-   "decompress_mbps": 750.56
+   "compress_mbps": 119.92,
+   "decompress_mbps": 755.96
   },
   {
    "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
    "level": 7,
    "out_size": 18749947,
    "ratio": 0.3661,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 759.3
+   "compress_mbps": 86.94,
+   "decompress_mbps": 742.23
   },
   {
    "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
    "level": 8,
    "out_size": 18718540,
    "ratio": 0.3655,
-   "compress_mbps": 47.56,
-   "decompress_mbps": 766.6
+   "compress_mbps": 46.75,
+   "decompress_mbps": 752.33
   },
   {
    "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
    "level": 9,
    "out_size": 18713659,
    "ratio": 0.3654,
-   "compress_mbps": 33.49,
-   "decompress_mbps": 676.15
+   "compress_mbps": 33.5,
+   "decompress_mbps": 672.97
   },
   {
    "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
    "level": 1,
    "out_size": 3740775,
    "ratio": 0.3752,
-   "compress_mbps": 293.42,
-   "decompress_mbps": 755.42
+   "compress_mbps": 292.46,
+   "decompress_mbps": 746.78
   },
   {
    "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
    "level": 2,
    "out_size": 3707407,
    "ratio": 0.3718,
-   "compress_mbps": 217.45,
-   "decompress_mbps": 768.84
+   "compress_mbps": 215.26,
+   "decompress_mbps": 781.74
   },
   {
    "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
    "level": 3,
    "out_size": 3672389,
    "ratio": 0.3683,
-   "compress_mbps": 185.43,
-   "decompress_mbps": 809.7
+   "compress_mbps": 183.45,
+   "decompress_mbps": 814.67
   },
   {
    "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
    "level": 4,
    "out_size": 3660011,
    "ratio": 0.3671,
-   "compress_mbps": 171.62,
-   "decompress_mbps": 751.11
+   "compress_mbps": 170.17,
+   "decompress_mbps": 754.88
   },
   {
    "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
    "level": 5,
    "out_size": 3664245,
    "ratio": 0.3675,
-   "compress_mbps": 141.37,
-   "decompress_mbps": 712.85
+   "compress_mbps": 140.73,
+   "decompress_mbps": 708.48
   },
   {
    "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
    "level": 6,
    "out_size": 3648644,
    "ratio": 0.3659,
-   "compress_mbps": 106.84,
-   "decompress_mbps": 739.26
+   "compress_mbps": 106.56,
+   "decompress_mbps": 741.03
   },
   {
    "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
    "level": 7,
    "out_size": 3635323,
    "ratio": 0.3646,
-   "compress_mbps": 68.34,
-   "decompress_mbps": 735.43
+   "compress_mbps": 68.82,
+   "decompress_mbps": 719.19
   },
   {
    "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
    "level": 8,
    "out_size": 3624778,
    "ratio": 0.3635,
-   "compress_mbps": 43.04,
-   "decompress_mbps": 773.18
+   "compress_mbps": 42.86,
+   "decompress_mbps": 722.9
   },
   {
    "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
    "level": 9,
    "out_size": 3625176,
    "ratio": 0.3636,
-   "compress_mbps": 38.87,
-   "decompress_mbps": 757.44
+   "compress_mbps": 39.04,
+   "decompress_mbps": 740.46
   },
   {
    "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
    "level": 1,
    "out_size": 3837577,
    "ratio": 0.1144,
-   "compress_mbps": 609.02,
-   "decompress_mbps": 1491.69
+   "compress_mbps": 607.37,
+   "decompress_mbps": 1488.74
   },
   {
    "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
    "level": 2,
    "out_size": 3714632,
    "ratio": 0.1107,
-   "compress_mbps": 462.85,
-   "decompress_mbps": 1747.31
+   "compress_mbps": 462.02,
+   "decompress_mbps": 1819.15
   },
   {
    "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
    "level": 3,
    "out_size": 3599455,
    "ratio": 0.1073,
-   "compress_mbps": 427.07,
-   "decompress_mbps": 1882.3
+   "compress_mbps": 427.56,
+   "decompress_mbps": 1850.83
   },
   {
    "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
    "level": 4,
    "out_size": 3431843,
    "ratio": 0.1023,
-   "compress_mbps": 388.74,
-   "decompress_mbps": 1763.39
+   "compress_mbps": 390.11,
+   "decompress_mbps": 1798.87
   },
   {
    "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
    "level": 5,
    "out_size": 3268188,
    "ratio": 0.0974,
-   "compress_mbps": 346.67,
-   "decompress_mbps": 1777.54
+   "compress_mbps": 348.31,
+   "decompress_mbps": 1791.64
   },
   {
    "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
    "level": 6,
    "out_size": 3091741,
    "ratio": 0.0921,
-   "compress_mbps": 264.16,
-   "decompress_mbps": 1787.13
+   "compress_mbps": 263.07,
+   "decompress_mbps": 1795.29
   },
   {
    "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
    "level": 7,
    "out_size": 3032499,
    "ratio": 0.0904,
-   "compress_mbps": 186.41,
-   "decompress_mbps": 1846.22
+   "compress_mbps": 185.69,
+   "decompress_mbps": 1792.22
   },
   {
    "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
    "level": 8,
    "out_size": 2949097,
    "ratio": 0.0879,
-   "compress_mbps": 97.63,
-   "decompress_mbps": 1789.45
+   "compress_mbps": 97.31,
+   "decompress_mbps": 1727.75
   },
   {
    "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
    "level": 9,
    "out_size": 2925243,
    "ratio": 0.0872,
-   "compress_mbps": 69.23,
-   "decompress_mbps": 1757.94
+   "compress_mbps": 68.91,
+   "decompress_mbps": 1734.51
   },
   {
    "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
    "level": 1,
    "out_size": 3275124,
    "ratio": 0.5324,
-   "compress_mbps": 166.26,
-   "decompress_mbps": 462.6
+   "compress_mbps": 165.71,
+   "decompress_mbps": 451.65
   },
   {
    "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
    "level": 2,
    "out_size": 3150806,
    "ratio": 0.5121,
-   "compress_mbps": 128.39,
-   "decompress_mbps": 483.21
+   "compress_mbps": 127.78,
+   "decompress_mbps": 511.54
   },
   {
    "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
    "level": 3,
    "out_size": 3137061,
    "ratio": 0.5099,
-   "compress_mbps": 120.82,
-   "decompress_mbps": 502.43
+   "compress_mbps": 120.37,
+   "decompress_mbps": 532.57
   },
   {
    "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
    "level": 4,
    "out_size": 3129676,
    "ratio": 0.5087,
-   "compress_mbps": 116.89,
-   "decompress_mbps": 518.56
+   "compress_mbps": 116.59,
+   "decompress_mbps": 550.4
   },
   {
    "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
    "level": 5,
    "out_size": 3079277,
    "ratio": 0.5005,
-   "compress_mbps": 99.99,
-   "decompress_mbps": 536.74
+   "compress_mbps": 99.31,
+   "decompress_mbps": 566.65
   },
   {
    "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
    "level": 6,
    "out_size": 3072378,
    "ratio": 0.4994,
-   "compress_mbps": 88.82,
-   "decompress_mbps": 533.12
+   "compress_mbps": 88.67,
+   "decompress_mbps": 573.75
   },
   {
    "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
    "level": 7,
    "out_size": 3068123,
    "ratio": 0.4987,
-   "compress_mbps": 76.38,
-   "decompress_mbps": 542.11
+   "compress_mbps": 76.1,
+   "decompress_mbps": 577.91
   },
   {
    "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
    "level": 8,
    "out_size": 3067299,
    "ratio": 0.4986,
-   "compress_mbps": 55.33,
-   "decompress_mbps": 533.57
+   "compress_mbps": 55.39,
+   "decompress_mbps": 555.96
   },
   {
    "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
    "level": 9,
    "out_size": 3066968,
    "ratio": 0.4985,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 507.58
+   "compress_mbps": 50.03,
+   "decompress_mbps": 569.89
   },
   {
    "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
    "level": 1,
    "out_size": 3868663,
    "ratio": 0.3836,
-   "compress_mbps": 285.16,
-   "decompress_mbps": 772.78
+   "compress_mbps": 284.7,
+   "decompress_mbps": 751.49
   },
   {
    "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
    "level": 2,
    "out_size": 3839158,
    "ratio": 0.3807,
-   "compress_mbps": 213.22,
-   "decompress_mbps": 914.82
+   "compress_mbps": 212.39,
+   "decompress_mbps": 902.25
   },
   {
    "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
    "level": 3,
    "out_size": 3818964,
    "ratio": 0.3787,
-   "compress_mbps": 197.74,
-   "decompress_mbps": 936.61
+   "compress_mbps": 197.38,
+   "decompress_mbps": 930.94
   },
   {
    "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
    "level": 4,
    "out_size": 3789325,
    "ratio": 0.3757,
-   "compress_mbps": 179.66,
-   "decompress_mbps": 954.8
+   "compress_mbps": 179.38,
+   "decompress_mbps": 969.91
   },
   {
    "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
    "level": 5,
    "out_size": 3666476,
    "ratio": 0.3635,
-   "compress_mbps": 157.89,
-   "decompress_mbps": 942.54
+   "compress_mbps": 157.97,
+   "decompress_mbps": 958.97
   },
   {
    "compressor": "libdeflate",
@@ -7714,7 +7714,7 @@
    "level": 6,
    "out_size": 3660266,
    "ratio": 0.3629,
-   "compress_mbps": 142.43,
+   "compress_mbps": 142.12,
    "decompress_mbps": 987.45
   },
   {
@@ -7724,8 +7724,8 @@
    "level": 7,
    "out_size": 3659491,
    "ratio": 0.3628,
-   "compress_mbps": 135.11,
-   "decompress_mbps": 999.79
+   "compress_mbps": 134.96,
+   "decompress_mbps": 1004.78
   },
   {
    "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
    "level": 8,
    "out_size": 3654863,
    "ratio": 0.3624,
-   "compress_mbps": 114.32,
-   "decompress_mbps": 1009.23
+   "compress_mbps": 114.71,
+   "decompress_mbps": 991.02
   },
   {
    "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
    "level": 9,
    "out_size": 3654860,
    "ratio": 0.3624,
-   "compress_mbps": 114.27,
-   "decompress_mbps": 1001.2
+   "compress_mbps": 114.75,
+   "decompress_mbps": 998.54
   },
   {
    "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
    "level": 1,
    "out_size": 2197055,
    "ratio": 0.3315,
-   "compress_mbps": 300.85,
-   "decompress_mbps": 858.37
+   "compress_mbps": 300.64,
+   "decompress_mbps": 880.96
   },
   {
    "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
    "level": 2,
    "out_size": 2082309,
    "ratio": 0.3142,
-   "compress_mbps": 214.77,
-   "decompress_mbps": 1130.12
+   "compress_mbps": 215.02,
+   "decompress_mbps": 995.45
   },
   {
    "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
    "level": 3,
    "out_size": 2021047,
    "ratio": 0.305,
-   "compress_mbps": 178.67,
-   "decompress_mbps": 1236.6
+   "compress_mbps": 178.31,
+   "decompress_mbps": 1023.53
   },
   {
    "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
    "level": 4,
    "out_size": 1990952,
    "ratio": 0.3004,
-   "compress_mbps": 157.4,
-   "decompress_mbps": 1146.54
+   "compress_mbps": 158.48,
+   "decompress_mbps": 999.16
   },
   {
    "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
    "level": 5,
    "out_size": 1921113,
    "ratio": 0.2899,
-   "compress_mbps": 127.99,
-   "decompress_mbps": 1093.81
+   "compress_mbps": 127.58,
+   "decompress_mbps": 976.32
   },
   {
    "compressor": "libdeflate",
@@ -7804,8 +7804,8 @@
    "level": 6,
    "out_size": 1876257,
    "ratio": 0.2831,
-   "compress_mbps": 86.94,
-   "decompress_mbps": 1090.38
+   "compress_mbps": 87.12,
+   "decompress_mbps": 987.5
   },
   {
    "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
    "level": 7,
    "out_size": 1832695,
    "ratio": 0.2765,
-   "compress_mbps": 46.02,
-   "decompress_mbps": 1103.5
+   "compress_mbps": 46.57,
+   "decompress_mbps": 974.69
   },
   {
    "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
    "level": 8,
    "out_size": 1809967,
    "ratio": 0.2731,
-   "compress_mbps": 24.27,
-   "decompress_mbps": 1063.53
+   "compress_mbps": 24.24,
+   "decompress_mbps": 918.51
   },
   {
    "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
    "level": 9,
    "out_size": 1806374,
    "ratio": 0.2726,
-   "compress_mbps": 19.83,
-   "decompress_mbps": 1054.62
+   "compress_mbps": 19.82,
+   "decompress_mbps": 891.89
   },
   {
    "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
    "level": 1,
    "out_size": 5866517,
    "ratio": 0.2715,
-   "compress_mbps": 338.52,
-   "decompress_mbps": 979.15
+   "compress_mbps": 339.22,
+   "decompress_mbps": 900.33
   },
   {
    "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
    "level": 2,
    "out_size": 5695942,
    "ratio": 0.2636,
-   "compress_mbps": 258.0,
-   "decompress_mbps": 1031.45
+   "compress_mbps": 257.9,
+   "decompress_mbps": 1045.5
   },
   {
    "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
    "level": 3,
    "out_size": 5605878,
    "ratio": 0.2595,
-   "compress_mbps": 233.32,
-   "decompress_mbps": 1100.86
+   "compress_mbps": 235.17,
+   "decompress_mbps": 1090.22
   },
   {
    "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
    "level": 4,
    "out_size": 5553432,
    "ratio": 0.257,
-   "compress_mbps": 216.59,
-   "decompress_mbps": 1079.15
+   "compress_mbps": 217.31,
+   "decompress_mbps": 1073.21
   },
   {
    "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
    "level": 5,
    "out_size": 5416713,
    "ratio": 0.2507,
-   "compress_mbps": 186.71,
-   "decompress_mbps": 1066.93
+   "compress_mbps": 186.44,
+   "decompress_mbps": 1084.54
   },
   {
    "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
    "level": 6,
    "out_size": 5337149,
    "ratio": 0.247,
-   "compress_mbps": 142.78,
-   "decompress_mbps": 1079.29
+   "compress_mbps": 143.56,
+   "decompress_mbps": 1095.03
   },
   {
    "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
    "level": 7,
    "out_size": 5310181,
    "ratio": 0.2458,
-   "compress_mbps": 100.23,
-   "decompress_mbps": 1069.71
+   "compress_mbps": 98.18,
+   "decompress_mbps": 1098.45
   },
   {
    "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
    "level": 8,
    "out_size": 5272761,
    "ratio": 0.244,
-   "compress_mbps": 62.39,
-   "decompress_mbps": 1089.17
+   "compress_mbps": 62.41,
+   "decompress_mbps": 1094.51
   },
   {
    "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
    "level": 9,
    "out_size": 5270405,
    "ratio": 0.2439,
-   "compress_mbps": 50.04,
-   "decompress_mbps": 1101.61
+   "compress_mbps": 50.08,
+   "decompress_mbps": 1084.37
   },
   {
    "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
    "level": 1,
    "out_size": 5575128,
    "ratio": 0.7688,
-   "compress_mbps": 162.23,
-   "decompress_mbps": 485.07
+   "compress_mbps": 161.68,
+   "decompress_mbps": 464.32
   },
   {
    "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
    "level": 2,
    "out_size": 5417142,
    "ratio": 0.747,
-   "compress_mbps": 116.65,
-   "decompress_mbps": 518.27
+   "compress_mbps": 116.8,
+   "decompress_mbps": 513.48
   },
   {
    "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
    "level": 3,
    "out_size": 5397999,
    "ratio": 0.7444,
-   "compress_mbps": 105.25,
-   "decompress_mbps": 528.2
+   "compress_mbps": 105.15,
+   "decompress_mbps": 524.52
   },
   {
    "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
    "level": 4,
    "out_size": 5391125,
    "ratio": 0.7434,
-   "compress_mbps": 99.31,
-   "decompress_mbps": 542.53
+   "compress_mbps": 99.41,
+   "decompress_mbps": 536.79
   },
   {
    "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
    "level": 5,
    "out_size": 5352212,
    "ratio": 0.738,
-   "compress_mbps": 87.58,
-   "decompress_mbps": 513.46
+   "compress_mbps": 87.98,
+   "decompress_mbps": 506.33
   },
   {
    "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
    "level": 6,
    "out_size": 5335405,
    "ratio": 0.7357,
-   "compress_mbps": 73.79,
-   "decompress_mbps": 526.1
+   "compress_mbps": 74.02,
+   "decompress_mbps": 521.25
   },
   {
    "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
    "level": 7,
    "out_size": 5325697,
    "ratio": 0.7344,
-   "compress_mbps": 63.45,
-   "decompress_mbps": 513.46
+   "compress_mbps": 63.76,
+   "decompress_mbps": 514.24
   },
   {
    "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
    "level": 8,
    "out_size": 5324004,
    "ratio": 0.7341,
-   "compress_mbps": 52.34,
-   "decompress_mbps": 522.62
+   "compress_mbps": 52.67,
+   "decompress_mbps": 523.93
   },
   {
    "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
    "level": 9,
    "out_size": 5323197,
    "ratio": 0.734,
-   "compress_mbps": 50.85,
-   "decompress_mbps": 511.04
+   "compress_mbps": 51.02,
+   "decompress_mbps": 509.84
   },
   {
    "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
    "level": 1,
    "out_size": 13550569,
    "ratio": 0.3268,
-   "compress_mbps": 266.06,
-   "decompress_mbps": 891.09
+   "compress_mbps": 270.44,
+   "decompress_mbps": 866.54
   },
   {
    "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
    "level": 2,
    "out_size": 13130705,
    "ratio": 0.3167,
-   "compress_mbps": 199.84,
-   "decompress_mbps": 973.65
+   "compress_mbps": 203.81,
+   "decompress_mbps": 935.35
   },
   {
    "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
    "level": 3,
    "out_size": 12839361,
    "ratio": 0.3097,
-   "compress_mbps": 176.74,
-   "decompress_mbps": 1015.15
+   "compress_mbps": 180.38,
+   "decompress_mbps": 1018.05
   },
   {
    "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
    "level": 4,
    "out_size": 12601933,
    "ratio": 0.304,
-   "compress_mbps": 161.98,
-   "decompress_mbps": 899.79
+   "compress_mbps": 165.1,
+   "decompress_mbps": 907.63
   },
   {
    "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
    "level": 5,
    "out_size": 12310776,
    "ratio": 0.2969,
-   "compress_mbps": 131.58,
-   "decompress_mbps": 879.58
+   "compress_mbps": 133.58,
+   "decompress_mbps": 892.36
   },
   {
    "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
    "level": 6,
    "out_size": 12140474,
    "ratio": 0.2928,
-   "compress_mbps": 104.62,
-   "decompress_mbps": 887.92
+   "compress_mbps": 105.56,
+   "decompress_mbps": 907.43
   },
   {
    "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
    "level": 7,
    "out_size": 12025296,
    "ratio": 0.2901,
-   "compress_mbps": 75.01,
-   "decompress_mbps": 892.91
+   "compress_mbps": 75.74,
+   "decompress_mbps": 905.78
   },
   {
    "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
    "level": 8,
    "out_size": 11893824,
    "ratio": 0.2869,
-   "compress_mbps": 45.87,
-   "decompress_mbps": 886.31
+   "compress_mbps": 46.11,
+   "decompress_mbps": 881.88
   },
   {
    "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
    "level": 9,
    "out_size": 11882496,
    "ratio": 0.2866,
-   "compress_mbps": 39.46,
-   "decompress_mbps": 930.2
+   "compress_mbps": 39.58,
+   "decompress_mbps": 897.2
   },
   {
    "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
    "level": 1,
    "out_size": 6293390,
    "ratio": 0.7426,
-   "compress_mbps": 145.39,
-   "decompress_mbps": 523.59
+   "compress_mbps": 145.12,
+   "decompress_mbps": 474.74
   },
   {
    "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
    "level": 2,
    "out_size": 6058412,
    "ratio": 0.7149,
-   "compress_mbps": 120.35,
-   "decompress_mbps": 529.46
+   "compress_mbps": 120.47,
+   "decompress_mbps": 513.25
   },
   {
    "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
    "level": 3,
    "out_size": 6058381,
    "ratio": 0.7149,
-   "compress_mbps": 120.3,
-   "decompress_mbps": 539.19
+   "compress_mbps": 120.64,
+   "decompress_mbps": 523.74
   },
   {
    "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
    "level": 4,
    "out_size": 6058363,
    "ratio": 0.7149,
-   "compress_mbps": 120.03,
-   "decompress_mbps": 437.57
+   "compress_mbps": 120.37,
+   "decompress_mbps": 423.03
   },
   {
    "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
    "level": 5,
    "out_size": 5998400,
    "ratio": 0.7078,
-   "compress_mbps": 108.52,
-   "decompress_mbps": 459.54
+   "compress_mbps": 108.07,
+   "decompress_mbps": 445.39
   },
   {
    "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
    "level": 6,
    "out_size": 5998438,
    "ratio": 0.7078,
-   "compress_mbps": 108.55,
-   "decompress_mbps": 463.75
+   "compress_mbps": 108.08,
+   "decompress_mbps": 453.26
   },
   {
    "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
    "level": 7,
    "out_size": 5998439,
    "ratio": 0.7078,
-   "compress_mbps": 108.18,
-   "decompress_mbps": 462.69
+   "compress_mbps": 108.04,
+   "decompress_mbps": 456.68
   },
   {
    "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
    "level": 8,
    "out_size": 5986859,
    "ratio": 0.7065,
-   "compress_mbps": 90.15,
-   "decompress_mbps": 462.82
+   "compress_mbps": 90.01,
+   "decompress_mbps": 450.63
   },
   {
    "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
    "level": 9,
    "out_size": 5986859,
    "ratio": 0.7065,
-   "compress_mbps": 90.18,
-   "decompress_mbps": 454.72
+   "compress_mbps": 90.19,
+   "decompress_mbps": 452.21
   },
   {
    "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
    "level": 1,
    "out_size": 887708,
    "ratio": 0.1661,
-   "compress_mbps": 492.83,
-   "decompress_mbps": 1270.45
+   "compress_mbps": 488.9,
+   "decompress_mbps": 1285.11
   },
   {
    "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
    "level": 2,
    "out_size": 843475,
    "ratio": 0.1578,
-   "compress_mbps": 363.79,
-   "decompress_mbps": 1801.54
+   "compress_mbps": 361.27,
+   "decompress_mbps": 1748.18
   },
   {
    "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
    "level": 3,
    "out_size": 793388,
    "ratio": 0.1484,
-   "compress_mbps": 337.16,
-   "decompress_mbps": 1867.27
+   "compress_mbps": 336.75,
+   "decompress_mbps": 1916.81
   },
   {
    "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
    "level": 4,
    "out_size": 747602,
    "ratio": 0.1399,
-   "compress_mbps": 304.24,
-   "decompress_mbps": 1819.5
+   "compress_mbps": 303.12,
+   "decompress_mbps": 1832.75
   },
   {
    "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
    "level": 5,
    "out_size": 718615,
    "ratio": 0.1344,
-   "compress_mbps": 263.07,
-   "decompress_mbps": 1830.67
+   "compress_mbps": 261.83,
+   "decompress_mbps": 1839.5
   },
   {
    "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
    "level": 6,
    "out_size": 684405,
    "ratio": 0.128,
-   "compress_mbps": 206.4,
-   "decompress_mbps": 1920.08
+   "compress_mbps": 206.25,
+   "decompress_mbps": 1907.45
   },
   {
    "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
    "level": 7,
    "out_size": 664859,
    "ratio": 0.1244,
-   "compress_mbps": 142.72,
-   "decompress_mbps": 1906.99
+   "compress_mbps": 142.95,
+   "decompress_mbps": 1906.54
   },
   {
    "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
    "level": 8,
    "out_size": 650835,
    "ratio": 0.1218,
-   "compress_mbps": 81.56,
-   "decompress_mbps": 1892.16
+   "compress_mbps": 84.59,
+   "decompress_mbps": 1722.27
   },
   {
    "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
    "level": 9,
    "out_size": 649494,
    "ratio": 0.1215,
-   "compress_mbps": 68.13,
-   "decompress_mbps": 1902.14
+   "compress_mbps": 68.24,
+   "decompress_mbps": 1745.52
   },
   {
    "compressor": "go",
@@ -16566,6 +16566,696 @@
    "ratio": 0.1307,
    "compress_mbps": 25.17,
    "decompress_mbps": 148.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 51721,
+   "ratio": 0.3401,
+   "compress_mbps": 12.25,
+   "decompress_mbps": 1283.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 11,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 8.43,
+   "decompress_mbps": 1273.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 12,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 5.17,
+   "decompress_mbps": 1286.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46657,
+   "ratio": 0.3727,
+   "compress_mbps": 13.72,
+   "decompress_mbps": 1168.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 11,
+   "out_size": 46515,
+   "ratio": 0.3716,
+   "compress_mbps": 9.35,
+   "decompress_mbps": 1168.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 12,
+   "out_size": 46469,
+   "ratio": 0.3712,
+   "compress_mbps": 7.14,
+   "decompress_mbps": 1170.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7725,
+   "ratio": 0.314,
+   "compress_mbps": 15.97,
+   "decompress_mbps": 1033.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 11,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 10.79,
+   "decompress_mbps": 1029.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 12,
+   "out_size": 7723,
+   "ratio": 0.3139,
+   "compress_mbps": 7.17,
+   "decompress_mbps": 1032.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3026,
+   "ratio": 0.2714,
+   "compress_mbps": 17.74,
+   "decompress_mbps": 829.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 11,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 14.13,
+   "decompress_mbps": 831.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 12,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 10.64,
+   "decompress_mbps": 832.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 41.49,
+   "decompress_mbps": 444.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 11,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 33.55,
+   "decompress_mbps": 445.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 12,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 24.35,
+   "decompress_mbps": 448.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 179347,
+   "ratio": 0.1742,
+   "compress_mbps": 30.91,
+   "decompress_mbps": 1179.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 11,
+   "out_size": 179096,
+   "ratio": 0.1739,
+   "compress_mbps": 20.04,
+   "decompress_mbps": 1177.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 12,
+   "out_size": 179049,
+   "ratio": 0.1739,
+   "compress_mbps": 15.47,
+   "decompress_mbps": 1172.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138116,
+   "ratio": 0.3236,
+   "compress_mbps": 12.77,
+   "decompress_mbps": 1066.02
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 11,
+   "out_size": 137923,
+   "ratio": 0.3232,
+   "compress_mbps": 8.78,
+   "decompress_mbps": 1054.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 12,
+   "out_size": 137921,
+   "ratio": 0.3232,
+   "compress_mbps": 7.43,
+   "decompress_mbps": 1059.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 185328,
+   "ratio": 0.3846,
+   "compress_mbps": 12.88,
+   "decompress_mbps": 841.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 11,
+   "out_size": 184440,
+   "ratio": 0.3828,
+   "compress_mbps": 9.1,
+   "decompress_mbps": 837.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 12,
+   "out_size": 184371,
+   "ratio": 0.3826,
+   "compress_mbps": 5.56,
+   "decompress_mbps": 834.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51319,
+   "ratio": 0.1,
+   "compress_mbps": 12.87,
+   "decompress_mbps": 1999.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 11,
+   "out_size": 49675,
+   "ratio": 0.0968,
+   "compress_mbps": 6.13,
+   "decompress_mbps": 2002.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 12,
+   "out_size": 49194,
+   "ratio": 0.0959,
+   "compress_mbps": 3.65,
+   "decompress_mbps": 2000.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 11975,
+   "ratio": 0.3132,
+   "compress_mbps": 20.05,
+   "decompress_mbps": 1027.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 11,
+   "out_size": 11966,
+   "ratio": 0.3129,
+   "compress_mbps": 13.4,
+   "decompress_mbps": 1026.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 12,
+   "out_size": 11965,
+   "ratio": 0.3129,
+   "compress_mbps": 10.77,
+   "decompress_mbps": 1040.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1692,
+   "ratio": 0.4003,
+   "compress_mbps": 54.22,
+   "decompress_mbps": 413.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 11,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 45.3,
+   "decompress_mbps": 411.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 12,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 29.74,
+   "decompress_mbps": 415.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3681797,
+   "ratio": 0.3612,
+   "compress_mbps": 12.62,
+   "decompress_mbps": 772.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 11,
+   "out_size": 3679289,
+   "ratio": 0.361,
+   "compress_mbps": 9.26,
+   "decompress_mbps": 788.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 12,
+   "out_size": 3679105,
+   "ratio": 0.361,
+   "compress_mbps": 7.67,
+   "decompress_mbps": 720.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18268811,
+   "ratio": 0.3567,
+   "compress_mbps": 16.35,
+   "decompress_mbps": 749.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 11,
+   "out_size": 18245674,
+   "ratio": 0.3562,
+   "compress_mbps": 11.71,
+   "decompress_mbps": 763.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 12,
+   "out_size": 18241312,
+   "ratio": 0.3561,
+   "compress_mbps": 9.35,
+   "decompress_mbps": 758.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3461494,
+   "ratio": 0.3472,
+   "compress_mbps": 18.28,
+   "decompress_mbps": 738.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 11,
+   "out_size": 3446053,
+   "ratio": 0.3456,
+   "compress_mbps": 10.54,
+   "decompress_mbps": 731.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 12,
+   "out_size": 3447985,
+   "ratio": 0.3458,
+   "compress_mbps": 5.38,
+   "decompress_mbps": 734.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2782465,
+   "ratio": 0.0829,
+   "compress_mbps": 8.49,
+   "decompress_mbps": 1705.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 11,
+   "out_size": 2751857,
+   "ratio": 0.082,
+   "compress_mbps": 5.54,
+   "decompress_mbps": 1451.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 12,
+   "out_size": 2748273,
+   "ratio": 0.0819,
+   "compress_mbps": 4.07,
+   "decompress_mbps": 1671.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 2995902,
+   "ratio": 0.487,
+   "compress_mbps": 19.22,
+   "decompress_mbps": 554.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 11,
+   "out_size": 2994386,
+   "ratio": 0.4867,
+   "compress_mbps": 14.58,
+   "decompress_mbps": 570.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 12,
+   "out_size": 2994086,
+   "ratio": 0.4867,
+   "compress_mbps": 12.48,
+   "decompress_mbps": 559.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3608746,
+   "ratio": 0.3578,
+   "compress_mbps": 19.08,
+   "decompress_mbps": 952.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 11,
+   "out_size": 3608161,
+   "ratio": 0.3578,
+   "compress_mbps": 14.81,
+   "decompress_mbps": 974.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 12,
+   "out_size": 3608138,
+   "ratio": 0.3577,
+   "compress_mbps": 13.22,
+   "decompress_mbps": 969.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1697693,
+   "ratio": 0.2562,
+   "compress_mbps": 8.9,
+   "decompress_mbps": 865.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 11,
+   "out_size": 1696742,
+   "ratio": 0.256,
+   "compress_mbps": 6.68,
+   "decompress_mbps": 872.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 12,
+   "out_size": 1696488,
+   "ratio": 0.256,
+   "compress_mbps": 5.74,
+   "decompress_mbps": 892.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5137640,
+   "ratio": 0.2378,
+   "compress_mbps": 16.05,
+   "decompress_mbps": 1074.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 11,
+   "out_size": 5122694,
+   "ratio": 0.2371,
+   "compress_mbps": 9.68,
+   "decompress_mbps": 1069.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 12,
+   "out_size": 5118130,
+   "ratio": 0.2369,
+   "compress_mbps": 7.0,
+   "decompress_mbps": 1056.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5250862,
+   "ratio": 0.7241,
+   "compress_mbps": 25.53,
+   "decompress_mbps": 514.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 11,
+   "out_size": 5250747,
+   "ratio": 0.724,
+   "compress_mbps": 20.83,
+   "decompress_mbps": 509.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 12,
+   "out_size": 5250745,
+   "ratio": 0.724,
+   "compress_mbps": 19.39,
+   "decompress_mbps": 510.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11526846,
+   "ratio": 0.278,
+   "compress_mbps": 10.51,
+   "decompress_mbps": 889.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 11,
+   "out_size": 11520969,
+   "ratio": 0.2779,
+   "compress_mbps": 7.08,
+   "decompress_mbps": 900.49
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 12,
+   "out_size": 11520871,
+   "ratio": 0.2779,
+   "compress_mbps": 6.12,
+   "decompress_mbps": 903.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5748096,
+   "ratio": 0.6783,
+   "compress_mbps": 38.25,
+   "decompress_mbps": 450.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 11,
+   "out_size": 5747172,
+   "ratio": 0.6782,
+   "compress_mbps": 29.45,
+   "decompress_mbps": 454.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 12,
+   "out_size": 5747146,
+   "ratio": 0.6782,
+   "compress_mbps": 26.58,
+   "decompress_mbps": 447.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637425,
+   "ratio": 0.1193,
+   "compress_mbps": 12.15,
+   "decompress_mbps": 1611.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 11,
+   "out_size": 630827,
+   "ratio": 0.118,
+   "compress_mbps": 7.32,
+   "decompress_mbps": 1598.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 12,
+   "out_size": 629349,
+   "ratio": 0.1177,
+   "compress_mbps": 4.73,
+   "decompress_mbps": 1541.91
   }
  ]
 }


### PR DESCRIPTION
This PR respreads the lower-middle of the compression ladder, extends the libdeflate comparison to its full level range, and records the memory-bandwidth ceilings — the parts of the #2710 ladder redesign that survive measurement. The issue's headline (a fixed-Huffman-only fast L1 corner) was implemented, measured, and rejected; that negative finding is recorded rather than shipped.

De-bunch the level 4/5/6 cluster. At the prior uniform lazy `goodMatch = 8` the gate fired so eagerly that the chain-depth ladder (48/64/128) barely moved the ratio, so L4/5/6 sat almost on top of each other on the Silesia Pareto (0.3336/0.3330/0.3320 at ~39/38/35 MB/s). Graduating the lazy-gate threshold up the tier (L4=8, L5=16, L6=64; L7+ stays ungated) and dropping L4's chain depth to 32 makes each level trade speed for ratio in an even step. Verified by controlled paired measurement on one machine (both binaries built in the same clean environment, run same-session, core-pinned): the byte-identical levels (L1-L3, L7-L9) stay at ~1.00x, and only L4/5/6 move — L4 neutral, L5 ~7% slower for a tighter ratio (0.3330 -> 0.3322), L6 ~14% slower for a tighter ratio (0.3320 -> 0.3304). Each level stays Pareto-efficient; the cluster becomes a smooth frontier (Canterbury de-bunches identically). `goodMatch`/`chainDepth` are pure heuristics — the matcher contracts hold for any value — so there is no proof change.

Sweep `libdeflate` over its full levels 1-12 in the bench report (every other codec caps at 9), so its densest points 10-12 appear on the comparison Pareto; `plot.py` already discovers each codec's levels, so no plotter change was needed. This also fixes a latent crash the sweep exposed: the decompress-timing path builds its canonical reference stream with the zlib FFI, whose `deflateInit2` rejects levels above 9, so libdeflate L10-12 raised a `deflateInit2: stream error` — the reference level is now clamped to `min(level, 9)` (the reference is a fixed decode workload whose density barely shifts past L9, and it was never the codec's own output). Record the memcpy-class ceilings in `bench/README.md` prose rather than plotting them (they blow out a log axis): the compress ceiling (`deflateStored`, ~8.4 GB/s) and the decode ceiling (~40 GB/s). The dashboard is refreshed in-PR (native de-bunched, libdeflate 1-12, zlib/miniz re-measured, external comparators reused).

On the fast-L1 corner: a fixed-Huffman-only level-1 fast emit (skip the dynamic-tree construction, pair with a chain-depth-1 matcher) was implemented end-to-end with full roundtrip proofs, then measured in the packed production path with a controlled paired benchmark. It is a Pareto **regression on Silesia** — ~0.86-0.92x the speed at a much looser ratio (0.347 -> 0.40-0.44) — because the fixed block is looser, so the extra output bytes it writes cost more emit time than the dynamic Huffman tree it skips: large files are emit-bound on *bytes written*, and the dynamic block is both tighter and faster there. It only wins on small files (Canterbury +30-40%). This is exactly the caveat the issue flagged ("confirm the emit-bound result in the packed path before sizing the encode work"). So the fast-L1 machinery was reverted; a genuine fast-L1 corner needs a faster per-byte emit (a faster `BitWriter`), not a different block type. The finding is recorded in `bench/README.md`.

Addresses #2710 (D1, D2, D3); the fast-L1 encode-path work is deferred per the measured finding above.

🤖 Prepared with Claude Code
