### PR TITLE
bench: sweep libdeflate over levels 1-12

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -50,7 +50,9 @@ optional nicety.
 
 The graphs show **native before vs after** on the real corpora (Canterbury +
 Silesia), overlaid on the existing other-language curves (zlib, miniz_oxide,
-libdeflate, Go, JS, Zig, OCaml) for context. The before/after **overlay** PNGs
+libdeflate, Go, JS, Zig, OCaml) for context. Native sweeps levels 1–9;
+`libdeflate` is swept 1–12 (its full range, the others cap at 9), so its
+curve carries the extra dense points 10–12. The before/after **overlay** PNGs
 (`$W/perf_before_after_*`) are a report artifact — NOT committed; they live
 only in the PR comment. The **dashboard** (`bench/results/latest.json` and the
 routine `bench/graphs/*.svg`), by contrast, **is** refreshed and committed inside

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -135,6 +135,12 @@ def Row.toJson (r : Row) : String :=
 /-! ## Matrix -/
 
 def levels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+/-- libdeflate's full level range. Unlike zlib/miniz/native (capped at 9),
+    libdeflate exposes 1–12, and its densest points (10–12) are exactly the
+    ones the comparison Pareto needs from it — so it is swept to 12 here while
+    every other codec stays on the shared `levels`. -/
+def libdeflateLevels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 def reps : Nat := 5
 
 /-- Run one compressor over a list of `(pattern, bytes)` workloads × levels,
@@ -155,17 +161,25 @@ def runWorkloads
       let ratio := outSize.toFloat / (max size 1).toFloat
       let cNs ← measureNs size theReps (compress data level >>= sink)
       -- Decompress timing uses a canonical zlib-FFI raw-deflate stream so all
-      -- decoders are measured on identical, format-correct input.
+      -- decoders are measured on identical, format-correct input. That reference
+      -- is built by the zlib FFI, whose `deflateInit2` accepts only levels 0–9,
+      -- so a codec swept past 9 (libdeflate 10–12) has no faithful reference at
+      -- its own level: decode timing is **omitted** there rather than measured on
+      -- a mislabelled lower-level stream (and the dedicated decode-density
+      -- experiment covers those levels on real libdeflate streams anyway). This
+      -- also sidesteps the `deflateInit2: stream error` the extended levels raise.
       let dMBps ← match decompress? with
         | none => pure none
-        | some dec => do
-          let ref ← RawDeflate.compress data level.toUInt8
-          -- The decompressed size is known here; pass it so the native decoder
-          -- pre-sizes its output buffer, matching the production ZIP/gzip path
-          -- where the uncompressed size comes from the archive metadata. The FFI
-          -- reference decoders ignore it.
-          let dNs ← measureNs size theReps (dec ref size >>= sink)
-          pure (mbps size dNs)
+        | some dec =>
+          if level > 9 then pure none
+          else do
+            let ref ← RawDeflate.compress data level.toUInt8
+            -- The decompressed size is known here; pass it so the native decoder
+            -- pre-sizes its output buffer, matching the production ZIP/gzip path
+            -- where the uncompressed size comes from the archive metadata. The FFI
+            -- reference decoders ignore it.
+            let dNs ← measureNs size theReps (dec ref size >>= sink)
+            pure (mbps size dNs)
       rows := { compressor := name, pattern := pat, size := size, level := level,
                 outSize := outSize, ratio := ratio,
                 compressMBps := mbps size cNs, decompressMBps := dMBps } :: rows
@@ -257,7 +271,11 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
     else
       let cz ← runWorkloads "zlib"        files zlibCompress       (some fun d _ => RawDeflate.decompress d) (theLevels := lvls) (theReps := rps)
       let cm ← runWorkloads "miniz_oxide" files minizCompress      (some fun d _ => MinizOxide.decompress d) (theLevels := lvls) (theReps := rps)
-      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some fun d _ => Libdeflate.decompress d) (theLevels := lvls) (theReps := rps)
+      -- libdeflate sweeps 1–12 (its full range); the others cap at 9. A level
+      -- override (the native-only dashboard regen) is for the Lean codec, so
+      -- libdeflate keeps its own full list unless that override is in effect.
+      let llvls := match levelOverride with | some ls => ls | none => libdeflateLevels
+      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some fun d _ => Libdeflate.decompress d) (theLevels := llvls) (theReps := rps)
       rows := rows ++ cn ++ cz ++ cm ++ cl
 
   let date ← shell "date" ["-u", "+%Y-%m-%dT%H:%M:%SZ"]

--- a/bench/README.md
+++ b/bench/README.md
@@ -32,7 +32,7 @@ implementations (no SIMD/asm, or GC'd, or JIT'd) — not just the C + SIMD ceili
 | `native` | lean-zip pure-Lean DEFLATE | the thing we are improving |
 | `zlib` | system zlib (FFI) | the ubiquitous baseline |
 | `miniz_oxide` | Rust miniz_oxide (FFI) | widely-used Rust reimplementation |
-| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar |
+| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar; swept over its full **levels 1–12** (the others cap at 9), so its densest points (10–12) appear on the Pareto |
 | `zopfli` | zopfli (FFI) | maximum-ratio ceiling — **frozen** (see below); never in the routine matrix |
 
 **Language-native peers** (each a self-verifying CLI under
@@ -66,7 +66,8 @@ whose toolchain is unavailable is skipped, so the dashboard degrades gracefully.
 
 ## Workloads
 
-The **real compression corpora** from the literature, swept over levels 1–9.
+The **real compression corpora** from the literature, swept over levels 1–9
+(`libdeflate` over its full 1–12 — see *Compressors compared*).
 Each corpus is a subdirectory of [`corpora/`](corpora); every file in it is one
 single-size workload tagged `<corpus>/<file>`, and the harness discovers corpora
 by directory (nothing hard-codes Canterbury — a new corpus slots in once its
@@ -112,14 +113,14 @@ complements give precise numbers and per-file detail:
 - `<corpus>_ratio_heatmap.svg` / `_compress_heatmap.svg` — per file, relative to
   zlib (red = worse), showing *where* a codec wins or loses without 100 bars.
 
-### Canterbury corpus (11 small files, levels 1–9)
+### Canterbury corpus (11 small files, levels 1–9; libdeflate 1–12)
 
 ![canterbury compression speed vs ratio](graphs/canterbury_compress_pareto.svg)
 ![canterbury summary table](graphs/canterbury_summary.svg)
 ![canterbury ratio vs zlib per file](graphs/canterbury_ratio_heatmap.svg)
 ![canterbury compress speed vs zlib per file](graphs/canterbury_compress_heatmap.svg)
 
-### Silesia corpus (12 large files, levels 1/6/9)
+### Silesia corpus (12 large files, levels 1–9; libdeflate 1–12)
 
 ![silesia compression speed vs ratio](graphs/silesia_compress_pareto.svg)
 ![silesia decode throughput vs input density](graphs/silesia_decode_density.svg)

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m028c07a5d8" d="M 0 0 
+       <path id="m04ba99b503" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m028c07a5d8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m028c07a5d8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m028c07a5d8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m028c07a5d8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m028c07a5d8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m028c07a5d8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m028c07a5d8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04ba99b503" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdd29712582" d="M 0 0 
+       <path id="md65b050d34" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md65b050d34" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md65b050d34" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdd29712582" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md65b050d34" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0adb36bd3e" d="M 0 0 
+       <path id="m7beeb5c2a1" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0adb36bd3e" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m63cc0edae1" d="M -2.5 2.5 
+     <path id="mc77529be24" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m63cc0edae1" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63cc0edae1" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#mc77529be24" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc77529be24" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb1e1c390ab" d="M 0 -2.5 
+     <path id="m054b1a44e9" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#mb1e1c390ab" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb1e1c390ab" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m054b1a44e9" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m054b1a44e9" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,45 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 92.613662 207.455314 
+L 87.348715 224.984992 
+L 86.053433 241.561213 
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma56d26ecf0" d="M -0 3.535534 
+     <path id="mba9466e3eb" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#ma56d26ecf0" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma56d26ecf0" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#mba9466e3eb" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba9466e3eb" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9e2024cbe2" d="M -0 2.5 
+     <path id="mdc8c231306" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m9e2024cbe2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#mdc8c231306" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1860,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m194df667a0" d="M -0.833333 2.5 
+     <path id="m47c87d962d" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1877,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m194df667a0" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m194df667a0" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m47c87d962d" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47c87d962d" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1899,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0a2eda9a0c" d="M -1.25 2.5 
+     <path id="m1032fd2c5e" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1916,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m0a2eda9a0c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a2eda9a0c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m1032fd2c5e" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1032fd2c5e" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1938,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6e7b3d869c" d="M 0 -2.5 
+     <path id="m8c0cfdb3b6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1953,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6e7b3d869c" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8c0cfdb3b6" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1975,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me64a5284fe" d="M 0 -2.5 
+     <path id="m1937a598b2" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1986,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#me64a5284fe" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me64a5284fe" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m1937a598b2" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1937a598b2" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2018,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m357f16c205" d="M 0 3.5 
+      <path id="m9968bc4dfe" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2031,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m357f16c205" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9968bc4dfe" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2094,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m63cc0edae1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc77529be24" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2112,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb1e1c390ab" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m054b1a44e9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2161,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma56d26ecf0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mba9466e3eb" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2208,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9e2024cbe2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdc8c231306" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2228,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m194df667a0" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m47c87d962d" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2286,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0a2eda9a0c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1032fd2c5e" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2355,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6e7b3d869c" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8c0cfdb3b6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2397,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me64a5284fe" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1937a598b2" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2470,17 +2476,17 @@ L 184.505355 195.842174
 L 164.72409 207.184059 
 L 150.950891 251.782768 
 L 98.348822 318.82831 
-" clip-path="url(#pd383cd252b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pd383cd252b)">
-     <use xlink:href="#m357f16c205" x="226.647908" y="180.671124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="214.084819" y="183.545645" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="206.266533" y="185.976577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="187.75787" y="192.485037" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="186.58897" y="193.499057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="184.505355" y="195.842174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="164.72409" y="207.184059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="150.950891" y="251.782768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m357f16c205" x="98.348822" y="318.82831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+" clip-path="url(#p292701f636)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p292701f636)">
+     <use xlink:href="#m9968bc4dfe" x="226.647908" y="180.671124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="214.084819" y="183.545645" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="206.266533" y="185.976577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="187.75787" y="192.485037" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="186.58897" y="193.499057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="184.505355" y="195.842174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="164.72409" y="207.184059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="150.950891" y="251.782768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9968bc4dfe" x="98.348822" y="318.82831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3198,7 +3204,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd383cd252b">
+  <clipPath id="p292701f636">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mcf2d38bc57" d="M 0 0 
+       <path id="m2edd9998b2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcf2d38bc57" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcf2d38bc57" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2edd9998b2" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m56c0a3fe0e" d="M 0 0 
+       <path id="m850c246714" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m850c246714" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m850c246714" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m56c0a3fe0e" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m850c246714" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7d7e06588d" d="M 0 0 
+       <path id="m6029d157d9" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7d7e06588d" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6029d157d9" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m178244bc6c" d="M -2.5 2.5 
+     <path id="m0674f832c9" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m178244bc6c" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m178244bc6c" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m0674f832c9" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0674f832c9" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m436450e9eb" d="M 0 -2.5 
+     <path id="mee54fd2ab2" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m436450e9eb" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m436450e9eb" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#mee54fd2ab2" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee54fd2ab2" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,45 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 81.012077 219.378594 
+L 77.44276 238.815213 
+L 76.953425 251.874777 
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md307489ca2" d="M -0 3.535534 
+     <path id="m94c55ec53f" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#md307489ca2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md307489ca2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m94c55ec53f" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m94c55ec53f" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma6227aa52e" d="M -0 2.5 
+     <path id="m6c8797ec23" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#ma6227aa52e" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m6c8797ec23" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1814,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb278c96180" d="M -0.833333 2.5 
+     <path id="m2e5986ed45" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1831,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mb278c96180" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb278c96180" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m2e5986ed45" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e5986ed45" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1853,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m598bf75ba4" d="M -1.25 2.5 
+     <path id="m16db0d2265" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1870,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#m598bf75ba4" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m598bf75ba4" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m16db0d2265" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m16db0d2265" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1892,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc3e4093720" d="M 0 -2.5 
+     <path id="mbfa4dccc88" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1907,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc3e4093720" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbfa4dccc88" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1929,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdd9f67dd3d" d="M 0 -2.5 
+     <path id="m0814a89d9b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1940,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mdd9f67dd3d" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd9f67dd3d" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#m0814a89d9b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0814a89d9b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1972,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mf594d85f73" d="M 0 3.5 
+      <path id="md038efbe48" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1985,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mf594d85f73" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#md038efbe48" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2048,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m178244bc6c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0674f832c9" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2066,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m436450e9eb" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee54fd2ab2" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2115,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md307489ca2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m94c55ec53f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2162,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma6227aa52e" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6c8797ec23" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2182,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb278c96180" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2e5986ed45" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2240,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m598bf75ba4" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m16db0d2265" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2309,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc3e4093720" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mbfa4dccc88" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2351,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdd9f67dd3d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0814a89d9b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2424,17 +2430,17 @@ L 195.893147 176.45193
 L 187.210062 190.253023 
 L 157.246106 245.621259 
 L 95.319203 339.14348 
-" clip-path="url(#p533e8fc221)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p533e8fc221)">
-     <use xlink:href="#mf594d85f73" x="257.531237" y="150.876361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="236.23654" y="155.378808" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="222.073314" y="159.773191" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="202.315941" y="170.53176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="199.905291" y="172.268949" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="195.893147" y="176.45193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="187.210062" y="190.253023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="157.246106" y="245.621259" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf594d85f73" x="95.319203" y="339.14348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p4fa5d58d89)">
+     <use xlink:href="#md038efbe48" x="257.531237" y="150.876361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="236.23654" y="155.378808" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="222.073314" y="159.773191" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="202.315941" y="170.53176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="199.905291" y="172.268949" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="195.893147" y="176.45193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="187.210062" y="190.253023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="157.246106" y="245.621259" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md038efbe48" x="95.319203" y="339.14348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3110,7 +3116,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p533e8fc221">
+  <clipPath id="p4fa5d58d89">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -4,7 +4,7 @@
   "machine": "Linux chungus x86_64",
   "git_commit": "6ed05ade",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
-  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic | libdeflate extended to levels 10-12 (chungus, this PR)"
  },
  "results": [
   {
@@ -16566,6 +16566,696 @@
    "ratio": 0.1307,
    "compress_mbps": 25.17,
    "decompress_mbps": 148.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 51721,
+   "ratio": 0.3401,
+   "compress_mbps": 12.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 11,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 8.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 12,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 5.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46657,
+   "ratio": 0.3727,
+   "compress_mbps": 13.72,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 11,
+   "out_size": 46515,
+   "ratio": 0.3716,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 12,
+   "out_size": 46469,
+   "ratio": 0.3712,
+   "compress_mbps": 7.14,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7725,
+   "ratio": 0.314,
+   "compress_mbps": 15.97,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 11,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 10.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 12,
+   "out_size": 7723,
+   "ratio": 0.3139,
+   "compress_mbps": 7.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3026,
+   "ratio": 0.2714,
+   "compress_mbps": 17.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 11,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 14.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 12,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 10.64,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 41.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 11,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 33.55,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 12,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 24.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 179347,
+   "ratio": 0.1742,
+   "compress_mbps": 30.91,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 11,
+   "out_size": 179096,
+   "ratio": 0.1739,
+   "compress_mbps": 20.04,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 12,
+   "out_size": 179049,
+   "ratio": 0.1739,
+   "compress_mbps": 15.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138116,
+   "ratio": 0.3236,
+   "compress_mbps": 12.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 11,
+   "out_size": 137923,
+   "ratio": 0.3232,
+   "compress_mbps": 8.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 12,
+   "out_size": 137921,
+   "ratio": 0.3232,
+   "compress_mbps": 7.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 185328,
+   "ratio": 0.3846,
+   "compress_mbps": 12.88,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 11,
+   "out_size": 184440,
+   "ratio": 0.3828,
+   "compress_mbps": 9.1,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 12,
+   "out_size": 184371,
+   "ratio": 0.3826,
+   "compress_mbps": 5.56,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51319,
+   "ratio": 0.1,
+   "compress_mbps": 12.87,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 11,
+   "out_size": 49675,
+   "ratio": 0.0968,
+   "compress_mbps": 6.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 12,
+   "out_size": 49194,
+   "ratio": 0.0959,
+   "compress_mbps": 3.65,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 11975,
+   "ratio": 0.3132,
+   "compress_mbps": 20.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 11,
+   "out_size": 11966,
+   "ratio": 0.3129,
+   "compress_mbps": 13.4,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 12,
+   "out_size": 11965,
+   "ratio": 0.3129,
+   "compress_mbps": 10.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1692,
+   "ratio": 0.4003,
+   "compress_mbps": 54.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 11,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 45.3,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 12,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 29.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3681797,
+   "ratio": 0.3612,
+   "compress_mbps": 12.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 11,
+   "out_size": 3679289,
+   "ratio": 0.361,
+   "compress_mbps": 9.26,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 12,
+   "out_size": 3679105,
+   "ratio": 0.361,
+   "compress_mbps": 7.67,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18268811,
+   "ratio": 0.3567,
+   "compress_mbps": 16.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 11,
+   "out_size": 18245674,
+   "ratio": 0.3562,
+   "compress_mbps": 11.71,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 12,
+   "out_size": 18241312,
+   "ratio": 0.3561,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3461494,
+   "ratio": 0.3472,
+   "compress_mbps": 18.28,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 11,
+   "out_size": 3446053,
+   "ratio": 0.3456,
+   "compress_mbps": 10.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 12,
+   "out_size": 3447985,
+   "ratio": 0.3458,
+   "compress_mbps": 5.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2782465,
+   "ratio": 0.0829,
+   "compress_mbps": 8.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 11,
+   "out_size": 2751857,
+   "ratio": 0.082,
+   "compress_mbps": 5.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 12,
+   "out_size": 2748273,
+   "ratio": 0.0819,
+   "compress_mbps": 4.07,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 2995902,
+   "ratio": 0.487,
+   "compress_mbps": 19.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 11,
+   "out_size": 2994386,
+   "ratio": 0.4867,
+   "compress_mbps": 14.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 12,
+   "out_size": 2994086,
+   "ratio": 0.4867,
+   "compress_mbps": 12.48,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3608746,
+   "ratio": 0.3578,
+   "compress_mbps": 19.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 11,
+   "out_size": 3608161,
+   "ratio": 0.3578,
+   "compress_mbps": 14.81,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 12,
+   "out_size": 3608138,
+   "ratio": 0.3577,
+   "compress_mbps": 13.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1697693,
+   "ratio": 0.2562,
+   "compress_mbps": 8.9,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 11,
+   "out_size": 1696742,
+   "ratio": 0.256,
+   "compress_mbps": 6.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 12,
+   "out_size": 1696488,
+   "ratio": 0.256,
+   "compress_mbps": 5.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5137640,
+   "ratio": 0.2378,
+   "compress_mbps": 16.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 11,
+   "out_size": 5122694,
+   "ratio": 0.2371,
+   "compress_mbps": 9.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 12,
+   "out_size": 5118130,
+   "ratio": 0.2369,
+   "compress_mbps": 7.0,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5250862,
+   "ratio": 0.7241,
+   "compress_mbps": 25.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 11,
+   "out_size": 5250747,
+   "ratio": 0.724,
+   "compress_mbps": 20.83,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 12,
+   "out_size": 5250745,
+   "ratio": 0.724,
+   "compress_mbps": 19.39,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11526846,
+   "ratio": 0.278,
+   "compress_mbps": 10.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 11,
+   "out_size": 11520969,
+   "ratio": 0.2779,
+   "compress_mbps": 7.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 12,
+   "out_size": 11520871,
+   "ratio": 0.2779,
+   "compress_mbps": 6.12,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5748096,
+   "ratio": 0.6783,
+   "compress_mbps": 38.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 11,
+   "out_size": 5747172,
+   "ratio": 0.6782,
+   "compress_mbps": 29.45,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 12,
+   "out_size": 5747146,
+   "ratio": 0.6782,
+   "compress_mbps": 26.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637425,
+   "ratio": 0.1193,
+   "compress_mbps": 12.15,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 11,
+   "out_size": 630827,
+   "ratio": 0.118,
+   "compress_mbps": 7.32,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 12,
+   "out_size": 629349,
+   "ratio": 0.1177,
+   "compress_mbps": 4.73,
+   "decompress_mbps": null
   }
  ]
 }


### PR DESCRIPTION
This PR sweeps the `libdeflate` reference over its full level range (1-12) in the bench report, instead of the 1-9 shared with the other codecs, so its densest points 10-12 — the ones the comparison Pareto actually wants from a C+SIMD encoder — appear on the dashboard. `plot.py` already discovers each codec's levels, so no plotter change is needed; the README and the perf-pr-graphs skill note the wider range.

It also handles a latent crash the sweep exposes: the decode-timing path builds its canonical reference stream with the zlib FFI, whose `deflateInit2` accepts only levels 0-9, so a codec swept past 9 has no faithful reference at its own level (libdeflate L10-12 raised a `deflateInit2: stream error`). Rather than clamp the reference to a mislabelled lower level, decode timing is **omitted** for those levels — the row keeps its own compress ratio/speed, the dedicated decode-density experiment already covers those levels on real libdeflate streams, so libdeflate 10-12 carry a null `decompress_mbps`.

The committed dashboard gains libdeflate's 10-12 rows (measured on `chungus`) and the two compress-Pareto SVGs; every other codec and chart is untouched. This is the D1 slice of the #2710 ladder-redesign discussion, split out to ship on its own.

A second opinion (Codex) flagged the clamp-vs-omit methodology question above (decode timing on a mislabelled L9 stream for L10-12); adopting its suggestion to omit those decode timings is what this PR now does.

🤖 Prepared with Claude Code