### PR TITLE
perf(bench): add enwik8 large-text corpus + zopfli ceiling for L9 ratio evaluation

### DIFF
--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -143,6 +143,13 @@ def levels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9]
 def libdeflateLevels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 def reps : Nat := 5
 
+/-- A corpus whose total bytes exceed this runs a single timing pass instead of
+    median-of-`reps` (variance is low on big files, and `reps` passes over a
+    large corpus dominate the matrix wall-clock). Size-based rather than a name
+    list so any large corpus (Silesia ~200 MB, the enwik8 ~20 MB slice, …) is
+    detected automatically. -/
+def bigCorpusThreshold : Nat := 16 * 1024 * 1024
+
 /-- Run one compressor over a list of `(pattern, bytes)` workloads × levels,
     timing compress (and optionally decompress on a canonical raw-deflate
     stream). The size of each row is the workload's byte length. -/
@@ -249,15 +256,18 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
   let mut rows : List Row := []
   for (corpus, files) in corpora do
     -- Every corpus is timed at all 9 levels (so the speed-vs-ratio scatter shows
-    -- the full level sweep). Large corpora (Silesia, ~200 MB) use a single timing
-    -- pass — variance is low on big files — to keep the run tractable; small
-    -- corpora (Canterbury) keep the median-of-`reps` matrix.
+    -- the full level sweep). Large corpora (Silesia ~200 MB, enwik8 slice ~20 MB)
+    -- use a single timing pass — variance is low on big files — to keep the run
+    -- tractable; small corpora (Canterbury) keep the median-of-`reps` matrix. The
+    -- threshold is size-based, not a name list, so a new large corpus slots in
+    -- with no code change.
     --
     -- zopfli is intentionally not benchmarked here: it is compress-only and
     -- ~100× slower than zlib (default iteration count), so even at one
     -- level/rep it dominated the wall-clock of the whole matrix. Its FFI binding
     -- (`zopfliCompress`) is kept for ad-hoc ratio-ceiling checks.
-    let big := corpus == "silesia"
+    let totalBytes := files.foldl (fun a (_, b) => a + b.size) 0
+    let big := totalBytes > bigCorpusThreshold
     let lvls := levelOverride.getD levels
     let rps  := if big then 1 else reps
     IO.eprintln s!"Running {corpus} corpus matrix ({files.length} files, levels {lvls}, reps {rps})…"
@@ -301,17 +311,56 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
   IO.FS.writeFile outPath json
   IO.eprintln s!"Wrote {rows.length} rows → {outPath}"
 
-/-- One-shot zopfli ratio-ceiling run over every corpus. zopfli is compress-only,
-    level-less, and ~100× slower than zlib (default iteration count), so it is
-    deliberately NOT part of the routine `runReport` matrix. This writes a FROZEN
-    snapshot of the best-achievable ratio per file; the dashboard overlays it
-    (see `bench/plot.py`) without ever recomputing it. Do not regenerate unless
-    the corpora themselves change — see `bench/README.md`. -/
-def runZopfliCeiling (outPath : String) : IO Unit := do
-  IO.eprintln "Running ONE-TIME zopfli ratio ceiling over all corpora (slow — frozen artifact)…"
+/-- Existing zopfli-ceiling row objects from a prior frozen file, as raw
+    `    {...}` JSON strings, with any rows for `dropCorpus` removed. Each row in
+    the file is one line `{"compressor": …}` (optionally trailing-comma); we keep
+    them verbatim so a per-corpus regeneration never perturbs the other corpora's
+    deterministic rows. Missing file ⇒ no rows. -/
+def existingCeilingRows (path : String) (dropCorpus : String) : IO (List String) := do
+  unless ← System.FilePath.pathExists path do return []
+  let text ← IO.FS.readFile path
+  let dropTag := s!"\"pattern\": \"{dropCorpus}/"
+  let mut out : List String := []
+  for line in text.splitOn "\n" do
+    let t := line.trim
+    if t.startsWith "{\"compressor\"" then
+      let obj := if t.endsWith "," then t.dropRight 1 else t
+      unless (obj.splitOn dropTag).length > 1 do
+        out := ("    " ++ obj) :: out
+  return out.reverse
+
+/-- One-shot zopfli ratio-ceiling run. zopfli is compress-only, level-less, and
+    ~100× slower than zlib (default iteration count), so it is deliberately NOT
+    part of the routine `runReport` matrix. This writes a FROZEN snapshot of the
+    best-achievable ratio per file; the dashboard overlays it (see `bench/plot.py`)
+    without ever recomputing it.
+
+    `onlyCorpus` restricts the run to a single corpus and **merges** its fresh
+    rows into the existing `outPath`, keeping every other corpus's rows verbatim.
+    This is how a newly-added large corpus (e.g. the enwik8 slice) joins the
+    ceiling without paying to re-run zopfli on the ~200 MB Silesia files — those
+    take the better part of an hour and their ratios are already frozen. With
+    `onlyCorpus = none` the whole file is regenerated from scratch.
+    Regenerate only when the corpora themselves change — see `bench/README.md`. -/
+def runZopfliCeiling (outPath : String) (onlyCorpus : Option String := none) : IO Unit := do
+  match onlyCorpus with
+  | some c => IO.eprintln s!"Running zopfli ratio ceiling for corpus '{c}' only, merging into {outPath} (slow)…"
+  | none   => IO.eprintln "Running ONE-TIME zopfli ratio ceiling over all corpora (slow — frozen artifact)…"
   let corpora ← loadCorpora
-  if corpora.isEmpty then
-    IO.eprintln "  no corpora found — run bench/fetch_corpora.sh"
+  let corpora := match onlyCorpus with
+    | some c => corpora.filter (fun (e : String × List (String × ByteArray)) => e.1 == c)
+    | none   => corpora
+  -- Fail closed in merge mode: if the requested corpus is not materialized we
+  -- would otherwise drop its existing frozen rows and write zero replacements,
+  -- silently corrupting the ceiling. Abort instead (the file is untouched).
+  match onlyCorpus with
+  | some c =>
+    if corpora.isEmpty then
+      throw (IO.userError s!"corpus '{c}' not found under {corporaDir} — run bench/fetch_corpora.sh; \
+refusing to overwrite {outPath} (would drop its existing rows)")
+  | none =>
+    if corpora.isEmpty then
+      IO.eprintln "  no corpora found — run bench/fetch_corpora.sh"
   let mut rows : List Row := []
   for (corpus, files) in corpora do
     IO.eprintln s!"  zopfli {corpus} ({files.length} files)…"
@@ -319,11 +368,15 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
     -- compress_mbps column is an artifact, not a benchmark).
     let cz ← runWorkloads "zopfli" files zopfliCompress none (theLevels := [6]) (theReps := 1)
     rows := rows ++ cz
+  -- In merge mode, prepend the preserved rows for the other corpora (verbatim).
+  let keptRows ← match onlyCorpus with
+    | some c => existingCeilingRows outPath c
+    | none   => pure []
   let date ← shell "date" ["-u", "+%Y-%m-%dT%H:%M:%SZ"]
   let machine ← shell "uname" ["-mns"]
   let commit ← shell "git" ["rev-parse", "--short", "HEAD"]
   let toolchain ← shell "cat" ["lean-toolchain"]
-  let body := String.intercalate ",\n" (rows.map Row.toJson)
+  let body := String.intercalate ",\n" (keptRows ++ rows.map Row.toJson)
   let json :=
     "{\n" ++
     "  \"meta\": {\n" ++
@@ -342,7 +395,7 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
   if let some parent := (System.FilePath.mk outPath).parent then
     IO.FS.createDirAll parent
   IO.FS.writeFile outPath json
-  IO.eprintln s!"Wrote {rows.length} zopfli rows → {outPath}"
+  IO.eprintln s!"Wrote {rows.length} fresh + {keptRows.length} preserved zopfli rows → {outPath}"
 
 /-- Decode `ref`, optionally pre-sizing the output to `hint` (`0` = no hint).
     `Inflate.inflate` is the shipped production decode path (tree-free).
@@ -483,6 +536,7 @@ def main (args : List String) : IO Unit := do
   | ["--decode-density", out, streamsDir] => runDecodeDensity out streamsDir
   | ["--dump-payloads", dir] => dumpPayloads dir
   | ["--zopfli-ceiling", out] => runZopfliCeiling out
+  | ["--zopfli-ceiling", out, corpus] => runZopfliCeiling out (onlyCorpus := some corpus)
   | ["--native-only", out] => runReport out (nativeOnly := true)
   | ["--native-only", out, lvlCsv] =>
     -- e.g. "1,2,3,4,5,6,7,8" to skip the slow optimal-parse L9 when a Lean change

--- a/bench/README.md
+++ b/bench/README.md
@@ -58,6 +58,11 @@ generated once and overlaid on the ratio graphs by [`plot.py`](plot.py):
 # One-time only — do NOT run on every regeneration (very slow). Re-run solely
 # if the corpora themselves change:
 lake env .lake/build/bin/bench-report --zopfli-ceiling bench/results/zopfli-ceiling.json
+
+# Or regenerate just ONE corpus and merge it into the frozen file, keeping every
+# other corpus's rows verbatim (how a newly-added corpus joins the ceiling without
+# re-running zopfli on the slow ~200 MB Silesia files):
+lake env .lake/build/bin/bench-report --zopfli-ceiling bench/results/zopfli-ceiling.json enwik8_20m
 ```
 
 Its `ratio`/`out_size` are deterministic (the meaningful signal); its single-rep
@@ -85,6 +90,17 @@ files land).
   SHA-256-verified); its rows slot into the same per-level charts automatically.
   Because it is ~70× larger than Canterbury, it runs a **reduced matrix** —
   a single timing pass — so the regeneration stays tractable.
+- **enwik8 corpus** (`enwik8_20m`, 1 file, 20 MB: the first 20 MB of
+  [enwik8](http://mattmahoney.net/dc/textdata.html), the Large Text Compression
+  Benchmark / Hutter Prize corpus — homogeneous English Wikipedia prose). This is
+  the large pure-text regime zopfli was designed for and where near-optimal
+  parsing pays off most, so it is the reference for "is L9 strictly better ratio
+  than libdeflate, and how close to zopfli". Fetched on demand into a gitignored
+  cache (`fetch_corpora.sh enwik8`, official zip, SHA-256-verified). zopfli at
+  default iterations is ~100× slower than zlib, so the **first 20 MB slice** (not
+  the full 100 MB) is the pinned input — deterministic and SHA-pinned, recorded in
+  the corpus name `enwik8_20m` — which keeps the one-time zopfli ceiling pass
+  tractable. Like Silesia it runs the **reduced matrix** (single timing pass).
 
 The synthetic `prng` pattern used to be the only incompressible workload; its
 replacement is **real** poorly-compressible files in the corpora (Silesia `sao`,
@@ -128,6 +144,16 @@ complements give precise numbers and per-file detail:
 ![silesia summary table](graphs/silesia_summary.svg)
 ![silesia ratio vs zlib per file](graphs/silesia_ratio_heatmap.svg)
 ![silesia compress speed vs zlib per file](graphs/silesia_compress_heatmap.svg)
+
+### enwik8 corpus (`enwik8_20m`, 20 MB large-text slice, levels 1–9; libdeflate 1–12)
+
+The zopfli ratio ceiling is overlaid on the Pareto and summary — this is the
+large pure-prose regime that judges L9 against zopfli on its home turf.
+
+![enwik8 compression speed vs ratio](graphs/enwik8_20m_compress_pareto.svg)
+![enwik8 summary table](graphs/enwik8_20m_summary.svg)
+![enwik8 ratio vs zlib per file](graphs/enwik8_20m_ratio_heatmap.svg)
+![enwik8 compress speed vs zlib per file](graphs/enwik8_20m_compress_heatmap.svg)
 
 ## Decoding (decode-density)
 

--- a/bench/fetch_corpora.sh
+++ b/bench/fetch_corpora.sh
@@ -6,9 +6,10 @@
 #
 # Canterbury (~2.8 MB, 11 files) is committed to the repo, so CI needs no
 # network; running this script is only needed to re-materialize or update it.
-# Larger corpora (e.g. Silesia) are NOT committed and are fetched on demand
-# into this gitignored cache — see bench/.gitignore. Sources (PLAN.md §D):
+# Larger corpora (e.g. Silesia, enwik8) are NOT committed and are fetched on
+# demand into this gitignored cache — see bench/.gitignore. Sources (PLAN.md §D):
 #   Canterbury: https://corpus.canterbury.ac.nz/
+#   enwik8:     http://mattmahoney.net/dc/ (Large Text Compression Benchmark)
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 
@@ -83,14 +84,52 @@ fetch_silesia() {
   echo "[silesia] ok — 12 files in $dest verified against recorded SHA-256"
 }
 
+# enwik8 (first 100 MB of English Wikipedia, the Large Text Compression
+# Benchmark / Hutter Prize corpus) — the canonical large pure-prose file zopfli
+# was designed for. NOT committed (gitignored). We fetch the official zip, unzip,
+# and slice the deterministic **first 20 MB** as the corpus workload: zopfli at
+# default iterations is ~100x slower than zlib, so the full 100 MB one-time
+# ceiling run is impractical, while 20 MB of homogeneous prose is plenty
+# representative for the ratio question and keeps the one-time zopfli pass quick.
+# The slice (not the 100 MB original) is what is SHA-256-pinned and benchmarked,
+# hence the corpus name `enwik8_20m`.
+ENWIK8_URL="http://mattmahoney.net/dc/enwik8.zip"
+ENWIK8_SLICE_BYTES=20000000
+# SHA-256 of the unzipped 100 MB original (sanity-check on the download) and of
+# the first-20 MB slice (the pinned benchmark input).
+ENWIK8_FULL_SHA256="2b49720ec4d78c3c9fabaee6e4179a5e997302b3a70029f30f2d582218c024a8"
+ENWIK8_SLICE_SHA256="ab409e5aee762114c7a3336bbb1093cd64c4a3d81fd3e67510d61d3151c36091"
+
+fetch_enwik8() {
+  local dest="$CORPORA_DIR/enwik8_20m"
+  mkdir -p "$dest"
+  if [ -f "$dest/enwik8" ]; then
+    echo "[enwik8_20m] slice present — verifying"
+  else
+    echo "[enwik8_20m] fetching $ENWIK8_URL"
+    local tmp
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    curl -sSL --fail --max-time 600 -o "$tmp/enwik8.zip" "$ENWIK8_URL"
+    python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+      "$tmp/enwik8.zip" "$tmp"
+    # Verify the 100 MB original before slicing, then take the first 20 MB.
+    echo "$ENWIK8_FULL_SHA256  $tmp/enwik8" | sha256sum --check --quiet
+    head -c "$ENWIK8_SLICE_BYTES" "$tmp/enwik8" > "$dest/enwik8"
+  fi
+  echo "$ENWIK8_SLICE_SHA256  $dest/enwik8" | sha256sum --check --quiet
+  echo "[enwik8_20m] ok — first ${ENWIK8_SLICE_BYTES}-byte slice in $dest verified against recorded SHA-256"
+}
+
 main() {
   mkdir -p "$CORPORA_DIR"
   local which="${1:-all}"
   case "$which" in
     canterbury) fetch_canterbury ;;
     silesia)    fetch_silesia ;;
-    all)        fetch_canterbury; fetch_silesia ;;
-    *) echo "unknown corpus: $which (known: canterbury, silesia, all)" >&2; exit 2 ;;
+    enwik8)     fetch_enwik8 ;;
+    all)        fetch_canterbury; fetch_silesia; fetch_enwik8 ;;
+    *) echo "unknown corpus: $which (known: canterbury, silesia, enwik8, all)" >&2; exit 2 ;;
   esac
 }
 

--- a/bench/graphs/enwik8_20m_compress_heatmap.svg
+++ b/bench/graphs/enwik8_20m_compress_heatmap.svg
@@ -1,0 +1,2070 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="259.2pt" viewBox="0 0 576 259.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 259.2 
+L 576 259.2 
+L 576 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 83.0775 208.010825 
+L 501.694456 208.010825 
+L 501.694456 43.9155 
+L 83.0775 43.9155 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p9831dcbffc)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAkYAAADkCAYAAAB9luugAAADzUlEQVR4nO3YQRHCQAAEwYQKeERcdCACD/EBRZF8xsPdo1vBPqd2/e7PcwEAYLmNHgAAMAthBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBAAQYQQAEGEEABBhBACQ7fE+Rm8AAJiCxwgAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDr5/c6R48AAJiBxwgAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDCCAAgwggAIMIIACDb/T96AgDAHDxGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAEUYAABFGAAARRgAAuQABQAsXalz4xQAAAABJRU5ErkJggg==" id="image377f5eb19c" transform="scale(1 -1) translate(0 -164.16)" x="83.0775" y="-43.850825" width="419.04" height="164.16"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mc4b5247ee8" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc4b5247ee8" x="292.385978" y="208.010825" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- enwik8 -->
+      <g transform="translate(271.071128 239.447551) rotate(-45) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-65"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(61.523438 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(124.902344 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(206.689453 0)"/>
+       <use xlink:href="#DejaVuSans-6b" transform="translate(234.472656 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(292.382812 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_2">
+      <defs>
+       <path id="m07abd419dc" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m07abd419dc" x="83.0775" y="64.427416" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- lean-zip (native) -->
+      <g transform="translate(10.8 67.466791) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6c"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+       <use xlink:href="#DejaVuSans-2d" transform="translate(213.964844 0)"/>
+       <use xlink:href="#DejaVuSans-7a" transform="translate(250.048828 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(302.539062 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(330.322266 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(393.798828 0)"/>
+       <use xlink:href="#DejaVuSans-28" transform="translate(425.585938 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(464.599609 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(527.978516 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(589.257812 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(628.466797 0)"/>
+       <use xlink:href="#DejaVuSans-76" transform="translate(656.25 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(715.429688 0)"/>
+       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m07abd419dc" x="83.0775" y="105.451247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- miniz_oxide -->
+      <g transform="translate(28.9675 108.490622) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+       <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+       <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m07abd419dc" x="83.0775" y="146.475078" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- libdeflate -->
+      <g transform="translate(38.5525 149.514453) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6c"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+       <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(119.042969 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(182.519531 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(244.042969 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(279.248047 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(307.03125 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(368.310547 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m07abd419dc" x="83.0775" y="187.498909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- zopfli -->
+      <g transform="translate(54.64375 190.538284) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-7a"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 83.0775 208.010825 
+L 83.0775 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 501.694456 208.010825 
+L 501.694456 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 83.0775 208.010825 
+L 501.694456 208.010825 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 83.0775 43.9155 
+L 501.694456 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_6">
+    <!-- -6 -->
+    <g transform="translate(289.145627 66.221009) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- +5 -->
+    <g transform="translate(287.594767 107.24484) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- +218 -->
+    <g transform="translate(283.459142 148.268672) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- -97 -->
+    <g transform="translate(287.077814 189.292503) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 510.461303 208.010825 
+L 518.66607 208.010825 
+L 518.66607 43.9155 
+L 510.461303 43.9155 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAsAAADkCAYAAABOvt5xAAABRUlEQVR4nO2ZQQ6DMAwEHRK+0p/zSSBxv+A5bGVDe16tJmNDo7Yd9nELfsa2RaN5wqOnwKgYbq3Fw2OoMJ4fjmvWegbjbp2EUXMOjL7H3UmZCUbBofSR44C6oRCMLckBZctvHTSb7ICo2XRD2eO3E4ahY2YYstcX2w2yz2xFs3jWPSnEBrhtw2akjjUXxJB5Rnf+mp5JM7htp9kNHUaThTvxrMNIYkMWbn3PgPH8oSTZZxJ28iuE+4qHFwm7qZqn3wADHZAwV1TnNuPhuYDnF6gruM8e/k8AMrNmQxgq5nupJqi0oRu3Knwv8JKB6urZ0E0Q7fOMF0MM2AzCk3lGzSB8geoBZvICdWiRLp06MkHlUFCzivkEabZIk3lGzeFsTeYTvcxl+6y0kYIZeiYYObYOfQE5wUDhBdwJMR4f/nv+Tbig5y+mwzk7SmmQEgAAAABJRU5ErkJggg==" id="image4a974c37b5" transform="scale(1 -1) translate(0 -164.16)" x="510.48" y="-43.92" width="7.92" height="164.16"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_6">
+      <defs>
+       <path id="m93828e65e2" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m93828e65e2" x="518.66607" y="201.352644" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- −2 -->
+      <g transform="translate(525.66607 205.151862) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m93828e65e2" x="518.66607" y="163.657903" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −1 -->
+      <g transform="translate(525.66607 167.457122) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m93828e65e2" x="518.66607" y="125.963162" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0 -->
+      <g transform="translate(525.66607 129.762381) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m93828e65e2" x="518.66607" y="88.268422" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1 -->
+      <g transform="translate(525.66607 92.06764) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m93828e65e2" x="518.66607" y="50.573681" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 2 -->
+      <g transform="translate(525.66607 54.3729) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- % vs zlib (higher=faster) -->
+     <g transform="translate(552.006695 188.267069) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-25" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-25"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(95.019531 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(126.806641 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(185.986328 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(238.085938 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(269.873047 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(322.363281 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(350.146484 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(377.929688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(441.40625 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(473.193359 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(512.207031 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(575.585938 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(603.369141 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(666.845703 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(730.224609 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(791.748047 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(832.861328 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(916.650391 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(951.855469 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1013.134766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1065.234375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1104.443359 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1165.966797 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1207.080078 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 510.461303 208.010825 
+L 514.563687 208.010825 
+L 518.66607 208.010825 
+L 518.66607 43.9155 
+L 514.563687 43.9155 
+L 510.461303 43.9155 
+L 510.461303 208.010825 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_16">
+   <!-- Compression speed vs zlib  (enwik8_20m, level 6, relative to zlib) -->
+   <g transform="translate(66.717187 14.302125) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-77" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-43"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(246.289062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(317.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(367.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(435.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(494.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(554.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(588.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(728.222656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(763.037109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(822.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(894.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(961.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1029.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1101.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1136.181641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1201.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1260.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(1295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1353.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1388.183594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(1422.460938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1494.042969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1528.857422 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1563.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1609.375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1677.197266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(1748.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1840.771484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(1875.048828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(1941.552734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(2011.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(2061.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(2130.712891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2200.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2304.492188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2342.480469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2377.294922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2411.572266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2479.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2544.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2612.402344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2646.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2681.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2751.074219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2789.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2823.876953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2873.193359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2941.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2975.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3042.773438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3090.576172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3124.853516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3190.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3257.861328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3292.675781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3340.478516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3409.179688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(3443.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3502.197266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3536.474609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(3570.751953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3642.333984 0)"/>
+   </g>
+  </g>
+  <g id="text_17">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(10.611875 257.904) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9831dcbffc">
+   <rect x="83.0775" y="43.9155" width="418.616956" height="164.095325"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/enwik8_20m_compress_pareto.svg
+++ b/bench/graphs/enwik8_20m_compress_pareto.svg
@@ -1,0 +1,2802 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="468pt" viewBox="0 0 648 468" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 468 
+L 648 468 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 49.078125 412.80375 
+L 637.2 412.80375 
+L 637.2 48.583125 
+L 49.078125 48.583125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 102.583121 412.80375 
+L 102.583121 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m8d6f28975c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8d6f28975c" x="102.583121" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.36 -->
+      <g transform="translate(91.450308 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 181.324837 412.80375 
+L 181.324837 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="181.324837" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.38 -->
+      <g transform="translate(170.192024 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 260.066552 412.80375 
+L 260.066552 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="260.066552" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.40 -->
+      <g transform="translate(248.93374 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 338.808268 412.80375 
+L 338.808268 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="338.808268" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.42 -->
+      <g transform="translate(327.675456 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 417.549984 412.80375 
+L 417.549984 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="417.549984" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.44 -->
+      <g transform="translate(406.417171 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 496.2917 412.80375 
+L 496.2917 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="496.2917" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.46 -->
+      <g transform="translate(485.158887 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 575.033415 412.80375 
+L 575.033415 48.583125 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8d6f28975c" x="575.033415" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.48 -->
+      <g transform="translate(563.900603 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- compression ratio   (compressed / original  —  ← smaller is better) -->
+     <g transform="translate(177.710156 441.080312) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2190" d="M 313 1866 
+L 313 2147 
+L 1541 3375 
+L 1916 3000 
+L 1188 2272 
+L 4997 2272 
+L 4997 1741 
+L 1188 1741 
+L 1916 1013 
+L 1541 638 
+L 313 1866 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(706.880859 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(768.160156 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(807.369141 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(835.152344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(896.333984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(928.121094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(959.908203 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(991.695312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1030.708984 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1085.689453 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1146.871094 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1244.283203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1307.759766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1346.623047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1408.146484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1460.246094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1512.345703 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1573.869141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1637.345703 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1669.132812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1702.824219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1734.611328 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1795.792969 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1836.90625 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1864.689453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1928.166016 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1955.949219 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2019.328125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2080.607422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2108.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2140.177734 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(2171.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2271.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2303.751953 0)"/>
+      <use xlink:href="#DejaVuSans-2190" transform="translate(2335.539062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2419.328125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2451.115234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(2503.214844 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2600.626953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2661.90625 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2689.689453 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2717.472656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2778.996094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2820.109375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2851.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2879.679688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2931.779297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2963.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3027.042969 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3088.566406 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3127.775391 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3166.984375 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(3228.507812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3269.621094 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_15">
+      <path d="M 49.078125 383.887411 
+L 637.2 383.887411 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="m178df041ab" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m178df041ab" x="49.078125" y="383.887411" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(24.478125 387.686629) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_17">
+      <path d="M 49.078125 248.818199 
+L 637.2 248.818199 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m178df041ab" x="49.078125" y="248.818199" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(24.478125 252.617418) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_19">
+      <path d="M 49.078125 113.748987 
+L 637.2 113.748987 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m178df041ab" x="49.078125" y="113.748987" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(24.478125 117.548206) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_21">
+      <path d="M 49.078125 404.809896 
+L 637.2 404.809896 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <defs>
+       <path id="mab5aacf89e" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="404.809896" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_23">
+      <path d="M 49.078125 396.97697 
+L 637.2 396.97697 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="396.97697" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_25">
+      <path d="M 49.078125 390.067839 
+L 637.2 390.067839 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="390.067839" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_27">
+      <path d="M 49.078125 343.227526 
+L 637.2 343.227526 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="343.227526" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_29">
+      <path d="M 49.078125 319.443019 
+L 637.2 319.443019 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="319.443019" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_31">
+      <path d="M 49.078125 302.567642 
+L 637.2 302.567642 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="302.567642" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_33">
+      <path d="M 49.078125 289.478083 
+L 637.2 289.478083 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="289.478083" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_35">
+      <path d="M 49.078125 278.783135 
+L 637.2 278.783135 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="278.783135" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_37">
+      <path d="M 49.078125 269.740685 
+L 637.2 269.740685 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="269.740685" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_39">
+      <path d="M 49.078125 261.907758 
+L 637.2 261.907758 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="261.907758" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_41">
+      <path d="M 49.078125 254.998627 
+L 637.2 254.998627 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="254.998627" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_43">
+      <path d="M 49.078125 208.158315 
+L 637.2 208.158315 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="208.158315" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_45">
+      <path d="M 49.078125 184.373807 
+L 637.2 184.373807 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="184.373807" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_47">
+      <path d="M 49.078125 167.49843 
+L 637.2 167.49843 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="167.49843" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_49">
+      <path d="M 49.078125 154.408871 
+L 637.2 154.408871 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="154.408871" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_51">
+      <path d="M 49.078125 143.713923 
+L 637.2 143.713923 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="143.713923" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_53">
+      <path d="M 49.078125 134.671473 
+L 637.2 134.671473 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="134.671473" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_55">
+      <path d="M 49.078125 126.838546 
+L 637.2 126.838546 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="126.838546" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_57">
+      <path d="M 49.078125 119.929415 
+L 637.2 119.929415 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="119.929415" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_59">
+      <path d="M 49.078125 73.089103 
+L 637.2 73.089103 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="73.089103" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_61">
+      <path d="M 49.078125 49.304595 
+L 637.2 49.304595 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#mab5aacf89e" x="49.078125" y="49.304595" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!-- compression speed   (MB/s, log) -->
+     <g transform="translate(18.398438 310.591094) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(717.867188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(781.34375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(842.867188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(904.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(967.867188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(999.654297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1031.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1063.228516 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(1102.242188 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(1188.521484 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1257.125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.816406 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1342.916016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1374.703125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1406.490234 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1434.273438 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1495.455078 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1558.931641 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 49.078125 412.80375 
+L 49.078125 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 637.2 412.80375 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 49.078125 412.80375 
+L 637.2 412.80375 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 49.078125 48.583125 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_13">
+    <!-- L1 -->
+    <g style="fill: #d62728" transform="translate(189.474505 164.345667) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-4c" d="M 588 4666 
+L 1791 4666 
+L 1791 909 
+L 3903 909 
+L 3903 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- L9 -->
+    <g style="fill: #d62728" transform="translate(91.441069 335.645504) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- ↖ fast &amp; small = best -->
+    <g style="fill: #2a8a3a" transform="translate(57.899953 61.644872) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-Bold-2196" d="M 872 3850 
+L 1181 4159 
+L 2919 4159 
+L 2919 3519 
+L 2044 3519 
+L 4606 956 
+L 4075 425 
+L 1513 2988 
+L 1513 2113 
+L 872 2113 
+L 872 3850 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-26" d="M 2497 3097 
+L 3775 1691 
+Q 3941 1909 4027 2181 
+Q 4113 2453 4128 2797 
+L 5100 2797 
+Q 5053 2228 4879 1784 
+Q 4706 1341 4397 1006 
+L 5313 0 
+L 3988 0 
+L 3681 341 
+Q 3353 122 2990 15 
+Q 2628 -91 2222 -91 
+Q 1400 -91 892 342 
+Q 384 775 384 1459 
+Q 384 1916 607 2267 
+Q 831 2619 1338 2950 
+Q 1206 3116 1143 3281 
+Q 1081 3447 1081 3628 
+Q 1081 4138 1478 4444 
+Q 1875 4750 2534 4750 
+Q 2819 4750 3126 4704 
+Q 3434 4659 3769 4569 
+L 3769 3700 
+Q 3475 3850 3212 3922 
+Q 2950 3994 2700 3994 
+Q 2459 3994 2326 3901 
+Q 2194 3809 2194 3641 
+Q 2194 3534 2270 3398 
+Q 2347 3263 2497 3097 
+z
+M 1875 2322 
+Q 1672 2175 1569 1989 
+Q 1466 1803 1466 1581 
+Q 1466 1222 1731 969 
+Q 1997 716 2369 716 
+Q 2578 716 2759 780 
+Q 2941 844 3097 972 
+L 1875 2322 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3d" d="M 678 3084 
+L 4684 3084 
+L 4684 2350 
+L 678 2350 
+L 678 3084 
+z
+M 678 1663 
+L 4684 1663 
+L 4684 922 
+L 678 922 
+L 678 1663 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-2196"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(118.603516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(162.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(229.589844 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(289.111328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(336.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-26" transform="translate(371.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(458.935547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(493.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(553.271484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(657.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(724.951172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(759.228516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(793.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(828.320312 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(912.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(946.923828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1018.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1086.328125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
+    </g>
+   </g>
+   <g id="line2d_63">
+    <path d="M 364.793034 107.185007 
+L 303.374496 114.993962 
+L 255.735758 134.721774 
+L 195.104637 136.458204 
+L 151.009276 163.420045 
+L 138.016893 186.849946 
+L 135.654641 193.953163 
+L 134.473516 200.010936 
+L 134.473516 200.113131 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <defs>
+     <path id="mc6064c187e" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p6ec9970131)">
+     <use xlink:href="#mc6064c187e" x="364.793034" y="107.185007" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="303.374496" y="114.993962" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="255.735758" y="134.721774" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="195.104637" y="136.458204" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="151.009276" y="163.420045" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="138.016893" y="186.849946" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="135.654641" y="193.953163" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="134.473516" y="200.010936" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6064c187e" x="134.473516" y="200.113131" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_64">
+    <path d="M 610.467187 85.420999 
+L 295.894033 99.608332 
+L 188.017882 134.889758 
+L 167.545036 140.675257 
+L 150.221859 157.901342 
+L 136.04835 183.809485 
+L 134.473516 190.597703 
+L 134.079807 194.206952 
+L 134.079807 194.369028 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <defs>
+     <path id="m29d20c708b" d="M 0 -2.5 
+L -2.5 2.5 
+L 2.5 2.5 
+z
+" style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p6ec9970131)">
+     <use xlink:href="#m29d20c708b" x="610.467187" y="85.420999" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="295.894033" y="99.608332" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="188.017882" y="134.889758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="167.545036" y="140.675257" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="150.221859" y="157.901342" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="136.04835" y="183.809485" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="134.473516" y="190.597703" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="134.079807" y="194.206952" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m29d20c708b" x="134.079807" y="194.369028" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_65">
+    <path d="M 239.987415 65.138608 
+L 204.159934 82.653496 
+L 186.443048 90.183886 
+L 180.143711 94.129026 
+L 147.465899 107.680119 
+L 139.591727 119.049631 
+L 136.442059 132.242012 
+L 126.205636 154.116303 
+L 125.811927 158.401536 
+L 81.322858 230.223148 
+L 80.929149 248.292622 
+L 80.929149 257.597272 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <defs>
+     <path id="m26964dd1a9" d="M -0 3.535534 
+L 3.535534 0 
+L 0 -3.535534 
+L -3.535534 -0 
+z
+" style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p6ec9970131)">
+     <use xlink:href="#m26964dd1a9" x="239.987415" y="65.138608" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="204.159934" y="82.653496" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="186.443048" y="90.183886" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="180.143711" y="94.129026" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="147.465899" y="107.680119" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="139.591727" y="119.049631" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="136.442059" y="132.242012" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="126.205636" y="154.116303" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="125.811927" y="158.401536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="81.322858" y="230.223148" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="80.929149" y="248.292622" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m26964dd1a9" x="80.929149" y="257.597272" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_66">
+    <path d="M 75.810937 396.248267 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <defs>
+     <path id="m18c126bc0f" d="M -0 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p6ec9970131)">
+     <use xlink:href="#m18c126bc0f" x="75.810937" y="396.248267" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 464.7975 408.80375 
+L 631.6 408.80375 
+Q 633.2 408.80375 633.2 407.20375 
+L 633.2 372.55375 
+Q 633.2 370.95375 631.6 370.95375 
+L 464.7975 370.95375 
+Q 463.1975 370.95375 463.1975 372.55375 
+L 463.1975 407.20375 
+Q 463.1975 408.80375 464.7975 408.80375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_67">
+     <path d="M 466.3975 377.4325 
+L 474.3975 377.4325 
+L 482.3975 377.4325 
+" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+     <defs>
+      <path id="m61684d0b00" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #d62728; stroke-width: 1.3"/>
+     </defs>
+     <g>
+      <use xlink:href="#m61684d0b00" x="474.3975" y="377.4325" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- lean-zip (native) -->
+     <g transform="translate(488.7975 380.2325) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(213.964844 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(250.048828 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(302.539062 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(330.322266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(393.798828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(425.585938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(464.599609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(527.978516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(589.257812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(628.466797 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(656.25 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(715.429688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_68">
+     <path d="M 466.3975 389.175 
+L 474.3975 389.175 
+L 482.3975 389.175 
+" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mc6064c187e" x="474.3975" y="389.175" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- zlib -->
+     <g transform="translate(488.7975 391.975) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-7a"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(52.490234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(80.273438 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
+     </g>
+    </g>
+    <g id="line2d_69">
+     <path d="M 466.3975 400.9175 
+L 474.3975 400.9175 
+L 482.3975 400.9175 
+" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m29d20c708b" x="474.3975" y="400.9175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- miniz_oxide -->
+     <g transform="translate(488.7975 403.7175) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+     </g>
+    </g>
+    <g id="line2d_70">
+     <path d="M 570.075 377.4325 
+L 578.075 377.4325 
+L 586.075 377.4325 
+" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m26964dd1a9" x="578.075" y="377.4325" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- libdeflate -->
+     <g transform="translate(592.475 380.2325) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(119.042969 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(182.519531 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(244.042969 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(279.248047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(307.03125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(368.310547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
+     </g>
+    </g>
+    <g id="line2d_71">
+     <path d="M 570.075 389.175 
+L 578.075 389.175 
+L 586.075 389.175 
+" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m18c126bc0f" x="578.075" y="389.175" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- zopfli -->
+     <g transform="translate(592.475 391.975) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-7a"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_72">
+    <path d="M 184.474505 169.345667 
+L 171.875831 172.950156 
+L 165.970202 175.971718 
+L 146.284773 187.982609 
+L 145.103647 189.201231 
+L 143.922522 190.7283 
+L 140.772853 199.275301 
+L 140.772853 259.395945 
+L 86.441069 340.645504 
+" clip-path="url(#p6ec9970131)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p6ec9970131)">
+     <use xlink:href="#m61684d0b00" x="184.474505" y="169.345667" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="171.875831" y="172.950156" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="165.970202" y="175.971718" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="146.284773" y="187.982609" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="145.103647" y="189.201231" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="143.922522" y="190.7283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="140.772853" y="199.275301" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="140.772853" y="259.395945" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m61684d0b00" x="86.441069" y="340.645504" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_21">
+   <!-- Compression speed vs ratio  (enwik8_20m — geomean over 1 files; line = level sweep) -->
+   <g transform="translate(7.354531 19.237969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-77" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-3b" d="M 716 1209 
+L 1844 1209 
+L 1844 256 
+L 1069 -909 
+L 403 -909 
+L 716 256 
+L 716 1209 
+z
+M 716 3500 
+L 1844 3500 
+L 1844 2291 
+L 716 2291 
+L 716 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-43"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(246.289062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(317.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(367.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(435.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(494.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(554.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(588.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(728.222656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(763.037109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(822.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(894.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(961.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1029.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1101.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1136.181641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1201.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1260.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1345.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1412.5 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1460.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1494.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1563.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1598.095703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1632.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1678.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1746.435547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(1817.626953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1910.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(1944.287109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(2010.791016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(2080.371094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(2130.371094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(2199.951172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2269.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2373.730469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(2408.544922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2508.544922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2543.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2614.941406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2682.763672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2751.464844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2855.664062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2923.486328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2990.966797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3062.158203 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3096.972656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3165.673828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3230.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3298.681641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3347.998047 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3382.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3452.392578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(3487.207031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3530.712891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3564.990234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3599.267578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3667.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3b" transform="translate(3726.611328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3766.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3801.416016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3835.693359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3869.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3941.162109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4008.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(4043.798828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4127.587891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(4162.402344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4196.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(4264.501953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4329.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(4397.509766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4431.787109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(4466.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(4526.123047 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4618.505859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4686.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(4754.150391 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(4825.732422 0)"/>
+   </g>
+  </g>
+  <g id="text_22">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.611875 465.66) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6ec9970131">
+   <rect x="49.078125" y="48.583125" width="588.121875" height="364.220625"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/enwik8_20m_ratio_heatmap.svg
+++ b/bench/graphs/enwik8_20m_ratio_heatmap.svg
@@ -1,0 +1,2022 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="576pt" height="259.2pt" viewBox="0 0 576 259.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 259.2 
+L 576 259.2 
+L 576 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 83.0775 208.010825 
+L 495.618269 208.010825 
+L 495.618269 43.9155 
+L 83.0775 43.9155 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p00b5a68d70)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAj0AAADkCAYAAABzP5XPAAAEH0lEQVR4nO3YwQ2CUAAFQSDElmzJDm3LxBsHsIrPT9yZCt5x89bl9bwWAIA/t80eAABwB9EDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkLCex/uaPQIAYDRPDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEvZjO2dvAAAYztMDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AICE/fH9zN4AADCcpwcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAmiBwBIED0AQILoAQASRA8AkCB6AIAE0QMAJIgeACBB9AAACaIHAEgQPQBAgugBABJEDwCQIHoAgATRAwAkiB4AIEH0AAAJogcASBA9AECC6AEAEkQPAJAgegCABNEDACSIHgAgQfQAAAk//O8K+gi8VroAAAAASUVORK5CYII=" id="imagee475c37a97" transform="scale(1 -1) translate(0 -164.16)" x="83.0775" y="-43.850825" width="412.56" height="164.16"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m2463b42375" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2463b42375" x="289.347884" y="208.010825" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- enwik8 -->
+      <g transform="translate(268.033034 239.447551) rotate(-45) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-65"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(61.523438 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(124.902344 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(206.689453 0)"/>
+       <use xlink:href="#DejaVuSans-6b" transform="translate(234.472656 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(292.382812 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_2">
+      <defs>
+       <path id="m6559ce519f" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6559ce519f" x="83.0775" y="64.427416" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- lean-zip (native) -->
+      <g transform="translate(10.8 67.466791) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6c"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+       <use xlink:href="#DejaVuSans-2d" transform="translate(213.964844 0)"/>
+       <use xlink:href="#DejaVuSans-7a" transform="translate(250.048828 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(302.539062 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(330.322266 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(393.798828 0)"/>
+       <use xlink:href="#DejaVuSans-28" transform="translate(425.585938 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(464.599609 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(527.978516 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(589.257812 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(628.466797 0)"/>
+       <use xlink:href="#DejaVuSans-76" transform="translate(656.25 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(715.429688 0)"/>
+       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m6559ce519f" x="83.0775" y="105.451247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- miniz_oxide -->
+      <g transform="translate(28.9675 108.490622) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+       <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+       <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m6559ce519f" x="83.0775" y="146.475078" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- libdeflate -->
+      <g transform="translate(38.5525 149.514453) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6c"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+       <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(119.042969 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(182.519531 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(244.042969 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(279.248047 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(307.03125 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(368.310547 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m6559ce519f" x="83.0775" y="187.498909" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- zopfli -->
+      <g transform="translate(54.64375 190.538284) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-7a"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 83.0775 208.010825 
+L 83.0775 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 495.618269 208.010825 
+L 495.618269 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 83.0775 208.010825 
+L 495.618269 208.010825 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 83.0775 43.9155 
+L 495.618269 43.9155 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_6">
+    <!-- +0 -->
+    <g transform="translate(284.556673 66.221009) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- -0 -->
+    <g transform="translate(286.107533 107.24484) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- +0 -->
+    <g transform="translate(284.556673 148.268672) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- -4 -->
+    <g transform="translate(286.107533 189.292503) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 504.257866 208.010825 
+L 512.462632 208.010825 
+L 512.462632 43.9155 
+L 504.257866 43.9155 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAwAAADkCAYAAACsYsUIAAABUklEQVR4nO2YQQ7DIAwEbSD5Ur/U/19bcL+QQVrkhvTMatZemyR1e7/CwK95cXI+paDUIibsKXCaQ3tyUAjy5VAYwFqlNVRqaYKAzk8QTnovVQZY0yVMQOdX1HBCT3tOa8IaTnwvYUt0WqGjGYJ843ANRz5LePhWBIcJsIaDEm7R1gU7DQk06lYcC9Q3HxdYuhpaqWLChIB2yfJZSpjDDbrkfDTo90NpTOB8p+mnpZ4gbysmVD+Y4GnrJQLPId8+YAH6P9esWYz/F/SvmoAFI1+XqCCiQ0LCHHYMbkEOuEuDXUwzhHyWvnSBEtZABRHpLG2ZQ0ZLNIfouAYqoISQE6zTjcOWPpTAc8CPrIQ5qC3FB79gqfdhxcbJx5vWMPA+UEtDP0v4Oa23JCd0eXArik4X3MAC+QMlYXC8S6xJEwL4frXC0paCzmcJEh7BFcEN9uEH5hwLZ2YWSFQAAAAASUVORK5CYII=" id="image068a51e05f" transform="scale(1 -1) translate(0 -164.16)" x="504" y="-43.92" width="8.64" height="164.16"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_6">
+      <defs>
+       <path id="mecc2404d9c" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mecc2404d9c" x="512.462632" y="202.610219" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- −0.04 -->
+      <g transform="translate(519.462632 206.409438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mecc2404d9c" x="512.462632" y="164.286691" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −0.02 -->
+      <g transform="translate(519.462632 168.085909) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(242.822266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mecc2404d9c" x="512.462632" y="125.963162" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.00 -->
+      <g transform="translate(519.462632 129.762381) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mecc2404d9c" x="512.462632" y="87.639634" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.02 -->
+      <g transform="translate(519.462632 91.438853) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mecc2404d9c" x="512.462632" y="49.316106" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.04 -->
+      <g transform="translate(519.462632 53.115324) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- % vs zlib (higher=bigger) -->
+     <g transform="translate(561.706382 189.789725) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-25" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-25"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(95.019531 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(126.806641 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(185.986328 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(238.085938 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(269.873047 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(322.363281 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(350.146484 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(377.929688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(441.40625 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(473.193359 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(512.207031 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(575.585938 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(603.369141 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(666.845703 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(730.224609 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(791.748047 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(832.861328 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(916.650391 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(980.126953 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1007.910156 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1071.386719 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1134.863281 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1196.386719 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1237.5 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 504.257866 208.010825 
+L 508.360249 208.010825 
+L 512.462632 208.010825 
+L 512.462632 43.9155 
+L 508.360249 43.9155 
+L 504.257866 43.9155 
+L 504.257866 208.010825 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_16">
+   <!-- Compression ratio vs zlib  (enwik8_20m, level 6, relative to zlib) -->
+   <g transform="translate(70.962187 14.302125) scale(0.12 -0.12)">
+    <defs>
+     <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-77" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-43"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(246.289062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(317.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(367.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(435.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(494.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(554.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(588.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(728.222656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(763.037109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(812.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(879.833984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(927.636719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(961.914062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1030.615234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1065.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1130.615234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1190.136719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(1224.951172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1283.154297 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(1351.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1423.291016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1458.105469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1492.919922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1538.623047 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1606.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(1677.636719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1770.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(1804.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(1870.800781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(1940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(1990.380859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(2059.960938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2129.541016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2233.740234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2271.728516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2306.542969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2340.820312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2408.642578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2473.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2575.927734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2610.742188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2680.322266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2718.310547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2753.125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2802.441406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2870.263672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2904.541016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2972.021484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3019.824219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3054.101562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3119.287109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3187.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3221.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3269.726562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3338.427734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(3373.242188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3431.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3465.722656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(3500 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3571.582031 0)"/>
+   </g>
+  </g>
+  <g id="text_17">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(10.611875 257.904) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p00b5a68d70">
+   <rect x="83.0775" y="43.9155" width="412.540769" height="164.095325"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/enwik8_20m_summary.svg
+++ b/bench/graphs/enwik8_20m_summary.svg
@@ -1,0 +1,2179 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.17625pt" height="260.490469pt" viewBox="0 0 569.17625 260.490469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M -0 260.490469 
+L 569.17625 260.490469 
+L 569.17625 -0 
+L -0 -0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 186.713125 97.08 
+L 291.338125 97.08 
+L 291.338125 64.74 
+L 186.713125 64.74 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #f26841; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 291.338125 97.08 
+L 395.963125 97.08 
+L 395.963125 64.74 
+L 291.338125 64.74 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 395.963125 97.08 
+L 500.588125 97.08 
+L 500.588125 64.74 
+L 395.963125 64.74 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 186.713125 129.42 
+L 291.338125 129.42 
+L 291.338125 97.08 
+L 186.713125 97.08 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 291.338125 129.42 
+L 395.963125 129.42 
+L 395.963125 97.08 
+L 291.338125 97.08 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 395.963125 129.42 
+L 500.588125 129.42 
+L 500.588125 97.08 
+L 395.963125 97.08 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #fffbb8; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 186.713125 161.76 
+L 291.338125 161.76 
+L 291.338125 129.42 
+L 186.713125 129.42 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 291.338125 161.76 
+L 395.963125 161.76 
+L 395.963125 129.42 
+L 291.338125 129.42 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 395.963125 161.76 
+L 500.588125 161.76 
+L 500.588125 129.42 
+L 395.963125 129.42 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #fee999; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 186.713125 194.1 
+L 291.338125 194.1 
+L 291.338125 161.76 
+L 186.713125 161.76 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 291.338125 194.1 
+L 395.963125 194.1 
+L 395.963125 161.76 
+L 291.338125 161.76 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 395.963125 194.1 
+L 500.588125 194.1 
+L 500.588125 161.76 
+L 395.963125 161.76 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 186.713125 226.44 
+L 291.338125 226.44 
+L 291.338125 194.1 
+L 186.713125 194.1 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 291.338125 226.44 
+L 395.963125 226.44 
+L 395.963125 194.1 
+L 291.338125 194.1 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 395.963125 226.44 
+L 500.588125 226.44 
+L 500.588125 194.1 
+L 395.963125 194.1 
+z
+" clip-path="url(#p2a958f9d2d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <!-- codec -->
+    <g transform="translate(119.700391 51.053438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(199.560547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(267.382812 0)"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <!-- ratio -->
+    <g transform="translate(226.984609 51.053438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-72"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(49.316406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(116.796875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(164.599609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.876953 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- compress MB/s -->
+    <g transform="translate(305.556719 51.053438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4d" d="M 588 4666 
+L 2119 4666 
+L 3181 2169 
+L 4250 4666 
+L 5778 4666 
+L 5778 0 
+L 4641 0 
+L 4641 3413 
+L 3566 897 
+L 2803 897 
+L 1728 3413 
+L 1728 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
+L 2338 4666 
+L 691 -594 
+L 0 -594 
+L 1644 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(232.177734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(303.759766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(353.076172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(420.898438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(480.419922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(539.941406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(574.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(674.267578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(750.488281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(787.011719 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- decompress MB/s -->
+    <g transform="translate(403.908437 51.053438) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-64"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.681641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(267.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(371.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(443.164062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(492.480469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(560.302734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(619.824219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(679.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(714.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(813.671875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(889.892578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(926.416016 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- libdeflate -->
+    <g transform="translate(115.638125 83.1175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6c"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(119.042969 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(182.519531 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(244.042969 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(279.248047 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(307.03125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(368.310547 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- 0.369 -->
+    <g transform="translate(227.574375 83.1175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- 91 -->
+    <g transform="translate(338.560625 83.1175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 735 -->
+    <g transform="translate(440.640625 83.1175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- miniz_oxide -->
+    <g transform="translate(110.845625 115.34625) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- 0.368 -->
+    <g transform="translate(227.574375 115.4575) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- 30 -->
+    <g transform="translate(338.560625 115.4575) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 424 -->
+    <g transform="translate(440.640625 115.4575) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-34"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- zlib -->
+    <g transform="translate(127.539375 147.7975) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-7a"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(52.490234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(80.273438 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- 0.369 -->
+    <g transform="translate(227.574375 147.7975) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 29 -->
+    <g transform="translate(338.560625 147.7975) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 373 -->
+    <g transform="translate(440.640625 147.7975) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- lean-zip (native) -->
+    <g transform="translate(97.3475 180.1375) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
+L 2309 2297 
+L 2309 1388 
+L 347 1388 
+L 347 2297 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-6c"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 0.370 -->
+    <g transform="translate(226.37375 180.1375) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 27 -->
+    <g transform="translate(338.084375 180.1375) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 135 -->
+    <g transform="translate(439.92625 180.1375) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- zopfli -->
+    <g transform="translate(123.68375 212.4775) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-7a"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 0.353 -->
+    <g transform="translate(227.574375 212.4775) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 1 -->
+    <g transform="translate(341.105625 212.4775) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- — -->
+    <g transform="translate(444.275625 212.4775) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2014"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_25">
+   <!-- enwik8_20m — geomean over files, level 6 -->
+   <g transform="translate(129.223906 17.077969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-77" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-65"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(67.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(139.013672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(231.396484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(265.673828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-38" transform="translate(332.177734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(401.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(451.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-30" transform="translate(521.337891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(590.917969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(695.117188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(729.931641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(829.931641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(864.746094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(936.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1004.150391 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1072.851562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1177.050781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1244.873047 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1312.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1383.544922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1418.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1487.060547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1620.068359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1669.384766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(1704.199219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1747.705078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1781.982422 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1816.259766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1884.082031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(1943.603516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1981.591797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2016.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2050.683594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2118.505859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2183.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2251.513672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2285.791016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2320.605469 0)"/>
+   </g>
+  </g>
+  <g id="text_26">
+   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(7.2 251.64) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2a958f9d2d">
+   <rect x="82.088125" y="32.4" width="418.5" height="194.04"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -17256,6 +17256,396 @@
    "ratio": 0.1177,
    "compress_mbps": 4.73,
    "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 1,
+   "out_size": 7615928,
+   "ratio": 0.3808,
+   "compress_mbps": 38.76,
+   "decompress_mbps": 110.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 2,
+   "out_size": 7552010,
+   "ratio": 0.3776,
+   "compress_mbps": 36.45,
+   "decompress_mbps": 119.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 3,
+   "out_size": 7521233,
+   "ratio": 0.3761,
+   "compress_mbps": 34.62,
+   "decompress_mbps": 126.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 4,
+   "out_size": 7421130,
+   "ratio": 0.3711,
+   "compress_mbps": 28.21,
+   "decompress_mbps": 127.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 5,
+   "out_size": 7416933,
+   "ratio": 0.3708,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 132.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 6,
+   "out_size": 7410362,
+   "ratio": 0.3705,
+   "compress_mbps": 26.92,
+   "decompress_mbps": 134.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 7,
+   "out_size": 7394844,
+   "ratio": 0.3697,
+   "compress_mbps": 23.27,
+   "decompress_mbps": 134.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 8,
+   "out_size": 7394453,
+   "ratio": 0.3697,
+   "compress_mbps": 8.35,
+   "decompress_mbps": 136.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 9,
+   "out_size": 7117522,
+   "ratio": 0.3559,
+   "compress_mbps": 2.09,
+   "decompress_mbps": 139.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 1,
+   "out_size": 8531194,
+   "ratio": 0.4266,
+   "compress_mbps": 111.84,
+   "decompress_mbps": 344.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 2,
+   "out_size": 8219632,
+   "ratio": 0.411,
+   "compress_mbps": 97.9,
+   "decompress_mbps": 357.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 3,
+   "out_size": 7978468,
+   "ratio": 0.3989,
+   "compress_mbps": 69.94,
+   "decompress_mbps": 376.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 4,
+   "out_size": 7669038,
+   "ratio": 0.3835,
+   "compress_mbps": 67.9,
+   "decompress_mbps": 379.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 5,
+   "out_size": 7446142,
+   "ratio": 0.3723,
+   "compress_mbps": 42.88,
+   "decompress_mbps": 369.87
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 6,
+   "out_size": 7379178,
+   "ratio": 0.369,
+   "compress_mbps": 28.76,
+   "decompress_mbps": 372.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 7,
+   "out_size": 7368345,
+   "ratio": 0.3684,
+   "compress_mbps": 25.48,
+   "decompress_mbps": 371.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 8,
+   "out_size": 7362936,
+   "ratio": 0.3681,
+   "compress_mbps": 22.98,
+   "decompress_mbps": 375.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 9,
+   "out_size": 7362907,
+   "ratio": 0.3681,
+   "compress_mbps": 22.94,
+   "decompress_mbps": 376.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 1,
+   "out_size": 9780791,
+   "ratio": 0.489,
+   "compress_mbps": 162.08,
+   "decompress_mbps": 329.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 2,
+   "out_size": 8182464,
+   "ratio": 0.4091,
+   "compress_mbps": 127.26,
+   "decompress_mbps": 364.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 3,
+   "out_size": 7634674,
+   "ratio": 0.3817,
+   "compress_mbps": 69.74,
+   "decompress_mbps": 420.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 4,
+   "out_size": 7530740,
+   "ratio": 0.3765,
+   "compress_mbps": 63.19,
+   "decompress_mbps": 420.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 5,
+   "out_size": 7441681,
+   "ratio": 0.3721,
+   "compress_mbps": 47.11,
+   "decompress_mbps": 415.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 6,
+   "out_size": 7370737,
+   "ratio": 0.3685,
+   "compress_mbps": 30.29,
+   "decompress_mbps": 424.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 7,
+   "out_size": 7361982,
+   "ratio": 0.3681,
+   "compress_mbps": 26.98,
+   "decompress_mbps": 423.9
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 8,
+   "out_size": 7359414,
+   "ratio": 0.368,
+   "compress_mbps": 25.37,
+   "decompress_mbps": 423.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 9,
+   "out_size": 7359347,
+   "ratio": 0.368,
+   "compress_mbps": 25.3,
+   "decompress_mbps": 423.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 1,
+   "out_size": 7898620,
+   "ratio": 0.3949,
+   "compress_mbps": 229.03,
+   "decompress_mbps": 733.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 2,
+   "out_size": 7715351,
+   "ratio": 0.3858,
+   "compress_mbps": 169.91,
+   "decompress_mbps": 787.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 3,
+   "out_size": 7625643,
+   "ratio": 0.3813,
+   "compress_mbps": 149.44,
+   "decompress_mbps": 810.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 4,
+   "out_size": 7594082,
+   "ratio": 0.3797,
+   "compress_mbps": 139.72,
+   "decompress_mbps": 739.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 5,
+   "out_size": 7428603,
+   "ratio": 0.3714,
+   "compress_mbps": 110.9,
+   "decompress_mbps": 722.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 6,
+   "out_size": 7388872,
+   "ratio": 0.3694,
+   "compress_mbps": 91.36,
+   "decompress_mbps": 735.49
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 7,
+   "out_size": 7371309,
+   "ratio": 0.3686,
+   "compress_mbps": 72.96,
+   "decompress_mbps": 734.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 8,
+   "out_size": 7320105,
+   "ratio": 0.366,
+   "compress_mbps": 50.25,
+   "decompress_mbps": 732.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 9,
+   "out_size": 7318266,
+   "ratio": 0.3659,
+   "compress_mbps": 46.71,
+   "decompress_mbps": 732.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 10,
+   "out_size": 7092809,
+   "ratio": 0.3546,
+   "compress_mbps": 13.73,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 11,
+   "out_size": 7089586,
+   "ratio": 0.3545,
+   "compress_mbps": 10.09,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "enwik8_20m/enwik8",
+   "size": 20000000,
+   "level": 12,
+   "out_size": 7089712,
+   "ratio": 0.3545,
+   "compress_mbps": 8.61,
+   "decompress_mbps": null
   }
  ]
 }

--- a/bench/results/zopfli-ceiling.json
+++ b/bench/results/zopfli-ceiling.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "date": "2026-06-10T13:20:10Z",
+    "date": "2026-06-26T13:44:42Z",
     "machine": "Linux chungus x86_64",
-    "git_commit": "118a98e",
+    "git_commit": "831a8bb2",
     "toolchain": "leanprover/lean4:v4.30.0-rc2",
     "frozen": true,
     "note": "FROZEN zopfli ratio ceiling — do NOT regenerate. zopfli is compress-only, level-less and ~100x slower than zlib; level=6 is nominal and compress_mbps is a single-rep artifact, not a benchmark. ratio/out_size are deterministic. Regenerate only if the corpora change: lake env .lake/build/bin/bench-report --zopfli-ceiling bench/results/zopfli-ceiling.json"
@@ -30,6 +30,7 @@
     {"compressor": "zopfli", "pattern": "silesia/sao", "size": 7251944, "level": 6, "out_size": 5242394, "ratio": 0.722900, "compress_mbps": 0.790000, "decompress_mbps": null},
     {"compressor": "zopfli", "pattern": "silesia/webster", "size": 41458703, "level": 6, "out_size": 11518290, "ratio": 0.277800, "compress_mbps": 0.760000, "decompress_mbps": null},
     {"compressor": "zopfli", "pattern": "silesia/x-ray", "size": 8474240, "level": 6, "out_size": 5744697, "ratio": 0.677900, "compress_mbps": 1.280000, "decompress_mbps": null},
-    {"compressor": "zopfli", "pattern": "silesia/xml", "size": 5345280, "level": 6, "out_size": 627169, "ratio": 0.117300, "compress_mbps": 0.400000, "decompress_mbps": null}
+    {"compressor": "zopfli", "pattern": "silesia/xml", "size": 5345280, "level": 6, "out_size": 627169, "ratio": 0.117300, "compress_mbps": 0.400000, "decompress_mbps": null},
+    {"compressor": "zopfli", "pattern": "enwik8_20m/enwik8", "size": 20000000, "level": 6, "out_size": 7064496, "ratio": 0.353200, "compress_mbps": 0.810000, "decompress_mbps": null}
   ]
 }


### PR DESCRIPTION
This PR adds a large pure-prose corpus (`enwik8_20m`, the first 20 MB of enwik8 from the Large Text Compression Benchmark) so L9 can be judged against the zopfli ceiling on zopfli's home turf — the large-text regime where near-optimal parsing pays off most and where our ratio gap to zopfli is widest. enwik8 is fetched on demand into the gitignored corpus cache (`fetch_corpora.sh enwik8`, official zip, SHA-256-verified on both the 100 MB original and the pinned 20 MB slice); the harness discovers it by directory, so it slots into the per-level Pareto/summary/heatmap charts with no `plot.py` change, and the zopfli ceiling overlays its ratio graph.

The full 100 MB at default zopfli iterations is ~100x slower than zlib and impractical, so the deterministic first-20 MB slice is the pinned, SHA-pinned input (recorded in the corpus name). The matrix `big` heuristic is now size-based (>16 MiB) rather than a `silesia` name check, so any large corpus runs the reduced single-pass timing automatically. `bench-report --zopfli-ceiling <out> <corpus>` regenerates one corpus and merges it into the frozen ceiling, keeping every other corpus's deterministic rows byte-identical — so the new corpus joins without re-running the ~1 h Silesia zopfli pass — and fails closed if the requested corpus is not materialized.

On enwik8 native L9 reaches ratio 0.356, beating libdeflate L9 (0.366) and landing just above zopfli's 0.353 ceiling, with libdeflate's densest L10–12 (0.355) in between. This is the reference data point for the "is L9 strictly better ratio than libdeflate, and how close to zopfli" question (ties to https://github.com/kim-em/lean-zip/issues/2638's ratio floor).

Closes https://github.com/kim-em/lean-zip/issues/2700.

🤖 Prepared with Claude Code
