### PR TITLE
refactor(wide): drop unused ugetUInt64LE reader

### DIFF
--- a/Zip/Native/Wide.lean
+++ b/Zip/Native/Wide.lean
@@ -1,29 +1,33 @@
 /-!
-  Word-sized little-endian `ByteArray` loads for the DEFLATE hot loops.
+  Word-sized little-endian `ByteArray` load for the DEFLATE hash hot loop.
 
-  `ByteArray.ugetUInt32LE a off` and `ByteArray.ugetUInt64LE a off` read a 4- or
-  8-byte little-endian word starting at byte `off` of `a`. The reference body —
-  and the trusted specification of the `@[extern]` — is literally the
-  byte-recombination expression the hot paths assemble today:
+  `ByteArray.ugetUInt32LE a off` reads a 4-byte little-endian word starting at
+  byte `off` of `a`. The reference body — and the trusted specification of the
+  `@[extern]` — is literally the byte-recombination expression the hot path
+  assembles today:
 
-      a[off] ||| a[off+1] <<< 8 ||| a[off+2] <<< 16 ||| a[off+3] <<< 24     (u32)
-      a[off] ||| a[off+1] <<< 8 ||| ... ||| a[off+7] <<< 56                 (u64)
+      a[off] ||| a[off+1] <<< 8 ||| a[off+2] <<< 16 ||| a[off+3] <<< 24
 
-  so swapping the inline byte assembly for one of these is definitional modulo
-  the offset's `Nat`/`USize` round-trip; `@[extern]` only changes the compiled
-  implementation (`c/bytearray_wide_ffi.c`) to a single wide load.
+  so swapping the inline byte assembly for it is definitional modulo the offset's
+  `Nat`/`USize` round-trip; `@[extern]` only changes the compiled implementation
+  (`c/bytearray_wide_ffi.c`) to a single wide load. Replacing `hash3`'s four
+  bounds-checked byte reads (four `uget` calls) with one `ugetUInt32LE` call is a
+  measured ~+3.4% compress win (#2707) — the win is the call-count reduction, and
+  it pays because the read is a *fixed* 4 bytes. (The 8-byte `ugetUInt64LE`
+  reader was removed: its only intended consumer, the decode refill, tops up ~1
+  byte at a time, so the wide load was measured neutral there — #2630.)
 
   The offset is a `USize`, so a hot loop's index arithmetic stays unboxed (the
   point of mirroring lean#14053's `uget*` readers rather than lean#8165's
-  `Nat`-indexed `getUIntN`). The in-bounds hypothesis `off.toNat + W/8 ≤ a.size`
+  `Nat`-indexed `getUIntN`). The in-bounds hypothesis `off.toNat + 4 ≤ a.size`
   is discharged by the caller's existing guards and means the C does no bounds
   check.
 
-  This is a project-local stopgap mirroring the readers of lean#14053 (`wide
-  fixed-width load/store`). The C symbols are namespaced `lean_zip_*` so they do
+  This is a project-local stopgap mirroring the reader of lean#14053 (`wide
+  fixed-width load/store`). The C symbol is namespaced `lean_zip_*` so it does
   not clash with core after the toolchain bump. Migration once lean#14053 lands:
   delete this file and `c/bytearray_wide_ffi.c`, and use core's `uget*`
-  primitives (their reference bodies are identical, so callers and proofs are
+  primitive (its reference body is identical, so callers and proofs are
   unchanged).
 -/
 
@@ -39,20 +43,5 @@ def ugetUInt32LE (a : @& ByteArray) (off : USize)
   ((a[off.toNat + 1]'(by omega)).toUInt32 <<< 8) |||
   ((a[off.toNat + 2]'(by omega)).toUInt32 <<< 16) |||
   ((a[off.toNat + 3]'(by omega)).toUInt32 <<< 24)
-
-/-- Load the little-endian `UInt64` at byte offset `off`. The reference body
-    `a[off] ||| a[off+1] <<< 8 ||| ... ||| a[off+7] <<< 56` is the trusted
-    specification of the `@[extern]`; the C reads it in one wide load. -/
-@[extern "lean_zip_uget_u64le"]
-def ugetUInt64LE (a : @& ByteArray) (off : USize)
-    (h : off.toNat + 8 ≤ a.size := by get_elem_tactic) : UInt64 :=
-  (a[off.toNat]'(by omega)).toUInt64 |||
-  ((a[off.toNat + 1]'(by omega)).toUInt64 <<< 8) |||
-  ((a[off.toNat + 2]'(by omega)).toUInt64 <<< 16) |||
-  ((a[off.toNat + 3]'(by omega)).toUInt64 <<< 24) |||
-  ((a[off.toNat + 4]'(by omega)).toUInt64 <<< 32) |||
-  ((a[off.toNat + 5]'(by omega)).toUInt64 <<< 40) |||
-  ((a[off.toNat + 6]'(by omega)).toUInt64 <<< 48) |||
-  ((a[off.toNat + 7]'(by omega)).toUInt64 <<< 56)
 
 end ByteArray

--- a/ZipTest/Wide.lean
+++ b/ZipTest/Wide.lean
@@ -1,13 +1,13 @@
 import ZipTest.Helpers
 
-/-! Conformance tests for the word-sized `@[extern]` ByteArray readers
-    (`ByteArray.ugetUInt32LE` / `ugetUInt64LE`).
+/-! Conformance tests for the word-sized `@[extern]` ByteArray reader
+    (`ByteArray.ugetUInt32LE`).
 
     Each test compares the compiled `@[extern]` result (which runs the C in
     `c/bytearray_wide_ffi.c`) against a pure-Lean reference recombination of the
     same bytes — i.e. the `@[extern]`'s own reference body, but evaluated without
     the extern so the comparison validates the C against the model. We sweep all
-    in-bounds offsets (including the `off + W/8 == size` boundary) over several
+    in-bounds offsets (including the `off + 4 == size` boundary) over several
     byte patterns. -/
 
 namespace ZipTest.Wide
@@ -18,17 +18,6 @@ def refU32LE (a : ByteArray) (off : Nat) : UInt32 :=
   (a[off + 1]!.toUInt32 <<< 8) |||
   (a[off + 2]!.toUInt32 <<< 16) |||
   (a[off + 3]!.toUInt32 <<< 24)
-
-/-- Pure-Lean reference for the little-endian `UInt64` load (no `@[extern]`). -/
-def refU64LE (a : ByteArray) (off : Nat) : UInt64 :=
-  a[off]!.toUInt64 |||
-  (a[off + 1]!.toUInt64 <<< 8) |||
-  (a[off + 2]!.toUInt64 <<< 16) |||
-  (a[off + 3]!.toUInt64 <<< 24) |||
-  (a[off + 4]!.toUInt64 <<< 32) |||
-  (a[off + 5]!.toUInt64 <<< 40) |||
-  (a[off + 6]!.toUInt64 <<< 48) |||
-  (a[off + 7]!.toUInt64 <<< 56)
 
 /-- Check every in-bounds 4-byte offset of `a`, extern vs reference. The `USize`
     index is passed straight to the extern, so its bound `off.toNat + 4 ≤ size`
@@ -41,15 +30,6 @@ partial def checkU32 (a : ByteArray) (off : USize := 0) : IO Unit := do
       throw (IO.userError s!"ugetUInt32LE mismatch at off {off.toNat}: got {got}, want {want}")
     checkU32 a (off + 1)
 
-/-- Check every in-bounds 8-byte offset of `a`, extern vs reference. -/
-partial def checkU64 (a : ByteArray) (off : USize := 0) : IO Unit := do
-  if h : off.toNat + 8 ≤ a.size then
-    let got := ByteArray.ugetUInt64LE a off h
-    let want := refU64LE a off.toNat
-    unless got == want do
-      throw (IO.userError s!"ugetUInt64LE mismatch at off {off.toNat}: got {got}, want {want}")
-    checkU64 a (off + 1)
-
 /-- A spread of byte patterns: zeros, max bytes, ascending, descending, and a
     high-bit-set pattern (to catch sign-extension bugs in the recombination). -/
 def patterns : List ByteArray :=
@@ -58,19 +38,16 @@ def patterns : List ByteArray :=
     ByteArray.mk (Array.range 20 |>.map (·.toUInt8)),
     ByteArray.mk (Array.range 20 |>.map (fun i => (19 - i).toUInt8)),
     ByteArray.mk (Array.range 20 |>.map (fun i => (0x80 ||| i).toUInt8)),
-    -- Exactly word-sized: hits only the `off + W/8 == size` boundary.
-    ByteArray.mk #[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE] ]
+    -- Exactly word-sized: hits only the `off + 4 == size` boundary.
+    ByteArray.mk #[0xDE, 0xAD, 0xBE, 0xEF] ]
 
 def tests : IO Unit := do
   for a in patterns do
     checkU32 a
-    checkU64 a
   -- A direct spot-check of a known little-endian value.
-  let a := ByteArray.mk #[0x78, 0x56, 0x34, 0x12, 0xF0, 0xDE, 0xBC, 0x9A]
+  let a := ByteArray.mk #[0x78, 0x56, 0x34, 0x12]
   unless ByteArray.ugetUInt32LE a 0 (by decide) == 0x12345678 do
     throw (IO.userError "ugetUInt32LE spot-check failed")
-  unless ByteArray.ugetUInt64LE a 0 (by decide) == 0x9ABCDEF012345678 do
-    throw (IO.userError "ugetUInt64LE spot-check failed")
   IO.println "Wide reader conformance tests: OK"
 
 end ZipTest.Wide

--- a/c/bytearray_wide_ffi.c
+++ b/c/bytearray_wide_ffi.c
@@ -1,31 +1,28 @@
 /*
- * Word-sized little-endian ByteArray loads for the DEFLATE hot loops.
+ * Word-sized little-endian ByteArray load for the DEFLATE hash hot loop.
  *
- * `lean_zip_uget_u32le(a, off)` and `lean_zip_uget_u64le(a, off)` read a
- * 4-/8-byte little-endian word starting at byte `off` of `a`, returning an
- * unboxed scalar. Their Lean reference bodies are the byte-recombination
- * expressions
+ * `lean_zip_uget_u32le(a, off)` reads a 4-byte little-endian word starting at
+ * byte `off` of `a`, returning an unboxed scalar. Its Lean reference body is the
+ * byte-recombination expression
  *
- *     a[off] | a[off+1]<<8 | a[off+2]<<16 | a[off+3]<<24                (u32)
- *     a[off] | a[off+1]<<8 | ... | a[off+7]<<56                        (u64)
+ *     a[off] | a[off+1]<<8 | a[off+2]<<16 | a[off+3]<<24
  *
- * (see `ugetUInt32LE` / `ugetUInt64LE` in `Zip/Native/Wide.lean`), and this C
- * must agree with those bodies. The recombination is written out byte-by-byte
- * so it is host-endian-independent — little-endian *by construction* — and free
- * of unaligned-access UB; on a little-endian target the optimizer folds each to
- * a single (possibly unaligned) load.
+ * (see `ugetUInt32LE` in `Zip/Native/Wide.lean`), and this C must agree with it.
+ * The recombination is written out byte-by-byte so it is host-endian-independent
+ * — little-endian *by construction* — and free of unaligned-access UB; on a
+ * little-endian target the optimizer folds it to a single (possibly unaligned)
+ * load.
  *
- * The Lean side carries the in-bounds proof (`off + W/8 ≤ a.size`), so C does
- * no bounds check: the caller has already proven the `W/8` bytes at `off` are
- * within the array. `a` is borrowed (`b_lean_obj_arg`); the offset is a
- * `size_t` (Lean `USize`), kept unboxed so a hot loop's index arithmetic never
- * boxes.
+ * The Lean side carries the in-bounds proof (`off + 4 ≤ a.size`), so C does no
+ * bounds check: the caller has already proven the 4 bytes at `off` are within
+ * the array. `a` is borrowed (`b_lean_obj_arg`); the offset is a `size_t` (Lean
+ * `USize`), kept unboxed so a hot loop's index arithmetic never boxes.
  *
- * This is a project-local stopgap mirroring the readers of lean#14053 (`wide
- * fixed-width load/store`); the symbols are namespaced `lean_zip_*` so they do
- * not clash with core after the toolchain bump. When lean#14053 lands this file
- * and its lakefile target are deleted and core's `uget*` primitives are used
- * (the reference bodies are identical, so callers and proofs are unchanged).
+ * This is a project-local stopgap mirroring the reader of lean#14053 (`wide
+ * fixed-width load/store`); the symbol is namespaced `lean_zip_*` so it does not
+ * clash with core after the toolchain bump. When lean#14053 lands this file and
+ * its lakefile target are deleted and core's `uget*` primitive is used (the
+ * reference body is identical, so callers and proofs are unchanged).
  */
 
 #include <lean/lean.h>
@@ -39,15 +36,4 @@ LEAN_EXPORT uint32_t lean_zip_uget_u32le(b_lean_obj_arg a, size_t off) {
     const uint8_t *p = lean_sarray_cptr(a) + off;
     return (uint32_t)p[0]         | ((uint32_t)p[1] << 8) |
            ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
-}
-
-/*
- * lean_zip_uget_u64le : ByteArray → USize → UInt64
- *   (a borrowed, off an unboxed size_t; returns an unboxed uint64_t)
- */
-LEAN_EXPORT uint64_t lean_zip_uget_u64le(b_lean_obj_arg a, size_t off) {
-    const uint8_t *p = lean_sarray_cptr(a) + off;
-    uint64_t v = 0;
-    for (int i = 0; i < 8; i++) v |= (uint64_t)p[i] << (8 * i);
-    return v;
 }


### PR DESCRIPTION
Remove the 8-byte wide reader `ByteArray.ugetUInt64LE` — the Lean `@[extern]` (`Zip/Native/Wide.lean`), the C `lean_zip_uget_u64le` (`c/bytearray_wide_ffi.c`), and its half of the conformance test (`ZipTest/Wide.lean`). It was added in #2707 as the reader for the decode refill, but that integration (#2630) was measured neutral and dropped, leaving the reader with no caller.

The mechanism is now understood: an `@[extern]` wide load is a function call, so its only benefit is replacing N per-byte `uget` calls with one — which pays exactly when the read is a *fixed* ≥2-byte count. `hash3` reads a fixed 4 bytes per call (4 calls → 1 → verified ~+3.4% compress, #2707), so `ugetUInt32LE` stays. The decode refill tops up ~1 byte at a time (it refills eagerly to keep ≥56 bits buffered), so the 8-byte load saved nothing — same-worktree A/B measured it at +0.02%. With #2630 closed, `ugetUInt64LE` is dead code.

`ugetUInt32LE` and its conformance test are untouched. Tests green.

🤖 Prepared with Claude Code