### PR TITLE
perf(matcher): uset the updateHashesFast hot writes (~2% L1 compress)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -982,14 +982,60 @@ def updateHashesFast (data : ByteArray) (hashSize : Nat)
 termination_by matchLen - j
 decreasing_by all_goals omega
 
+/-- `updateHashesFast` with the two hot per-insertion writes done via the
+    proven-bounds `Array.set` (no panic-bounds branch) instead of `set!`. The
+    bucket index `hsh < hashTable.size` (`hb`) and the chain mask `(pos+j) &&&
+    0x7FFF < chainWinSize ≤ prev.size` (`winMask_lt`/`Nat.and_le_left` + `hpv`)
+    are proven, so the bounds checks `set!` performs are wasted work. Proven
+    equal to `updateHashesFast` (`updateHashesFastU_eq`); the `min chainWinSize
+    data.size ≤ prev.size` guard is the same one `chainWalkGuardedPacked` carries
+    — always true for the production chain arrays (`prev` is the fixed
+    `min chainWinSize data.size`-entry ring), so it is a defensive guard, not
+    hot-path branching — established once per call by `updateHashesGuarded`. -/
+def updateHashesFastU (data : ByteArray) (hashSize : Nat)
+    (hashTable : Array Nat) (prev : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hht : hashSize ≤ hashTable.size)
+    (hpv : min chainWinSize data.size ≤ prev.size) : Array Nat × Array Nat :=
+  if j < matchLen ∧ j ≤ insertCap then
+    if h : pos + j + 2 < data.size then
+      let hsh := lz77Greedy.hash3 data (pos + j) hashSize h
+      have hb : hsh < hashTable.size := by
+        have : hsh < hashSize := Nat.mod_lt _ hhs
+        omega
+      have hmask : ((pos + j) &&& 0x7FFF) < prev.size := by
+        -- `h1`: mask `< chainWinSize` (covers `chainWinSize ≤ data.size`). `h2`:
+        -- mask `≤ pos+j < data.size` (covers the small-data `data.size <
+        -- chainWinSize` side). Together: mask `< min chainWinSize data.size ≤
+        -- prev.size`, even when `prev.size` is exactly that minimum.
+        have h1 := winMask_lt (pos + j)
+        have h2 := Nat.and_le_left (n := pos + j) (m := 0x7FFF)
+        simp only [chainWinSize] at h1 hpv; omega
+      let head := hashTable[hsh]'hb
+      updateHashesFastU data hashSize
+        (hashTable.set hsh (pos + j) hb)
+        (prev.set ((pos + j) &&& 0x7FFF) head hmask)
+        pos (j + 1) matchLen insertCap hhs
+        (by rw [Array.size_set]; exact hht) (by rw [Array.size_set]; exact hpv)
+    else
+      updateHashesFastU data hashSize hashTable prev pos (j + 1) matchLen insertCap hhs hht hpv
+  else (hashTable, prev)
+termination_by matchLen - j
+decreasing_by all_goals omega
+
 /-- One runtime `0 < hashSize ∧ hashSize ≤ hashTable.size` check guards the whole
     `updateHashesFast` insertion loop; the fallback is the original panic-checked
-    insertion, so this equals `lz77Chain.updateHashes`. -/
+    insertion, so this equals `lz77Chain.updateHashes`. The extra
+    `min chainWinSize data.size ≤ prev.size` check unlocks the proven-bounds-`set`
+    walk (`updateHashesFastU`); both other branches fall back to the `set!` walk
+    (`updateHashesFast`) / the reference insertion. -/
 @[inline] def updateHashesGuarded (data : ByteArray) (hashSize : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos j matchLen insertCap : Nat) :
     Array Nat × Array Nat :=
   if hu : 0 < hashSize ∧ hashSize ≤ hashTable.size then
-    updateHashesFast data hashSize hashTable prev pos j matchLen insertCap hu.1 hu.2
+    if hpv : min chainWinSize data.size ≤ prev.size then
+      updateHashesFastU data hashSize hashTable prev pos j matchLen insertCap hu.1 hu.2 hpv
+    else
+      updateHashesFast data hashSize hashTable prev pos j matchLen insertCap hu.1 hu.2
   else
     lz77Chain.updateHashes data hashSize hashTable prev pos j matchLen insertCap
 

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -384,6 +384,44 @@ theorem updateHashesFast_eq (data : ByteArray) (hashSize : Nat)
         exact ih _ (by omega) _ _ _ hht rfl
     · rw [if_neg hcond, if_neg hcond]
 
+/-- The `uset`-write insertion walk (`updateHashesFastU`) is the proven-bounds
+    `set!` walk: identical control flow, with the two writes' in-bounds `set`
+    collapsing to `set!` (`Array.set!_eq_setIfInBounds` + `dif_pos`) at each step. -/
+theorem updateHashesFastU_eq (data : ByteArray) (hashSize : Nat)
+    (hashTable : Array Nat) (prev : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hht : hashSize ≤ hashTable.size)
+    (hpv : min chainWinSize data.size ≤ prev.size) :
+    updateHashesFastU data hashSize hashTable prev pos j matchLen insertCap hhs hht hpv =
+      updateHashesFast data hashSize hashTable prev pos j matchLen insertCap hhs hht := by
+  induction hn : matchLen - j using Nat.strongRecOn generalizing j hashTable prev hht hpv with
+  | _ n ih =>
+    unfold updateHashesFastU updateHashesFast
+    by_cases hcond : j < matchLen ∧ j ≤ insertCap
+    · rw [if_pos hcond, if_pos hcond]
+      by_cases hd : pos + j + 2 < data.size
+      · rw [dif_pos hd, dif_pos hd]
+        have hb : lz77Greedy.hash3 data (pos + j) hashSize hd < hashTable.size := by
+          have : lz77Greedy.hash3 data (pos + j) hashSize hd < hashSize := Nat.mod_lt _ hhs
+          omega
+        have hmask : ((pos + j) &&& 0x7FFF) < prev.size := by
+          have h1 := winMask_lt (pos + j)
+          have h2 := Nat.and_le_left (n := pos + j) (m := 0x7FFF)
+          simp only [chainWinSize] at h1 hpv; omega
+        have e1 : hashTable.set (lz77Greedy.hash3 data (pos + j) hashSize hd) (pos + j) hb
+            = hashTable.set! (lz77Greedy.hash3 data (pos + j) hashSize hd) (pos + j) := by
+          rw [Array.set!_eq_setIfInBounds, Array.setIfInBounds, dif_pos hb]
+        have e2 : prev.set ((pos + j) &&& 0x7FFF)
+              (hashTable[lz77Greedy.hash3 data (pos + j) hashSize hd]'hb) hmask
+            = prev.set! ((pos + j) &&& 0x7FFF)
+              (hashTable[lz77Greedy.hash3 data (pos + j) hashSize hd]'hb) := by
+          rw [Array.set!_eq_setIfInBounds, Array.setIfInBounds, dif_pos hmask]
+        simp only [e1, e2]
+        exact ih _ (by omega) _ _ _ (by rw [Array.size_set!]; exact hht)
+          (by rw [Array.size_set!]; exact hpv) rfl
+      · rw [dif_neg hd, dif_neg hd]
+        exact ih _ (by omega) _ _ _ hht hpv rfl
+    · rw [if_neg hcond, if_neg hcond]
+
 /-- One runtime guard collapses to the reference insertion. -/
 theorem updateHashesGuarded_eq (data : ByteArray) (hashSize : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos j matchLen insertCap : Nat) :
@@ -391,7 +429,9 @@ theorem updateHashesGuarded_eq (data : ByteArray) (hashSize : Nat)
       lz77Chain.updateHashes data hashSize hashTable prev pos j matchLen insertCap := by
   unfold updateHashesGuarded
   split
-  · exact updateHashesFast_eq ..
+  · split
+    · exact (updateHashesFastU_eq ..).trans (updateHashesFast_eq ..)
+    · exact updateHashesFast_eq ..
   · rfl
 
 /-! ## Iterative version: equivalence + transferred contracts -/

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p52ac0cfe24)">
+   <g clip-path="url(#pd7fc49fe48)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3Yz4rkZxmG4eqemiEMzaBC/jiISEBxkb2EHIObHEiOIGfhEQiCq2yD6NKdh6BJECFjiO2MGTozle6a+rnLPnB/vElxXUfwFAVv3fVdnL7647bjh+VwM71gncPz6QVLbHe30xOWuXj0xvSENe6/Nr1gncvL6QVr3B2mF6xzcZ7f2fbsyfSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3/urqc3LHF3OkxPWOanP3p7esIyV9tb0xOWuPj66fSEZf768u/TE5b42YM3picsczzdTk9Y4ubV+d7929NxesISv3n08+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF828+2qZHrPDyeDM9YZnXTw+nJ6xzvJ1esMbN9fSCdd781fSCJW62F9MTljnX+/j6djU9YZknu6fTE5Z4fP2/6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7q2fX0hiWu9g+mJ6xz+GJ6wTLbzVfTE9Y4naYXLHPx8MvpCUuc8w252j+anrDGg9emFyzz+OXt9IQlthf/np6wjBcsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYfrv+YnoD39XpNL0AvrV9/tn0hDUu/f/8wXEb+R5xQQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+A//5resMSzw6vpCcv87cnz6QnLfPz+e9MTlnjr4S+mJyzzzu//MD1hid/+8ifTE5b59NlhegLf0Z/+/Mn0hCVe/O7D6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2MXx9JdtesQKr07H6QnLXF6cbxffO7yYnrDGvf30gnW+fjq9YInTjx9PT1hm207TE5a4d8ZvBnfbef6m3T+e5+fa7bxgAQDkBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/ea6NdbmfXrDM5ZefTU9YZnv+3+kJaxyP0wuW2X797vSEJc72Nu52u1e70/SENe4O0wuWuf/NzfSEJbbP/zE9YZnzvSAAAEMEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7P/Fq4wDs6FcsgAAAABJRU5ErkJggg==" id="image042e0e9f3c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3Yz4pkZx3H4erumiEMzaBCYhxERFA37rPwGtzkQrwC7yJXIAiu3IagS3degn+CCBlDbGdM05mpdNfUyS77wOflZ4rnuYLv4RRvfc57cfr899uOb5fD3fSCdQ630wuW2B7upycsc/H0nekJazx6a3rBOpeX0wvWeDhML1jn4jzf2fby+fSEZc7zjQEADBJYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/T93N9Mblng4HaYnLPOD7/xkesIy19u70xOWuPjixfSEZf78+q/TE5b44eN3picsczzdT09Y4u7N+Z7796fj9IQl3nv6o+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF7Zd/2KZHrPD6eDc9YZm3T0+mJ6xzvJ9esMbdzfSCdb7/s+kFS9xtr6YnLHOu5+Pb2/X0hGWe715MT1ji2c3/pics4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYvvrlzfTG5a43j+enrDO4dPpBctsd59PT1jjdJpesMzFk8+mJyxxzmfI9f7p9IQ1Hr81vWCZZ6/vpycssb369/SEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9tvNp9Mb+KZOp+kF8LXtk4+nJ6xx6fvzW8fZyP8RJwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9r/+z7+mNyzx8vBmesIyf3l+Oz1hmQ/f/+X0hCXeffLj6QnL/OK3v5uesMSvfvq96QnL/OPlYXoC39BHf/z79IQlXn3wm+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF8fSnbXrECm9Ox+kJy1xenG8XXx1eTU9Y42o/vWCdL15ML1ji9N1n0xOW2bbT9IQlrs74zuBhO8//tEfH83yu3c4NFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2l+faWJf76QXLXH728fSEZbbb/05PWON4nF6wzOnn701PWOLqXM/G3W73sJ3n7/HqzXk+12632z063E5PWGL75G/TE5Y53xMEAGCIwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiH0F426NAdZrLn8AAAAASUVORK5CYII=" id="image31c74c7c0c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2242ed6f90" d="M 0 0 
+       <path id="mb6cd1d1dad" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2242ed6f90" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2242ed6f90" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2242ed6f90" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2242ed6f90" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2242ed6f90" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2242ed6f90" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2242ed6f90" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2242ed6f90" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2242ed6f90" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2242ed6f90" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2242ed6f90" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6cd1d1dad" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m701f343775" d="M 0 0 
+       <path id="m57ed81b3d5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m701f343775" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m57ed81b3d5" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,48 +1303,14 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -3 -->
+    <!-- -1 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +4 -->
+    <!-- +6 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1362,33 +1328,64 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -58 -->
+    <!-- -57 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -87 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1431,26 +1428,6 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -87 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
@@ -1458,78 +1435,102 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +6 -->
+    <!-- +9 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +3 -->
+    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +0 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +7 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -16 -->
+    <!-- -14 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -36 -->
+    <!-- -35 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2178,18 +2179,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageaa5f87d647" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image7d3460814c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mba761233e2" d="M 0 0 
+       <path id="m161dd572f8" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2213,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2227,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2241,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2254,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2267,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2280,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mba761233e2" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m161dd572f8" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2941,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.611875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,16 +3009,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p52ac0cfe24">
+  <clipPath id="pd7fc49fe48">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m04ba99b503" d="M 0 0 
+       <path id="m29a98c4e9f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m04ba99b503" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m04ba99b503" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m04ba99b503" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m04ba99b503" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m04ba99b503" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m04ba99b503" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m04ba99b503" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29a98c4e9f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="md65b050d34" d="M 0 0 
+       <path id="m5d5cd3a1de" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md65b050d34" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md65b050d34" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md65b050d34" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7beeb5c2a1" d="M 0 0 
+       <path id="ma6858662ba" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m7beeb5c2a1" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6858662ba" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 175.671124) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 174.618486) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.82831) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 313.908823) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc77529be24" d="M -2.5 2.5 
+     <path id="m366a485e49" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#mc77529be24" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc77529be24" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m366a485e49" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m366a485e49" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m054b1a44e9" d="M 0 -2.5 
+     <path id="m02f854e414" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m054b1a44e9" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m054b1a44e9" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m02f854e414" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m02f854e414" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1812,42 +1812,42 @@ L 124.491988 152.059912
 L 92.613662 207.455314 
 L 87.348715 224.984992 
 L 86.053433 241.561213 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mba9466e3eb" d="M -0 3.535534 
+     <path id="m9e50b830b3" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#mba9466e3eb" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba9466e3eb" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m9e50b830b3" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9e50b830b3" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdc8c231306" d="M -0 2.5 
+     <path id="m8063323e4d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#mdc8c231306" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m8063323e4d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1860,9 +1860,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m47c87d962d" d="M -0.833333 2.5 
+     <path id="m36d8200e3c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1877,16 +1877,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m47c87d962d" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47c87d962d" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m36d8200e3c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m36d8200e3c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1899,9 +1899,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1032fd2c5e" d="M -1.25 2.5 
+     <path id="me7e7c6836c" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1916,16 +1916,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m1032fd2c5e" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1032fd2c5e" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#me7e7c6836c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me7e7c6836c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1938,9 +1938,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8c0cfdb3b6" d="M 0 -2.5 
+     <path id="mdc78908ea3" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1953,16 +1953,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8c0cfdb3b6" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdc78908ea3" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1975,9 +1975,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1937a598b2" d="M 0 -2.5 
+     <path id="m2751a69b6d" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1986,16 +1986,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m1937a598b2" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1937a598b2" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m2751a69b6d" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2751a69b6d" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2018,7 +2018,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m9968bc4dfe" d="M 0 3.5 
+      <path id="m40d7fa8cc6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2031,7 +2031,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m9968bc4dfe" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m40d7fa8cc6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2094,7 +2094,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc77529be24" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m366a485e49" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2112,7 +2112,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m054b1a44e9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m02f854e414" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2161,7 +2161,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mba9466e3eb" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9e50b830b3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2208,7 +2208,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdc8c231306" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8063323e4d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2228,7 +2228,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m47c87d962d" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m36d8200e3c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2286,7 +2286,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1032fd2c5e" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me7e7c6836c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2355,7 +2355,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8c0cfdb3b6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdc78908ea3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2397,7 +2397,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1937a598b2" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2751a69b6d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2467,26 +2467,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 180.671124 
-L 214.084819 183.545645 
-L 206.266533 185.976577 
-L 187.75787 192.485037 
-L 186.58897 193.499057 
-L 184.505355 195.842174 
-L 164.72409 207.184059 
-L 150.950891 251.782768 
-L 98.348822 318.82831 
-" clip-path="url(#p292701f636)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p292701f636)">
-     <use xlink:href="#m9968bc4dfe" x="226.647908" y="180.671124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="214.084819" y="183.545645" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="206.266533" y="185.976577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="187.75787" y="192.485037" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="186.58897" y="193.499057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="184.505355" y="195.842174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="164.72409" y="207.184059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="150.950891" y="251.782768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9968bc4dfe" x="98.348822" y="318.82831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 179.618486 
+L 214.084819 182.356552 
+L 206.266533 184.821312 
+L 187.75787 192.089877 
+L 186.58897 192.797576 
+L 184.505355 194.997697 
+L 164.72409 206.439744 
+L 150.950891 251.438009 
+L 98.348822 318.908823 
+" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pd91135d0bf)">
+     <use xlink:href="#m40d7fa8cc6" x="226.647908" y="179.618486" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="214.084819" y="182.356552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="206.266533" y="184.821312" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="187.75787" y="192.089877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="186.58897" y="192.797576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="184.505355" y="194.997697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="164.72409" y="206.439744" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="150.950891" y="251.438009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m40d7fa8cc6" x="98.348822" y="318.908823" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2897,8 +2897,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.611875 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2909,16 +2909,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -3016,6 +3006,16 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3054,16 +3054,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3102,109 +3102,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p292701f636">
+  <clipPath id="pd91135d0bf">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.17625pt" height="386.202469pt" viewBox="0 0 569.17625 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,233 +21,233 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 386.202469 
-L 570.708594 386.202469 
-L 570.708594 0 
-L 0 0 
+   <path d="M -0 386.202469 
+L 569.17625 386.202469 
+L 569.17625 0 
+L -0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.479297 104.1264 
-L 292.104297 104.1264 
-L 292.104297 74.7432 
-L 187.479297 74.7432 
+    <path d="M 186.713125 104.1264 
+L 291.338125 104.1264 
+L 291.338125 74.7432 
+L 186.713125 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.104297 104.1264 
-L 396.729297 104.1264 
-L 396.729297 74.7432 
-L 292.104297 74.7432 
+    <path d="M 291.338125 104.1264 
+L 395.963125 104.1264 
+L 395.963125 74.7432 
+L 291.338125 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.729297 104.1264 
-L 501.354297 104.1264 
-L 501.354297 74.7432 
-L 396.729297 74.7432 
+    <path d="M 395.963125 104.1264 
+L 500.588125 104.1264 
+L 500.588125 74.7432 
+L 395.963125 74.7432 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.479297 133.5096 
-L 292.104297 133.5096 
-L 292.104297 104.1264 
-L 187.479297 104.1264 
+    <path d="M 186.713125 133.5096 
+L 291.338125 133.5096 
+L 291.338125 104.1264 
+L 186.713125 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.104297 133.5096 
-L 396.729297 133.5096 
-L 396.729297 104.1264 
-L 292.104297 104.1264 
+    <path d="M 291.338125 133.5096 
+L 395.963125 133.5096 
+L 395.963125 104.1264 
+L 291.338125 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.729297 133.5096 
-L 501.354297 133.5096 
-L 501.354297 104.1264 
-L 396.729297 104.1264 
+    <path d="M 395.963125 133.5096 
+L 500.588125 133.5096 
+L 500.588125 104.1264 
+L 395.963125 104.1264 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.479297 162.8928 
-L 292.104297 162.8928 
-L 292.104297 133.5096 
-L 187.479297 133.5096 
+    <path d="M 186.713125 162.8928 
+L 291.338125 162.8928 
+L 291.338125 133.5096 
+L 186.713125 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.104297 162.8928 
-L 396.729297 162.8928 
-L 396.729297 133.5096 
-L 292.104297 133.5096 
+    <path d="M 291.338125 162.8928 
+L 395.963125 162.8928 
+L 395.963125 133.5096 
+L 291.338125 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.729297 162.8928 
-L 501.354297 162.8928 
-L 501.354297 133.5096 
-L 396.729297 133.5096 
+    <path d="M 395.963125 162.8928 
+L 500.588125 162.8928 
+L 500.588125 133.5096 
+L 395.963125 133.5096 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.479297 192.276 
-L 292.104297 192.276 
-L 292.104297 162.8928 
-L 187.479297 162.8928 
+    <path d="M 186.713125 192.276 
+L 291.338125 192.276 
+L 291.338125 162.8928 
+L 186.713125 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.104297 192.276 
-L 396.729297 192.276 
-L 396.729297 162.8928 
-L 292.104297 162.8928 
+    <path d="M 291.338125 192.276 
+L 395.963125 192.276 
+L 395.963125 162.8928 
+L 291.338125 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.729297 192.276 
-L 501.354297 192.276 
-L 501.354297 162.8928 
-L 396.729297 162.8928 
+    <path d="M 395.963125 192.276 
+L 500.588125 192.276 
+L 500.588125 162.8928 
+L 395.963125 162.8928 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.479297 221.6592 
-L 292.104297 221.6592 
-L 292.104297 192.276 
-L 187.479297 192.276 
+    <path d="M 186.713125 221.6592 
+L 291.338125 221.6592 
+L 291.338125 192.276 
+L 186.713125 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.104297 221.6592 
-L 396.729297 221.6592 
-L 396.729297 192.276 
-L 292.104297 192.276 
+    <path d="M 291.338125 221.6592 
+L 395.963125 221.6592 
+L 395.963125 192.276 
+L 291.338125 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.729297 221.6592 
-L 501.354297 221.6592 
-L 501.354297 192.276 
-L 396.729297 192.276 
+    <path d="M 395.963125 221.6592 
+L 500.588125 221.6592 
+L 500.588125 192.276 
+L 395.963125 192.276 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.479297 251.0424 
-L 292.104297 251.0424 
-L 292.104297 221.6592 
-L 187.479297 221.6592 
+    <path d="M 186.713125 251.0424 
+L 291.338125 251.0424 
+L 291.338125 221.6592 
+L 186.713125 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.104297 251.0424 
-L 396.729297 251.0424 
-L 396.729297 221.6592 
-L 292.104297 221.6592 
+    <path d="M 291.338125 251.0424 
+L 395.963125 251.0424 
+L 395.963125 221.6592 
+L 291.338125 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.729297 251.0424 
-L 501.354297 251.0424 
-L 501.354297 221.6592 
-L 396.729297 221.6592 
+    <path d="M 395.963125 251.0424 
+L 500.588125 251.0424 
+L 500.588125 221.6592 
+L 395.963125 221.6592 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.479297 280.4256 
-L 292.104297 280.4256 
-L 292.104297 251.0424 
-L 187.479297 251.0424 
+    <path d="M 186.713125 280.4256 
+L 291.338125 280.4256 
+L 291.338125 251.0424 
+L 186.713125 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.104297 280.4256 
-L 396.729297 280.4256 
-L 396.729297 251.0424 
-L 292.104297 251.0424 
+    <path d="M 291.338125 280.4256 
+L 395.963125 280.4256 
+L 395.963125 251.0424 
+L 291.338125 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.729297 280.4256 
-L 501.354297 280.4256 
-L 501.354297 251.0424 
-L 396.729297 251.0424 
+    <path d="M 395.963125 280.4256 
+L 500.588125 280.4256 
+L 500.588125 251.0424 
+L 395.963125 251.0424 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.479297 309.8088 
-L 292.104297 309.8088 
-L 292.104297 280.4256 
-L 187.479297 280.4256 
+    <path d="M 186.713125 309.8088 
+L 291.338125 309.8088 
+L 291.338125 280.4256 
+L 186.713125 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.104297 309.8088 
-L 396.729297 309.8088 
-L 396.729297 280.4256 
-L 292.104297 280.4256 
+    <path d="M 291.338125 309.8088 
+L 395.963125 309.8088 
+L 395.963125 280.4256 
+L 291.338125 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.729297 309.8088 
-L 501.354297 309.8088 
-L 501.354297 280.4256 
-L 396.729297 280.4256 
+    <path d="M 395.963125 309.8088 
+L 500.588125 309.8088 
+L 500.588125 280.4256 
+L 395.963125 280.4256 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.479297 339.192 
-L 292.104297 339.192 
-L 292.104297 309.8088 
-L 187.479297 309.8088 
+    <path d="M 186.713125 339.192 
+L 291.338125 339.192 
+L 291.338125 309.8088 
+L 186.713125 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.104297 339.192 
-L 396.729297 339.192 
-L 396.729297 309.8088 
-L 292.104297 309.8088 
+    <path d="M 291.338125 339.192 
+L 395.963125 339.192 
+L 395.963125 309.8088 
+L 291.338125 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.729297 339.192 
-L 501.354297 339.192 
-L 501.354297 309.8088 
-L 396.729297 309.8088 
+    <path d="M 395.963125 339.192 
+L 500.588125 339.192 
+L 500.588125 309.8088 
+L 395.963125 309.8088 
 z
-" clip-path="url(#pf20f32977c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0ec17fb101)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.700391 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.984609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.556719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.908437 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.638125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.015625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.27625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.305547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.539375 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.611797 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.845625 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.768047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.001875 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.113672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.3475 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(227.139922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.37375 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(338.850547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.084375 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,48 +1755,32 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 209 -->
-    <g transform="translate(440.692422 238.5583) scale(0.08 -0.08)">
+    <!-- 211 -->
+    <g transform="translate(439.92625 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.228672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.4625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1925,7 +1909,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.340547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1935,14 +1919,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.326797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.406797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1950,7 +1934,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.735547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.969375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2006,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2016,21 +2000,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.185625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.68375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2041,7 +2025,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2051,13 +2035,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.105625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.275625 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2073,7 +2057,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.863047 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.096875 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2286,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2425,16 +2409,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2473,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf20f32977c">
-   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p0ec17fb101">
+   <rect x="82.088125" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9c5857dfb0)">
+   <g clip-path="url(#p658f00267e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6ElEQVR4nO3YPW5cVQCGYY89cSA/IpCQCJAiGqACKYKKhh1QsAxKWnpKalp6NkAFokJCCLrQEQEFJALlj8j22GNWQBWd9zhXz7OCT7pz7nnvrLZ/f3m6s2Sbg9kLeBrb49kLxlrtzl4w1vHR7AVjXbgye8FYh49nLxhrb3/2Ap7G0n+f+xdmLxhq4bcfAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1/nFzZ/aGoda7e7MnDLU9PZ09Yajrl6/PnjDUnYe/z54w1sI/cd987srsCUNtzu/PnjDUT3dvz54w1DvX3pg9YajD/e3sCUOtVk9mTxhq4dcDAABnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1vXn599oahrpy/PnvCUPcO/pg9YahXnyz7G+nS1bdnTxhqb7WePWGo7c529oShXt65NnvCUMfXjmZPGOrGhZuzJwy12S77+V08Wvb7Zdm3OwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtV6tlt2gjzb/zJ4w1PN7l2ZPGOrk6kuzJwz154OfZ08Y6vHRwewJQ7374nuzJwx1tDd7wVj/bh7NnsBTuH94d/aEsc5fn71gqGXXJwAAZ44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtTr57pPT2SOG2m5nL4D/t+sb8Jnm/fJsW/r5W/rv0/N7pi386QEAcNYIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUusbP/wye8NQu+tlN/bd2/dmTxjqi49vzZ4w1Gff/zV7wlAf3Hxh9oShvvr219kThvr0o7dmTxjq829+mz1hqA9vvTJ7wlC/PTicPWGo91+7OHvCUMuuMwAAzhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBabU6+Pp09YqS94+PZE8baXc9eMNbxwewFY+1fmL1grNXCv3FPt7MXjLVx/p5pJ8u+/zarZZ+/cwvvl4XfDgAAnDUCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1Prk9Hj2hqH21vuzJwy1Xc1eMNbuw/uzJwx1dG49e8JQ+zvLPn87x0ezF4y1OZi9YKjHq2U/v0unyz5/53aX/f5c+vnzDygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBA6j/J1X2rX/GsGgAAAABJRU5ErkJggg==" id="image1894bd2286" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ50lEQVR4nO3XsY6lYwDH4TkzZ2fX2GWxRpBsNKhIhErjDhQuQ6nVK9VavRtQEZVEhI6OoGA3hN3FzJyZM65AtXl/78yX57mC/8n3fef9vavt7x+f7yzZ5mj2Ah7G9nT2grFWu7MXjHV6MnvBWAc3Zy8Y6/jB7AVj7e3PXsDDWPr7uX8we8FQCz/9AAC4aAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp9debH2dvGGq9uzd7wlDb8/PZE4Y6vHE4e8JQP977efaEsRZ+xX3p2s3ZE4baXN2fPWGob+58N3vCUK/eenH2hKGO97ezJwy1Wv0ze8JQCz8eAAC4aAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp9+8YLszcMdfPq4ewJQ909+mX2hKGe+2fZd6TrT70ye8JQe6v17AlDbXe2sycM9fTOrdkThjq9dTJ7wlDPHNyePWGozXbZz+/Rk2X/vyz7dAcA4MIRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNar1bIb9P7mj9kThnpk7/rsCUOdPfXk7AlD/frXt7MnDPXg5Gj2hKFef+KN2ROGOtmbvWCsvzf3Z0/gIfx5fGf2hLGuHs5eMNSy6xMAgAtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFqdffHe+ewRQ223sxfA/9t1B7zU/L9cbkv//pb+fnp+l9rCnx4AABeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILV+5qvvZ28Yane97Ma+893d2ROG+ujd12ZPGOqDL3+bPWGot24/PnvCUJ98/sPsCUO9/87LsycM9eFnP82eMNTbrz07e8JQP/11PHvCUG8+/+jsCUMtu84AALhwBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAarU5+/R89oiR9k5PZ08Ya3c9e8FYp0ezF4y1fzB7wVirhd9xz7ezF4y18f1damfLPv82q2V/f1cW3i8LPx0AALhoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn12fnp7A1D7V25NnvCUIt/fv/emz1hqKP1su+A13aX/f3tnJ7MXjDWwn/fvdXR7AlDPbZzMHvCUFd217MnjLVZ9vu57NMPAIALR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJD6D73JfrYxDoK3AAAAAElFTkSuQmCC" id="image3c05d5abb7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7c0bd0b811" d="M 0 0 
+       <path id="m83d6319e56" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7c0bd0b811" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7c0bd0b811" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m83d6319e56" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m680eb3e83a" d="M 0 0 
+       <path id="m3bf9415f65" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m680eb3e83a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3bf9415f65" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +10 -->
+    <!-- +12 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1170,129 +1170,6 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -3 -->
-    <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +3 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -34 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +10 -->
-    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -4 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -12 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1318,94 +1195,21 @@ Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -23 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +21 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- -12 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -1 -->
+    <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- -8 -->
-    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -24 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
+   <g id="text_23">
     <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1442,24 +1246,142 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_34">
+   <g id="text_24">
+    <!-- -31 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +12 -->
+    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -3 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -21 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +24 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- -11 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- -6 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -15 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+   <g id="text_31">
+    <!-- -5 -->
+    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1487,6 +1409,43 @@ L 691 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -22 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -11 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -6 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -15 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -1621,6 +1580,47 @@ z
    <g id="text_49">
     <!-- +238 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
@@ -2193,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image3e150843d4" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image56645b04d8" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mca6c818348" d="M 0 0 
+       <path id="m02d55240a4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mca6c818348" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m02d55240a4" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.611875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,16 +3000,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9c5857dfb0">
+  <clipPath id="p658f00267e">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2edd9998b2" d="M 0 0 
+       <path id="m21eccd11d5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2edd9998b2" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2edd9998b2" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2edd9998b2" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2edd9998b2" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2edd9998b2" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2edd9998b2" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2edd9998b2" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21eccd11d5" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m850c246714" d="M 0 0 
+       <path id="m0e7cf36816" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m850c246714" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e7cf36816" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m850c246714" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e7cf36816" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m850c246714" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e7cf36816" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6029d157d9" d="M 0 0 
+       <path id="m7b0f6ce7cb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6029d157d9" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 145.876361) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 144.107129) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 334.14348) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 334.014613) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0674f832c9" d="M -2.5 2.5 
+     <path id="m8e4da0fa55" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m0674f832c9" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0674f832c9" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#m8e4da0fa55" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8e4da0fa55" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mee54fd2ab2" d="M 0 -2.5 
+     <path id="m7afd972a80" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#mee54fd2ab2" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee54fd2ab2" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#m7afd972a80" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7afd972a80" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1766,42 +1766,42 @@ L 122.462976 157.203722
 L 81.012077 219.378594 
 L 77.44276 238.815213 
 L 76.953425 251.874777 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m94c55ec53f" d="M -0 3.535534 
+     <path id="md5c3e9c0bc" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m94c55ec53f" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94c55ec53f" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#md5c3e9c0bc" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md5c3e9c0bc" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6c8797ec23" d="M -0 2.5 
+     <path id="mee3cfe3861" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m6c8797ec23" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#mee3cfe3861" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1814,9 +1814,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2e5986ed45" d="M -0.833333 2.5 
+     <path id="mec891f9a24" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1831,16 +1831,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m2e5986ed45" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e5986ed45" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#mec891f9a24" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec891f9a24" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1853,9 +1853,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m16db0d2265" d="M -1.25 2.5 
+     <path id="m5336607f75" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1870,16 +1870,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m16db0d2265" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m16db0d2265" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#m5336607f75" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5336607f75" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1892,9 +1892,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbfa4dccc88" d="M 0 -2.5 
+     <path id="m477f4e2bc6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1907,16 +1907,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbfa4dccc88" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m477f4e2bc6" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1929,9 +1929,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0814a89d9b" d="M 0 -2.5 
+     <path id="mb68c7a53d1" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1940,16 +1940,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#m0814a89d9b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0814a89d9b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#mb68c7a53d1" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb68c7a53d1" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1972,7 +1972,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="md038efbe48" d="M 0 3.5 
+      <path id="m8c99534ff6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1985,7 +1985,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md038efbe48" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8c99534ff6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2048,7 +2048,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0674f832c9" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8e4da0fa55" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2066,7 +2066,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mee54fd2ab2" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7afd972a80" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2115,7 +2115,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m94c55ec53f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md5c3e9c0bc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2162,7 +2162,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6c8797ec23" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee3cfe3861" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2182,7 +2182,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2e5986ed45" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mec891f9a24" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2240,7 +2240,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m16db0d2265" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5336607f75" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2309,7 +2309,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbfa4dccc88" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m477f4e2bc6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2351,7 +2351,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0814a89d9b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb68c7a53d1" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2421,26 +2421,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 150.876361 
-L 236.23654 155.378808 
-L 222.073314 159.773191 
-L 202.315941 170.53176 
-L 199.905291 172.268949 
-L 195.893147 176.45193 
-L 187.210062 190.253023 
-L 157.246106 245.621259 
-L 95.319203 339.14348 
-" clip-path="url(#p4fa5d58d89)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p4fa5d58d89)">
-     <use xlink:href="#md038efbe48" x="257.531237" y="150.876361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="236.23654" y="155.378808" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="222.073314" y="159.773191" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="202.315941" y="170.53176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="199.905291" y="172.268949" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="195.893147" y="176.45193" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="187.210062" y="190.253023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="157.246106" y="245.621259" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md038efbe48" x="95.319203" y="339.14348" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 149.107129 
+L 236.23654 153.82467 
+L 222.073314 158.324086 
+L 202.315941 169.281009 
+L 199.905291 170.980798 
+L 195.893147 175.179401 
+L 187.210062 188.875151 
+L 157.246106 245.372702 
+L 95.319203 339.014613 
+" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pbf47cf6877)">
+     <use xlink:href="#m8c99534ff6" x="257.531237" y="149.107129" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="236.23654" y="153.82467" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="222.073314" y="158.324086" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="202.315941" y="169.281009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="199.905291" y="170.980798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="195.893147" y="175.179401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="187.210062" y="188.875151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="157.246106" y="245.372702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8c99534ff6" x="95.319203" y="339.014613" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2809,8 +2809,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.611875 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2821,16 +2821,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2928,6 +2918,16 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2966,16 +2966,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3014,109 +3014,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4fa5d58d89">
+  <clipPath id="pbf47cf6877">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.708594pt" height="386.202469pt" viewBox="0 0 570.708594 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.17625pt" height="386.202469pt" viewBox="0 0 569.17625 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,233 +21,233 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 386.202469 
-L 570.708594 386.202469 
-L 570.708594 0 
-L 0 0 
+   <path d="M -0 386.202469 
+L 569.17625 386.202469 
+L 569.17625 0 
+L -0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.479297 104.1264 
-L 292.104297 104.1264 
-L 292.104297 74.7432 
-L 187.479297 74.7432 
+    <path d="M 186.713125 104.1264 
+L 291.338125 104.1264 
+L 291.338125 74.7432 
+L 186.713125 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.104297 104.1264 
-L 396.729297 104.1264 
-L 396.729297 74.7432 
-L 292.104297 74.7432 
+    <path d="M 291.338125 104.1264 
+L 395.963125 104.1264 
+L 395.963125 74.7432 
+L 291.338125 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.729297 104.1264 
-L 501.354297 104.1264 
-L 501.354297 74.7432 
-L 396.729297 74.7432 
+    <path d="M 395.963125 104.1264 
+L 500.588125 104.1264 
+L 500.588125 74.7432 
+L 395.963125 74.7432 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.479297 133.5096 
-L 292.104297 133.5096 
-L 292.104297 104.1264 
-L 187.479297 104.1264 
+    <path d="M 186.713125 133.5096 
+L 291.338125 133.5096 
+L 291.338125 104.1264 
+L 186.713125 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.104297 133.5096 
-L 396.729297 133.5096 
-L 396.729297 104.1264 
-L 292.104297 104.1264 
+    <path d="M 291.338125 133.5096 
+L 395.963125 133.5096 
+L 395.963125 104.1264 
+L 291.338125 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.729297 133.5096 
-L 501.354297 133.5096 
-L 501.354297 104.1264 
-L 396.729297 104.1264 
+    <path d="M 395.963125 133.5096 
+L 500.588125 133.5096 
+L 500.588125 104.1264 
+L 395.963125 104.1264 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.479297 162.8928 
-L 292.104297 162.8928 
-L 292.104297 133.5096 
-L 187.479297 133.5096 
+    <path d="M 186.713125 162.8928 
+L 291.338125 162.8928 
+L 291.338125 133.5096 
+L 186.713125 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.104297 162.8928 
-L 396.729297 162.8928 
-L 396.729297 133.5096 
-L 292.104297 133.5096 
+    <path d="M 291.338125 162.8928 
+L 395.963125 162.8928 
+L 395.963125 133.5096 
+L 291.338125 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.729297 162.8928 
-L 501.354297 162.8928 
-L 501.354297 133.5096 
-L 396.729297 133.5096 
+    <path d="M 395.963125 162.8928 
+L 500.588125 162.8928 
+L 500.588125 133.5096 
+L 395.963125 133.5096 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.479297 192.276 
-L 292.104297 192.276 
-L 292.104297 162.8928 
-L 187.479297 162.8928 
+    <path d="M 186.713125 192.276 
+L 291.338125 192.276 
+L 291.338125 162.8928 
+L 186.713125 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.104297 192.276 
-L 396.729297 192.276 
-L 396.729297 162.8928 
-L 292.104297 162.8928 
+    <path d="M 291.338125 192.276 
+L 395.963125 192.276 
+L 395.963125 162.8928 
+L 291.338125 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.729297 192.276 
-L 501.354297 192.276 
-L 501.354297 162.8928 
-L 396.729297 162.8928 
+    <path d="M 395.963125 192.276 
+L 500.588125 192.276 
+L 500.588125 162.8928 
+L 395.963125 162.8928 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.479297 221.6592 
-L 292.104297 221.6592 
-L 292.104297 192.276 
-L 187.479297 192.276 
+    <path d="M 186.713125 221.6592 
+L 291.338125 221.6592 
+L 291.338125 192.276 
+L 186.713125 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.104297 221.6592 
-L 396.729297 221.6592 
-L 396.729297 192.276 
-L 292.104297 192.276 
+    <path d="M 291.338125 221.6592 
+L 395.963125 221.6592 
+L 395.963125 192.276 
+L 291.338125 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.729297 221.6592 
-L 501.354297 221.6592 
-L 501.354297 192.276 
-L 396.729297 192.276 
+    <path d="M 395.963125 221.6592 
+L 500.588125 221.6592 
+L 500.588125 192.276 
+L 395.963125 192.276 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.479297 251.0424 
-L 292.104297 251.0424 
-L 292.104297 221.6592 
-L 187.479297 221.6592 
+    <path d="M 186.713125 251.0424 
+L 291.338125 251.0424 
+L 291.338125 221.6592 
+L 186.713125 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.104297 251.0424 
-L 396.729297 251.0424 
-L 396.729297 221.6592 
-L 292.104297 221.6592 
+    <path d="M 291.338125 251.0424 
+L 395.963125 251.0424 
+L 395.963125 221.6592 
+L 291.338125 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.729297 251.0424 
-L 501.354297 251.0424 
-L 501.354297 221.6592 
-L 396.729297 221.6592 
+    <path d="M 395.963125 251.0424 
+L 500.588125 251.0424 
+L 500.588125 221.6592 
+L 395.963125 221.6592 
 z
-" clip-path="url(#p03382f488f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.479297 280.4256 
-L 292.104297 280.4256 
-L 292.104297 251.0424 
-L 187.479297 251.0424 
+    <path d="M 186.713125 280.4256 
+L 291.338125 280.4256 
+L 291.338125 251.0424 
+L 186.713125 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.104297 280.4256 
-L 396.729297 280.4256 
-L 396.729297 251.0424 
-L 292.104297 251.0424 
+    <path d="M 291.338125 280.4256 
+L 395.963125 280.4256 
+L 395.963125 251.0424 
+L 291.338125 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.729297 280.4256 
-L 501.354297 280.4256 
-L 501.354297 251.0424 
-L 396.729297 251.0424 
+    <path d="M 395.963125 280.4256 
+L 500.588125 280.4256 
+L 500.588125 251.0424 
+L 395.963125 251.0424 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.479297 309.8088 
-L 292.104297 309.8088 
-L 292.104297 280.4256 
-L 187.479297 280.4256 
+    <path d="M 186.713125 309.8088 
+L 291.338125 309.8088 
+L 291.338125 280.4256 
+L 186.713125 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.104297 309.8088 
-L 396.729297 309.8088 
-L 396.729297 280.4256 
-L 292.104297 280.4256 
+    <path d="M 291.338125 309.8088 
+L 395.963125 309.8088 
+L 395.963125 280.4256 
+L 291.338125 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.729297 309.8088 
-L 501.354297 309.8088 
-L 501.354297 280.4256 
-L 396.729297 280.4256 
+    <path d="M 395.963125 309.8088 
+L 500.588125 309.8088 
+L 500.588125 280.4256 
+L 395.963125 280.4256 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.479297 339.192 
-L 292.104297 339.192 
-L 292.104297 309.8088 
-L 187.479297 309.8088 
+    <path d="M 186.713125 339.192 
+L 291.338125 339.192 
+L 291.338125 309.8088 
+L 186.713125 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.104297 339.192 
-L 396.729297 339.192 
-L 396.729297 309.8088 
-L 292.104297 309.8088 
+    <path d="M 291.338125 339.192 
+L 395.963125 339.192 
+L 395.963125 309.8088 
+L 291.338125 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.729297 339.192 
-L 501.354297 339.192 
-L 501.354297 309.8088 
-L 396.729297 309.8088 
+    <path d="M 395.963125 339.192 
+L 500.588125 339.192 
+L 500.588125 309.8088 
+L 395.963125 309.8088 
 z
-" clip-path="url(#p03382f488f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8852518683)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.466562 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.700391 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.750781 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.984609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.322891 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.556719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.674609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.908437 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.404297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.638125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.340547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.781797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.015625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.406797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.042422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.27625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.340547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.326797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.406797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.735547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.969375 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.340547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.326797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.406797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.768047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.001875 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.340547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.326797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.406797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.305547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.539375 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.340547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.326797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.406797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.611797 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.845625 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.340547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.326797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(441.406797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.640625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.113672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.3475 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(227.139922 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.37375 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 35 -->
-    <g transform="translate(338.850547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.084375 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
@@ -1887,39 +1887,9 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 267 -->
-    <g transform="translate(440.692422 267.9415) scale(0.08 -0.08)">
+    <!-- 272 -->
+    <g transform="translate(439.92625 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
 L 3944 3988 
@@ -1932,13 +1902,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.228672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.4625 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2003,7 +1973,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.340547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2013,21 +1983,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.326797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.560625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.951797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.185625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.449922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.68375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2038,7 +2008,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.340547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.574375 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2048,13 +2018,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.871797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.105625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.041797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.275625 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2070,7 +2040,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.956016 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.189844 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2143,6 +2113,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2184,7 +2184,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2323,16 +2323,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2371,110 +2371,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p03382f488f">
-   <rect x="82.854297" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p8852518683">
+   <rect x="82.088125" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,10 +1,10 @@
 {
  "meta": {
-  "date": "2026-06-24T07:32:44Z",
+  "date": "2026-06-26T00:03:38Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "6ed05ade",
+  "git_commit": "4fb5715b",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
-  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic | libdeflate extended to levels 10-12 (chungus, this PR)"
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
  "results": [
   {
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.81,
-   "decompress_mbps": 192.5
+   "compress_mbps": 42.28,
+   "decompress_mbps": 194.68
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 218.79
+   "compress_mbps": 38.68,
+   "decompress_mbps": 221.88
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.01,
-   "decompress_mbps": 237.81
+   "compress_mbps": 35.74,
+   "decompress_mbps": 240.79
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.67,
-   "decompress_mbps": 240.42
+   "compress_mbps": 28.35,
+   "decompress_mbps": 241.59
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.72,
-   "decompress_mbps": 243.55
+   "compress_mbps": 27.39,
+   "decompress_mbps": 245.31
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.85,
-   "decompress_mbps": 249.58
+   "compress_mbps": 25.34,
+   "decompress_mbps": 252.52
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 249.87
+   "compress_mbps": 20.64,
+   "decompress_mbps": 252.34
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.16,
-   "decompress_mbps": 250.97
+   "compress_mbps": 9.26,
+   "decompress_mbps": 253.87
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.78,
-   "decompress_mbps": 250.74
+   "compress_mbps": 1.8,
+   "decompress_mbps": 254.15
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 38.45,
-   "decompress_mbps": 185.72
+   "compress_mbps": 39.33,
+   "decompress_mbps": 187.05
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 35.32,
-   "decompress_mbps": 201.82
+   "compress_mbps": 36.25,
+   "decompress_mbps": 202.22
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 218.98
+   "compress_mbps": 33.82,
+   "decompress_mbps": 220.58
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.6,
-   "decompress_mbps": 223.52
+   "compress_mbps": 26.22,
+   "decompress_mbps": 224.79
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 224.7
+   "compress_mbps": 25.53,
+   "decompress_mbps": 226.88
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.67,
-   "decompress_mbps": 228.08
+   "compress_mbps": 24.21,
+   "decompress_mbps": 230.18
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 228.56
+   "compress_mbps": 21.43,
+   "decompress_mbps": 230.26
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.93,
-   "decompress_mbps": 229.51
+   "compress_mbps": 9.01,
+   "decompress_mbps": 230.54
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.05,
-   "decompress_mbps": 228.42
+   "compress_mbps": 2.06,
+   "decompress_mbps": 229.99
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.99,
-   "decompress_mbps": 218.78
+   "compress_mbps": 34.82,
+   "decompress_mbps": 222.03
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.08,
-   "decompress_mbps": 226.09
+   "compress_mbps": 33.61,
+   "decompress_mbps": 227.42
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.18,
-   "decompress_mbps": 230.46
+   "compress_mbps": 32.66,
+   "decompress_mbps": 231.53
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.2,
-   "decompress_mbps": 238.74
+   "compress_mbps": 30.71,
+   "decompress_mbps": 240.41
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.71,
-   "decompress_mbps": 245.79
+   "compress_mbps": 30.16,
+   "decompress_mbps": 245.88
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.9,
-   "decompress_mbps": 245.84
+   "compress_mbps": 29.43,
+   "decompress_mbps": 248.36
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 249.81
+   "compress_mbps": 25.9,
+   "decompress_mbps": 250.71
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.62,
-   "decompress_mbps": 248.03
+   "compress_mbps": 9.75,
+   "decompress_mbps": 251.25
   },
   {
    "compressor": "native",
@@ -275,7 +275,7 @@
    "out_size": 7727,
    "ratio": 0.3141,
    "compress_mbps": 2.38,
-   "decompress_mbps": 249.38
+   "decompress_mbps": 253.18
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 148.73
+   "compress_mbps": 23.41,
+   "decompress_mbps": 150.14
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.77,
-   "decompress_mbps": 150.49
+   "compress_mbps": 22.94,
+   "decompress_mbps": 152.34
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.42,
-   "decompress_mbps": 154.29
+   "compress_mbps": 22.56,
+   "decompress_mbps": 155.74
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.3,
-   "decompress_mbps": 156.56
+   "compress_mbps": 21.26,
+   "decompress_mbps": 158.49
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.11,
-   "decompress_mbps": 158.05
+   "compress_mbps": 21.13,
+   "decompress_mbps": 160.08
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 20.75,
-   "decompress_mbps": 158.35
+   "compress_mbps": 20.78,
+   "decompress_mbps": 160.05
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 18.97,
-   "decompress_mbps": 159.05
+   "compress_mbps": 19.06,
+   "decompress_mbps": 160.57
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.02,
-   "decompress_mbps": 158.68
+   "compress_mbps": 7.04,
+   "decompress_mbps": 155.73
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 2.35,
-   "decompress_mbps": 159.2
+   "compress_mbps": 2.34,
+   "decompress_mbps": 159.15
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.71,
-   "decompress_mbps": 68.85
+   "compress_mbps": 11.69,
+   "decompress_mbps": 68.98
   },
   {
    "compressor": "native",
@@ -385,7 +385,7 @@
    "out_size": 1223,
    "ratio": 0.3287,
    "compress_mbps": 11.59,
-   "decompress_mbps": 69.86
+   "decompress_mbps": 69.53
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 69.53
+   "compress_mbps": 11.53,
+   "decompress_mbps": 69.5
   },
   {
    "compressor": "native",
@@ -405,7 +405,7 @@
    "out_size": 1213,
    "ratio": 0.326,
    "compress_mbps": 11.34,
-   "decompress_mbps": 70.11
+   "decompress_mbps": 69.94
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 69.87
+   "compress_mbps": 11.31,
+   "decompress_mbps": 70.2
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.31,
-   "decompress_mbps": 70.45
+   "compress_mbps": 11.32,
+   "decompress_mbps": 70.27
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.08,
-   "decompress_mbps": 70.49
+   "compress_mbps": 11.1,
+   "decompress_mbps": 70.4
   },
   {
    "compressor": "native",
@@ -445,7 +445,7 @@
    "out_size": 1209,
    "ratio": 0.3249,
    "compress_mbps": 3.82,
-   "decompress_mbps": 70.27
+   "decompress_mbps": 70.43
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 2.11,
-   "decompress_mbps": 70.29
+   "compress_mbps": 2.1,
+   "decompress_mbps": 70.55
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 65.25,
-   "decompress_mbps": 352.23
+   "compress_mbps": 68.32,
+   "decompress_mbps": 355.17
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 60.31,
-   "decompress_mbps": 381.58
+   "compress_mbps": 63.82,
+   "decompress_mbps": 380.28
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 61.17,
-   "decompress_mbps": 402.39
+   "compress_mbps": 63.11,
+   "decompress_mbps": 406.23
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 57.87,
-   "decompress_mbps": 427.0
+   "compress_mbps": 58.48,
+   "decompress_mbps": 428.56
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 56.72,
-   "decompress_mbps": 408.23
+   "compress_mbps": 57.77,
+   "decompress_mbps": 410.96
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 53.11,
-   "decompress_mbps": 410.96
+   "compress_mbps": 54.52,
+   "decompress_mbps": 425.34
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 427.98
+   "compress_mbps": 20.26,
+   "decompress_mbps": 429.99
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.39,
-   "decompress_mbps": 432.98
+   "compress_mbps": 7.27,
+   "decompress_mbps": 433.9
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.23,
-   "decompress_mbps": 435.5
+   "compress_mbps": 1.19,
+   "decompress_mbps": 434.41
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.66,
-   "decompress_mbps": 202.6
+   "compress_mbps": 45.8,
+   "decompress_mbps": 204.64
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.39,
-   "decompress_mbps": 217.96
+   "compress_mbps": 41.82,
+   "decompress_mbps": 220.98
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.78,
-   "decompress_mbps": 243.06
+   "compress_mbps": 38.32,
+   "decompress_mbps": 245.69
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 247.21
+   "compress_mbps": 30.55,
+   "decompress_mbps": 250.03
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.54,
-   "decompress_mbps": 251.0
+   "compress_mbps": 29.42,
+   "decompress_mbps": 251.77
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.66,
-   "decompress_mbps": 254.42
+   "compress_mbps": 27.29,
+   "decompress_mbps": 258.64
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.12,
-   "decompress_mbps": 255.63
+   "compress_mbps": 22.78,
+   "decompress_mbps": 259.09
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.92,
-   "decompress_mbps": 256.24
+   "compress_mbps": 10.05,
+   "decompress_mbps": 259.54
   },
   {
    "compressor": "native",
@@ -635,7 +635,7 @@
    "out_size": 138661,
    "ratio": 0.3249,
    "compress_mbps": 1.82,
-   "decompress_mbps": 255.5
+   "decompress_mbps": 260.16
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 38.78,
-   "decompress_mbps": 175.7
+   "compress_mbps": 40.55,
+   "decompress_mbps": 176.28
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 35.34,
-   "decompress_mbps": 195.44
+   "compress_mbps": 36.75,
+   "decompress_mbps": 196.24
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.81,
-   "decompress_mbps": 214.63
+   "compress_mbps": 33.55,
+   "decompress_mbps": 215.91
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.35,
-   "decompress_mbps": 218.58
+   "compress_mbps": 24.25,
+   "decompress_mbps": 219.47
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 216.54
+   "compress_mbps": 23.33,
+   "decompress_mbps": 219.86
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 221.35
+   "compress_mbps": 21.45,
+   "decompress_mbps": 223.68
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.12,
-   "decompress_mbps": 221.41
+   "compress_mbps": 18.72,
+   "decompress_mbps": 223.66
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 222.59
+   "compress_mbps": 8.5,
+   "decompress_mbps": 223.84
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.75,
-   "decompress_mbps": 221.76
+   "compress_mbps": 1.77,
+   "decompress_mbps": 223.88
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 125.1,
-   "decompress_mbps": 482.42
+   "compress_mbps": 129.97,
+   "decompress_mbps": 491.97
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 110.69,
-   "decompress_mbps": 505.87
+   "compress_mbps": 115.39,
+   "decompress_mbps": 518.75
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 95.36,
-   "decompress_mbps": 547.73
+   "compress_mbps": 98.32,
+   "decompress_mbps": 560.55
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 75.64,
-   "decompress_mbps": 464.63
+   "compress_mbps": 77.99,
+   "decompress_mbps": 474.88
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 73.03,
-   "decompress_mbps": 498.82
+   "compress_mbps": 74.88,
+   "decompress_mbps": 507.44
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 65.45,
-   "decompress_mbps": 545.1
+   "compress_mbps": 66.98,
+   "decompress_mbps": 555.6
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 36.76,
-   "decompress_mbps": 578.87
+   "compress_mbps": 37.95,
+   "decompress_mbps": 592.41
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.67,
-   "decompress_mbps": 621.92
+   "compress_mbps": 16.87,
+   "decompress_mbps": 637.23
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 1.09,
-   "decompress_mbps": 640.94
+   "compress_mbps": 1.08,
+   "decompress_mbps": 650.48
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.51,
-   "decompress_mbps": 186.49
+   "compress_mbps": 26.6,
+   "decompress_mbps": 188.53
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.78,
-   "decompress_mbps": 191.31
+   "compress_mbps": 25.98,
+   "decompress_mbps": 191.46
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 194.47
+   "compress_mbps": 25.42,
+   "decompress_mbps": 195.56
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.02,
-   "decompress_mbps": 201.79
+   "compress_mbps": 23.14,
+   "decompress_mbps": 192.66
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 211.36
+   "compress_mbps": 21.78,
+   "decompress_mbps": 211.73
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.32,
-   "decompress_mbps": 216.29
+   "compress_mbps": 21.61,
+   "decompress_mbps": 217.57
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.34,
-   "decompress_mbps": 217.45
+   "compress_mbps": 17.57,
+   "decompress_mbps": 218.24
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.32,
-   "decompress_mbps": 219.13
+   "compress_mbps": 5.35,
+   "decompress_mbps": 220.89
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.84,
-   "decompress_mbps": 220.23
+   "compress_mbps": 1.82,
+   "decompress_mbps": 223.12
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 75.88
+   "compress_mbps": 12.94,
+   "decompress_mbps": 74.21
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 75.9
+   "compress_mbps": 12.93,
+   "decompress_mbps": 75.13
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.85,
-   "decompress_mbps": 75.96
+   "compress_mbps": 12.91,
+   "decompress_mbps": 75.25
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 76.56
+   "compress_mbps": 11.56,
+   "decompress_mbps": 75.85
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.64,
-   "decompress_mbps": 76.5
+   "compress_mbps": 12.95,
+   "decompress_mbps": 76.26
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 76.48
+   "compress_mbps": 12.91,
+   "decompress_mbps": 76.33
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.47,
-   "decompress_mbps": 76.38
+   "compress_mbps": 12.74,
+   "decompress_mbps": 76.06
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 76.57
+   "compress_mbps": 4.22,
+   "decompress_mbps": 76.16
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.46,
-   "decompress_mbps": 76.55
+   "compress_mbps": 2.5,
+   "decompress_mbps": 75.94
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 40.66,
-   "decompress_mbps": 180.47
+   "compress_mbps": 42.19,
+   "decompress_mbps": 180.86
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 36.48,
-   "decompress_mbps": 195.0
+   "compress_mbps": 38.02,
+   "decompress_mbps": 197.28
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.53,
-   "decompress_mbps": 213.45
+   "compress_mbps": 34.95,
+   "decompress_mbps": 218.39
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.56,
-   "decompress_mbps": 218.22
+   "compress_mbps": 26.31,
+   "decompress_mbps": 220.15
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.22,
-   "decompress_mbps": 219.64
+   "compress_mbps": 25.84,
+   "decompress_mbps": 219.93
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.27,
-   "decompress_mbps": 223.75
+   "compress_mbps": 23.74,
+   "decompress_mbps": 225.76
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 19.57,
-   "decompress_mbps": 223.21
+   "compress_mbps": 20.02,
+   "decompress_mbps": 225.83
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.91,
-   "decompress_mbps": 231.11
+   "compress_mbps": 9.06,
+   "decompress_mbps": 233.13
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.75,
-   "decompress_mbps": 232.17
+   "compress_mbps": 1.78,
+   "decompress_mbps": 229.68
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 53.27,
-   "decompress_mbps": 195.05
+   "compress_mbps": 55.28,
+   "decompress_mbps": 196.77
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 50.2,
-   "decompress_mbps": 205.62
+   "compress_mbps": 51.28,
+   "decompress_mbps": 207.44
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 46.84,
-   "decompress_mbps": 211.89
+   "compress_mbps": 48.65,
+   "decompress_mbps": 214.79
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.72,
-   "decompress_mbps": 219.95
+   "compress_mbps": 39.82,
+   "decompress_mbps": 223.92
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 37.03,
-   "decompress_mbps": 225.91
+   "compress_mbps": 38.17,
+   "decompress_mbps": 228.53
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.44,
-   "decompress_mbps": 230.44
+   "compress_mbps": 33.07,
+   "decompress_mbps": 234.22
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 21.64,
-   "decompress_mbps": 229.74
+   "compress_mbps": 22.29,
+   "decompress_mbps": 234.38
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.75,
-   "decompress_mbps": 223.14
+   "compress_mbps": 6.84,
+   "decompress_mbps": 227.63
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.63,
-   "decompress_mbps": 231.46
+   "compress_mbps": 1.62,
+   "decompress_mbps": 234.51
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 54.1,
-   "decompress_mbps": 211.59
+   "compress_mbps": 55.61,
+   "decompress_mbps": 211.63
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 220.82
+   "compress_mbps": 51.0,
+   "decompress_mbps": 219.06
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 43.42,
-   "decompress_mbps": 229.54
+   "compress_mbps": 44.85,
+   "decompress_mbps": 230.36
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 213.18
+   "compress_mbps": 32.41,
+   "decompress_mbps": 213.32
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 210.22
+   "compress_mbps": 30.71,
+   "decompress_mbps": 211.57
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.19,
-   "decompress_mbps": 216.34
+   "compress_mbps": 27.9,
+   "decompress_mbps": 218.52
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 219.72
+   "compress_mbps": 21.2,
+   "decompress_mbps": 222.37
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.12,
-   "decompress_mbps": 223.44
+   "compress_mbps": 8.18,
+   "decompress_mbps": 225.68
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 1.26,
-   "decompress_mbps": 233.75
+   "compress_mbps": 1.25,
+   "decompress_mbps": 235.07
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 134.78,
-   "decompress_mbps": 616.51
+   "compress_mbps": 141.29,
+   "decompress_mbps": 623.5
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 113.36,
-   "decompress_mbps": 687.31
+   "compress_mbps": 120.28,
+   "decompress_mbps": 696.85
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 98.15,
-   "decompress_mbps": 762.76
+   "compress_mbps": 101.79,
+   "decompress_mbps": 771.67
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 85.08,
-   "decompress_mbps": 747.53
+   "compress_mbps": 88.28,
+   "decompress_mbps": 776.08
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 82.49,
-   "decompress_mbps": 846.2
+   "compress_mbps": 85.2,
+   "decompress_mbps": 851.06
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 74.86,
-   "decompress_mbps": 902.75
+   "compress_mbps": 78.16,
+   "decompress_mbps": 920.26
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 42.64,
-   "decompress_mbps": 922.1
+   "compress_mbps": 44.1,
+   "decompress_mbps": 930.05
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 903.63
+   "compress_mbps": 23.04,
+   "decompress_mbps": 923.97
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.89,
-   "decompress_mbps": 882.21
+   "compress_mbps": 0.88,
+   "decompress_mbps": 841.46
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 39.17,
-   "decompress_mbps": 131.95
+   "compress_mbps": 40.55,
+   "decompress_mbps": 135.89
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.14,
-   "decompress_mbps": 136.55
+   "compress_mbps": 38.55,
+   "decompress_mbps": 139.4
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 37.1,
-   "decompress_mbps": 140.32
+   "compress_mbps": 37.63,
+   "decompress_mbps": 144.01
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 30.38,
-   "decompress_mbps": 150.33
+   "compress_mbps": 31.26,
+   "decompress_mbps": 152.68
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 29.95,
-   "decompress_mbps": 155.7
+   "compress_mbps": 30.72,
+   "decompress_mbps": 157.45
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 28.79,
-   "decompress_mbps": 156.3
+   "compress_mbps": 29.45,
+   "decompress_mbps": 160.18
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 25.51,
-   "decompress_mbps": 155.89
+   "compress_mbps": 26.08,
+   "decompress_mbps": 161.35
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.82,
-   "decompress_mbps": 160.83
+   "compress_mbps": 6.81,
+   "decompress_mbps": 161.77
   },
   {
    "compressor": "native",
@@ -4415,7 +4415,7 @@
    "out_size": 3017696,
    "ratio": 0.4905,
    "compress_mbps": 2.28,
-   "decompress_mbps": 161.36
+   "decompress_mbps": 167.69
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 56.32,
-   "decompress_mbps": 236.5
+   "compress_mbps": 58.73,
+   "decompress_mbps": 225.04
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 52.83,
-   "decompress_mbps": 245.48
+   "compress_mbps": 54.88,
+   "decompress_mbps": 230.93
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 52.31,
-   "decompress_mbps": 253.06
+   "compress_mbps": 52.59,
+   "decompress_mbps": 237.11
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 47.42,
-   "decompress_mbps": 261.01
+   "compress_mbps": 47.94,
+   "decompress_mbps": 246.93
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 46.83,
-   "decompress_mbps": 264.95
+   "compress_mbps": 47.62,
+   "decompress_mbps": 243.17
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 47.21,
-   "decompress_mbps": 258.13
+   "compress_mbps": 47.9,
+   "decompress_mbps": 259.4
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 261.55
+   "compress_mbps": 45.17,
+   "decompress_mbps": 263.52
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.27,
-   "decompress_mbps": 273.33
+   "compress_mbps": 12.24,
+   "decompress_mbps": 276.62
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 2.7,
-   "decompress_mbps": 273.21
+   "compress_mbps": 2.73,
+   "decompress_mbps": 275.07
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 48.77,
-   "decompress_mbps": 231.07
+   "compress_mbps": 50.4,
+   "decompress_mbps": 231.87
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 43.47,
-   "decompress_mbps": 243.08
+   "compress_mbps": 44.62,
+   "decompress_mbps": 242.56
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 37.34,
-   "decompress_mbps": 276.1
+   "compress_mbps": 38.18,
+   "decompress_mbps": 278.92
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.55,
-   "decompress_mbps": 270.09
+   "compress_mbps": 27.05,
+   "decompress_mbps": 270.87
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.46,
-   "decompress_mbps": 284.01
+   "compress_mbps": 24.91,
+   "decompress_mbps": 285.58
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.11,
-   "decompress_mbps": 282.6
+   "compress_mbps": 20.56,
+   "decompress_mbps": 283.2
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 13.02,
-   "decompress_mbps": 301.65
+   "compress_mbps": 13.24,
+   "decompress_mbps": 305.97
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.56,
-   "decompress_mbps": 292.39
+   "compress_mbps": 7.63,
+   "decompress_mbps": 299.17
   },
   {
    "compressor": "native",
@@ -4594,7 +4594,7 @@
    "level": 9,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 1.14,
+   "compress_mbps": 1.15,
    "decompress_mbps": 289.62
   },
   {
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 71.7,
-   "decompress_mbps": 303.43
+   "compress_mbps": 73.66,
+   "decompress_mbps": 305.25
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 64.43,
-   "decompress_mbps": 322.75
+   "compress_mbps": 66.15,
+   "decompress_mbps": 325.74
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 58.1,
-   "decompress_mbps": 336.85
+   "compress_mbps": 60.41,
+   "decompress_mbps": 338.54
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 48.52,
-   "decompress_mbps": 344.17
+   "compress_mbps": 49.67,
+   "decompress_mbps": 346.6
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 47.04,
-   "decompress_mbps": 354.7
+   "compress_mbps": 48.02,
+   "decompress_mbps": 358.06
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 43.81,
-   "decompress_mbps": 361.6
+   "compress_mbps": 44.55,
+   "decompress_mbps": 368.3
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 32.57,
-   "decompress_mbps": 361.9
+   "compress_mbps": 33.04,
+   "decompress_mbps": 366.61
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.83,
-   "decompress_mbps": 336.69
+   "compress_mbps": 12.78,
+   "decompress_mbps": 340.66
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.64,
-   "decompress_mbps": 361.43
+   "decompress_mbps": 372.65
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 34.52,
-   "decompress_mbps": 134.13
+   "compress_mbps": 35.46,
+   "decompress_mbps": 135.52
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 134.68
+   "compress_mbps": 33.51,
+   "decompress_mbps": 135.93
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 141.89
+   "compress_mbps": 31.72,
+   "decompress_mbps": 143.21
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.83,
-   "decompress_mbps": 144.02
+   "compress_mbps": 26.49,
+   "decompress_mbps": 143.69
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 141.78
+   "compress_mbps": 26.17,
+   "decompress_mbps": 145.36
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.76,
-   "decompress_mbps": 143.17
+   "compress_mbps": 25.4,
+   "decompress_mbps": 143.31
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 23.49,
-   "decompress_mbps": 141.88
+   "compress_mbps": 24.23,
+   "decompress_mbps": 143.33
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.26,
-   "decompress_mbps": 145.86
+   "compress_mbps": 6.21,
+   "decompress_mbps": 147.13
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.6,
-   "decompress_mbps": 143.38
+   "compress_mbps": 2.57,
+   "decompress_mbps": 143.72
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 53.09,
-   "decompress_mbps": 229.8
+   "compress_mbps": 54.24,
+   "decompress_mbps": 231.99
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 48.01,
-   "decompress_mbps": 248.49
+   "compress_mbps": 49.43,
+   "decompress_mbps": 251.46
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 44.97,
-   "decompress_mbps": 267.59
+   "compress_mbps": 46.39,
+   "decompress_mbps": 271.43
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 36.65,
-   "decompress_mbps": 274.82
+   "compress_mbps": 37.46,
+   "decompress_mbps": 277.68
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 278.7
+   "compress_mbps": 36.04,
+   "decompress_mbps": 283.77
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 286.61
+   "compress_mbps": 32.45,
+   "decompress_mbps": 291.37
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.54,
-   "decompress_mbps": 287.26
+   "compress_mbps": 25.03,
+   "decompress_mbps": 292.15
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.44,
-   "decompress_mbps": 288.01
+   "compress_mbps": 11.51,
+   "decompress_mbps": 292.29
   },
   {
    "compressor": "native",
@@ -4865,7 +4865,7 @@
    "out_size": 11638957,
    "ratio": 0.2807,
    "compress_mbps": 1.6,
-   "decompress_mbps": 290.11
+   "decompress_mbps": 293.08
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 34.91,
-   "decompress_mbps": 128.68
+   "compress_mbps": 35.1,
+   "decompress_mbps": 129.86
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 35.06,
-   "decompress_mbps": 129.81
+   "compress_mbps": 35.23,
+   "decompress_mbps": 129.98
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 131.85
+   "compress_mbps": 35.26,
+   "decompress_mbps": 132.95
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 32.91,
-   "decompress_mbps": 119.71
+   "compress_mbps": 33.3,
+   "decompress_mbps": 121.43
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 32.98,
-   "decompress_mbps": 121.67
+   "compress_mbps": 33.1,
+   "decompress_mbps": 122.39
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 32.25,
-   "decompress_mbps": 122.06
+   "compress_mbps": 33.26,
+   "decompress_mbps": 122.55
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 122.35
+   "compress_mbps": 33.23,
+   "decompress_mbps": 123.91
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.74,
-   "decompress_mbps": 123.53
+   "compress_mbps": 4.7,
+   "decompress_mbps": 125.24
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.42,
-   "decompress_mbps": 124.58
+   "compress_mbps": 3.52,
+   "decompress_mbps": 125.06
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 106.02,
-   "decompress_mbps": 424.57
+   "compress_mbps": 111.85,
+   "decompress_mbps": 429.63
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 95.42,
-   "decompress_mbps": 481.81
+   "compress_mbps": 98.62,
+   "decompress_mbps": 488.99
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 84.48,
-   "decompress_mbps": 523.46
+   "compress_mbps": 86.21,
+   "decompress_mbps": 585.23
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 68.78,
-   "decompress_mbps": 521.72
+   "compress_mbps": 69.99,
+   "decompress_mbps": 577.41
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 66.0,
-   "decompress_mbps": 569.86
+   "compress_mbps": 67.92,
+   "decompress_mbps": 634.07
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 60.6,
-   "decompress_mbps": 629.92
+   "compress_mbps": 62.24,
+   "decompress_mbps": 682.88
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 40.71,
-   "decompress_mbps": 682.83
+   "compress_mbps": 41.8,
+   "decompress_mbps": 696.04
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.49,
-   "decompress_mbps": 610.52
+   "compress_mbps": 20.59,
+   "decompress_mbps": 703.78
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 1.17,
-   "decompress_mbps": 667.34
+   "decompress_mbps": 689.18
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR replaces the two panic-checked `Array.set!` writes in the matcher's interior hash-chain insertion loop (`updateHashesFast`, ~18-24% of level-1 compress per `perf`) with proven-bounds `Array.set`, dropping the redundant bounds-check branches. The bucket index `hsh < hashTable.size` and the chain mask `(pos+j) &&& 0x7FFF < chainWinSize ≤ prev.size` are already proven, so the checks `set!` performs are wasted work. Output is byte-identical; the matcher is shared, so every level benefits.

`updateHashesGuarded` gains one runtime `min chainWinSize data.size ≤ prev.size` check (the same guard `chainWalkGuardedPacked` already carries — always true for the production chain ring, so it is defensive, not hot-path branching) to establish the `prev`-mask bound, dispatching to the new `updateHashesFastU`; it falls back to the proven-bounds `set!` walk otherwise. `updateHashesFastU_eq` proves the new walk equal to `updateHashesFast` (the in-bounds `set` collapses to `set!` at each step via `Array.set!_eq_setIfInBounds`), and `updateHashesGuarded_eq` routes through it, so the unified matcher correctness chain is unchanged. Zero `sorry`s; all conformance and roundtrip tests pass.

Measured on `chungus` (same-worktree before/after, core-pinned). Full-corpus geomean compress, output-neutral (`max |Δratio| = 0`):

| level | Silesia | Canterbury |
|---|---|---|
| 1 | +1.9% | +1.3% |
| 2 | +1.3% | +0.8% |
| 3 | +1.8% | +0.7% |
| 4-6 | ~neutral | ~neutral |
| 7-9 (barely touch the loop) | ~1.00x | ~1.00x |

The win concentrates at the matcher-heavy low levels, as expected; a controlled paired `perf stat -r 5` on individual files corroborates (alice29 -2.3%, kennedy.xls -3.9%, dickens -3.1% wall-clock on a level-1 compress loop). The dashboard is refreshed in-PR (native speed rows + the six speed-derived SVGs; ratios and ratio heatmaps are unchanged since the change is output-neutral).

This is the first of the matcher de-boxing levers found by profiling level-1 compress (which is matcher-bound, ~52%, not emit-bound). The sibling lever — USize-ifying `chainWalkPacked` — is filed separately as #2714 (it needs a `prev`/`hashTable` content-bound invariant, a heavier proof).

Closes #2715.

🤖 Prepared with Claude Code