### PR TITLE
doc: lead README with verified zlib and the performance story

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,80 @@
 # lean-zip
 
-Lean 4 bindings for [zlib](https://zlib.net/) compression, plus tar and ZIP archive support.
+**A formally verified zlib implementation in Lean 4.**
 
-Provides whole-buffer and streaming APIs for zlib, gzip, and raw deflate formats, CRC32/Adler32 checksums, tar archives (.tar and .tar.gz with PAX/GNU extension support), and ZIP archives (with ZIP64 support).
+lean-zip contains a from-scratch, pure-Lean DEFLATE encoder and decoder, and
+Lean's kernel checks that they are inverse to each other. Compression here is
+something the type checker has *proved* cannot silently corrupt your data:
 
-For Zstandard (zstd) support, see [lean-zstd](https://github.com/kim-em/lean-zstd).
-
-## Requirements
-
-- Lean 4 (tested with v4.20.0 through v4.29.0-rc1)
-- zlib development headers (`zlib-dev`, `zlib1g-dev`, or equivalent)
-- `pkg-config` (for header discovery on NixOS and similar)
-- Optional: `cargo` + `rustc` to build the Track D `miniz_oxide`
-  comparator. When unavailable, `lake build` still succeeds and the
-  `MinizOxide.*` FFI wrappers raise `IO.userError` at runtime.
-  See [BENCH.md](BENCH.md) for the comparator-toolchain matrix.
-
-On NixOS (or any system where zlib isn't in the default library path),
-the project includes a `shell.nix` that provides all C dependencies:
-
-```bash
-nix-shell    # then run lake build, lake exe test, etc. inside the shell
+```lean
+/-- Decompressing the output of `compress` returns the original data,
+    for every input and every compression level. -/
+theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    ZlibDecode.decompressSingle (ZlibEncode.compress data level) maxOutputSize = .ok data
 ```
 
-Or use [direnv](https://direnv.net/) for automatic environment activation:
-```bash
-direnv allow   # one-time setup; environment then activates on cd
-```
+That theorem rests on the DEFLATE round-trip at the core,
+`inflate (deflateRaw data level) = .ok data`, and on more than 1,100 theorems
+across ~32k lines of proof in [`Zip/Spec/`](Zip/Spec). There are no `sorry`s,
+and the proofs are re-checked from scratch on every commit.
 
-You can also set `ZLIB_CFLAGS` manually to point at the headers if you prefer.
+(lean-zip also ships thin FFI bindings to system zlib, for when you just want
+the C library directly, plus pure-Lean tar and ZIP archives. Jump to
+[Using it](#using-it).)
 
-## Usage
+## Verification turns performance into a free-for-all
+
+Here is the interesting part.
+
+![Silesia compression: speed vs ratio](bench/graphs/silesia_compress_pareto.svg)
+
+*Silesia corpus. x = compression ratio (← smaller is better), y = throughput
+(MB/s, log scale); each line is one codec swept across its levels, so up-and-to-the-left
+wins. The full dashboard (decode benchmarks, per-file heatmaps, and methodology)
+is in [`bench/`](bench/README.md).*
+
+Once correctness is a *theorem*, you can be
+reckless about speed. Rewrite the hot loop, hand-roll the Huffman table walk,
+add a block-splitting heuristic, swap a clean fold for a word-at-a-time byte
+reader, and the obligation `inflate (deflate x) = x` either still holds or the
+build goes red. An optimization *cannot* quietly trade away correctness, because
+correctness here isn't a test suite that samples some inputs; it's a statement
+about **all** inputs that the kernel insists on.
+
+That makes the optimization work safe to hand to a machine. Much of lean-zip,
+including essentially all of the performance work behind that graph, was
+written by coding agents working autonomously: each one claims an issue, works
+in its own git worktree, opens a pull request, and that PR cannot merge unless
+the round-trip proof still goes through. The proof is the ratchet. Aggressive,
+half-understood, "I'm not sure *why* this is faster but the benchmark says it
+is" changes are exactly the kind a verified codebase can accept without fear.
+
+And it works. With minimal human direction, the pure-Lean codec (`native` above)
+now, at its default level on the Silesia corpus:
+
+- **beats** the pure-OCaml [`decompress`](https://github.com/mirage/decompress)
+  library: across the practical range it is faster at a given ratio *and*
+  reaches ratios OCaml's encoder can't;
+- lands **within about 2× of Rust's miniz_oxide and C's zlib**, squarely among
+  the mature language-native implementations;
+- trails only hand-tuned **C + SIMD** (libdeflate), several times faster and the
+  realistic ceiling for this format.
+
+This codec started out far slower than everything else on the chart. The gap
+closed not through one clever human insight but through a long series of small,
+individually-verified steps. That is the bet behind
+Gwern's ["Lean software scaling laws"](https://gwern.net/lean-scaling):
+formally-verifiable languages may start from a worse baseline but scale better,
+because verified code is the substrate on which automated optimization can
+safely compound.
+
+The author cheerfully admits to being an amateur at performance work, which is
+rather the point: she didn't have to be an expert, only to keep the proofs
+green. If you know how to make DEFLATE go faster, the proofs are waiting to
+catch your mistakes; contributions very welcome.
+
+## Using it
 
 Add to your `lakefile.lean`:
 
@@ -54,8 +98,13 @@ let original ← Gzip.decompress gzipped
 -- Raw deflate (no header/trailer, used internally by ZIP)
 let deflated ← RawDeflate.compress data
 let original ← RawDeflate.decompress deflated
-
 ```
+
+The high-level `Zlib`/`Gzip`/`RawDeflate` entry points above bind system zlib
+through FFI: the fast, ubiquitous baseline. The verified pure-Lean codec that
+the proofs and benchmarks are about lives under
+[`Zip.Native`](Zip/Native) (`Zip.Native.Deflate.deflateRaw` to compress,
+`Zip.Native.InflateBuf.inflate` to decompress); it needs no C library at all.
 
 ### Streaming
 
@@ -89,6 +138,9 @@ let adler ← Checksum.adler32 1 data     -- Adler-32
 let crc2 ← Checksum.crc32 crc moreData
 ```
 
+CRC-32 and Adler-32 also have verified pure-Lean implementations in
+[`Zip.Native`](Zip/Native), each proved equal to its specification.
+
 ### Tar archives
 
 ```lean
@@ -106,7 +158,9 @@ Tar.extract stream outDir
 let entries ← Tar.list stream
 ```
 
-Tar supports UStar, PAX extended headers (for long paths, large files, UTF-8), and GNU long name/link extensions. Paths exceeding UStar limits are automatically encoded with PAX headers on creation.
+Tar supports UStar, PAX extended headers (for long paths, large files, UTF-8),
+and GNU long name/link extensions. Paths exceeding UStar limits are
+automatically encoded with PAX headers on creation.
 
 ### ZIP archives
 
@@ -130,46 +184,84 @@ let data ← Archive.extractFile "/tmp/archive.zip" "name-in-zip.txt"
 let entries ← Archive.list "/tmp/archive.zip"
 ```
 
-ZIP supports stored (method 0) and deflated (method 8) entries with automatic method selection, CRC32 verification, and ZIP64 extensions for archives exceeding 4GB or 65535 entries.
+ZIP supports stored (method 0) and deflated (method 8) entries with automatic
+method selection, CRC32 verification, and ZIP64 extensions for archives
+exceeding 4GB or 65535 entries.
 
-## Building
+For Zstandard (zstd) support, see [lean-zstd](https://github.com/kim-em/lean-zstd).
+
+## How it's organized
+
+- [`Zip/`](Zip): FFI wrappers and the public API
+- [`Zip/Native/`](Zip/Native): the pure-Lean implementations (no FFI)
+- [`Zip/Spec/`](Zip/Spec): formal specifications and the correctness proofs
+- [`ZipTest/`](ZipTest): per-module conformance tests (native vs FFI)
+- [`bench/`](bench/README.md): the benchmark dashboard and methodology
+
+Every source file opens with a module docstring describing its purpose. Shared
+utilities (Binary, Handle, BitReader) live in
+[lean-zip-common](https://github.com/kim-em/lean-zip-common).
+
+The specifications aim past the tautological. Where possible they characterize
+mathematical properties independent of the implementation (`crc32 (a ++ b)`
+in terms of `crc32 a` and `crc32 b`, prefix-freeness and the Kraft inequality
+for the Huffman codes, invertibility for the codecs) rather than merely
+asserting that two pieces of code agree. The round-trip theorem above is the
+capstone: it says the encoder and decoder are genuine inverses, not that they
+were transcribed from the same RFC.
+
+## Requirements
+
+- Lean 4 (tested with v4.20.0 through v4.30.0)
+- zlib development headers (`zlib-dev`, `zlib1g-dev`, or equivalent), for the
+  FFI baseline
+- `pkg-config` (for header discovery on NixOS and similar)
+- Optional comparator toolchains (`cargo`, `libdeflate`, `zopfli`, Go, Node,
+  Zig, OCaml) used only by the benchmark harness; absent ones degrade
+  gracefully. See [BENCH.md](BENCH.md).
+
+On NixOS (or any system where zlib isn't on the default library path), a
+`shell.nix` provides the C dependencies:
 
 ```bash
-lake build
+nix-shell    # then run lake build, lake exe test, etc. inside the shell
 ```
 
-## Testing
+Or use [direnv](https://direnv.net/) for automatic activation (`direnv allow`
+once; the environment then activates on `cd`). You can also set `ZLIB_CFLAGS`
+manually to point at the headers.
+
+## Building and testing
 
 ```bash
-lake build test && .lake/build/bin/test
+lake build                              # library + test executable
+lake build test && .lake/build/bin/test # run all tests
 ```
 
 ## Benchmarking
 
-A benchmark driver is included for use with [hyperfine](https://github.com/sharkdp/hyperfine):
+The committed dashboard in [`bench/`](bench/README.md) is regenerated by a
+single `bench/run.sh`. For ad-hoc measurements there is also a driver for use
+with [hyperfine](https://github.com/sharkdp/hyperfine):
 
 ```bash
 lake build bench
-
-# Single benchmark
 hyperfine 'lake exe bench inflate 1048576 prng 6'
-
-# Compare patterns
-hyperfine 'lake exe bench inflate 1048576 constant 6' \
-          'lake exe bench inflate 1048576 prng 6'
-
-# Sweep sizes
-hyperfine --parameter-list size 1024,65536,1048576 \
-          'lake exe bench inflate {size} prng 6'
 ```
 
-Operations: `inflate`, `gzip`, `zlib`, `crc32`, `adler32`, `crc32-ffi`, `adler32-ffi`.
-Patterns: `constant`, `cyclic`, `prng`. Level: 0-9 (default 6).
+Operations: `inflate`, `deflate`, `gzip`, `zlib`, `crc32`, `adler32`, and their
+FFI counterparts. See `lake exe bench` for the full list.
 
-## Known Limitations
+## Known limitations
 
-- **TOCTOU in extraction**: archive extraction creates parent directories then writes files; a local attacker could replace a directory with a symlink between these steps. Fixing this requires `openat()`/`O_NOFOLLOW`, which Lean's stdlib doesn't expose.
-- **No streaming output limit**: whole-buffer decompression accepts a `max_output` cap, but the streaming API (`push`/`finish`) has no built-in limit — callers processing untrusted data should track total output themselves.
+- **TOCTOU in extraction**: archive extraction creates parent directories then
+  writes files; a local attacker could replace a directory with a symlink
+  between these steps. Fixing this needs `openat()`/`O_NOFOLLOW`, which Lean's
+  stdlib doesn't expose.
+- **No streaming output limit**: whole-buffer decompression accepts a
+  `max_output` cap, but the streaming API (`push`/`finish`) has no built-in
+  limit, so callers processing untrusted data should track total output
+  themselves.
 
 ## License
 


### PR DESCRIPTION
This PR rewrites the README to lead with what the project actually is: a formally verified zlib implementation in Lean 4. The first thing a visitor sees is the round-trip theorem (`decompress ∘ compress = id`, for every input and level), backed by 1,100+ theorems and zero `sorry`s, re-checked on every commit.

It then makes the verification-enables-optimization case the centerpiece. The Silesia speed-vs-ratio Pareto graph is the visual hook, placed up front, and the surrounding prose explains why a proof obligation that holds at every commit lets you (and autonomous agents) be reckless about performance: an optimization either keeps `inflate (deflate x) = x` or turns the build red. The measured result, drawn from the committed bench data, is that the native pure-Lean codec now beats pure-OCaml `decompress`, lands within about 2x of Rust's miniz_oxide and C's zlib, and trails only C+SIMD libdeflate. The framing ties to Gwern's "Lean software scaling laws".

The practical usage, archive, streaming, checksum, build, and limitations sections are preserved, reorganized under a "Using it" heading, with a note distinguishing the FFI baseline from the verified native codec.

🤖 Prepared with Claude Code