### PR TITLE
feat: proven-bounds the native DEFLATE decode path in Zip/Native/Inflate.lean

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -31,9 +31,9 @@ where
       Nat → Except String (UInt32 × BitReader)
     | 0 => .ok (acc, { br with pos := pos, bitOff := bitOff })
     | k + 1 =>
-      if pos ≥ br.data.size then .error "BitReader: unexpected end of input"
+      if h : pos ≥ br.data.size then .error "BitReader: unexpected end of input"
       else
-        let bit : UInt32 := ((br.data[pos]!.toUInt32 >>> bitOff.toUInt32) &&& 1)
+        let bit : UInt32 := (((br.data[pos]'(by omega)).toUInt32 >>> bitOff.toUInt32) &&& 1)
         if bitOff + 1 ≥ 8 then
           go (pos + 1) 0 (acc ||| (bit <<< shift.toUInt32)) (shift + 1) k
         else
@@ -220,19 +220,27 @@ structure DecodeTable where
     the length is the low byte, so this stays inert under the well-founded
     recursions' `whnf`). -/
 @[inline] def DecodeTable.lenAt (t : DecodeTable) (idx : Nat) : UInt8 :=
-  unpackLen t.packed[idx]!
+  if h : idx < t.packed.size then unpackLen (t.packed[idx]'h) else 0
 
 /-- The symbol of slot `idx`: bits 8–23 of the packed entry. One scalar-array read
     plus a shift; the symbol never enters a termination measure, so the shift is
     never `whnf`-forced. -/
 @[inline] def DecodeTable.symAt (t : DecodeTable) (idx : Nat) : UInt16 :=
-  unpackSym t.packed[idx]!
+  if h : idx < t.packed.size then unpackSym (t.packed[idx]'h) else 0
 
 theorem DecodeTable.lenAt_def (t : DecodeTable) (idx : Nat) :
-    t.lenAt idx = unpackLen t.packed[idx]! := rfl
+    t.lenAt idx = unpackLen t.packed[idx]! := by
+  unfold DecodeTable.lenAt
+  split
+  · rw [getElem!_pos t.packed idx ‹_›]
+  · rw [getElem!_neg t.packed idx ‹_›]; rfl
 
 theorem DecodeTable.symAt_def (t : DecodeTable) (idx : Nat) :
-    t.symAt idx = unpackSym t.packed[idx]! := rfl
+    t.symAt idx = unpackSym t.packed[idx]! := by
+  unfold DecodeTable.symAt
+  split
+  · rw [getElem!_pos t.packed idx ‹_›]
+  · rw [getElem!_neg t.packed idx ‹_›]; rfl
 
 /-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds
     `packEntry sym codeLen` for the `(sym, codeLen)` reached by walking `tree` on
@@ -431,9 +439,9 @@ def bitsAvail (br : BitReader) : Nat :=
     end of the stream read as zero; the caller uses `bitsAvail` to decide whether
     the looked-up code actually fits. -/
 def peekFast (br : BitReader) : UInt32 :=
-  let b0 : UInt32 := if br.pos < br.data.size then br.data[br.pos]!.toUInt32 else 0
-  let b1 : UInt32 := if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toUInt32 else 0
-  let b2 : UInt32 := if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toUInt32 else 0
+  let b0 : UInt32 := if h : br.pos < br.data.size then (br.data[br.pos]'h).toUInt32 else 0
+  let b1 : UInt32 := if h : br.pos + 1 < br.data.size then (br.data[br.pos + 1]'h).toUInt32 else 0
+  let b2 : UInt32 := if h : br.pos + 2 < br.data.size then (br.data[br.pos + 2]'h).toUInt32 else 0
   ((b0 ||| (b1 <<< 8) ||| (b2 <<< 16)) >>> br.bitOff.toUInt32) &&& 0x7FF
 
 /-- Table-driven single-symbol decode. Peeks `fastBits` bits, reads the
@@ -863,8 +871,8 @@ theorem litGuard_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : U
     the input is exhausted. Preserves the consumed bit position `pos*8 - cnt`. -/
 @[specialize] def refill (data : ByteArray) (pos : Nat) (bitBuf : UInt64) (cnt : Nat) :
     Nat × UInt64 × Nat :=
-  if cnt ≤ 56 ∧ pos < data.size then
-    refill data (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8)
+  if h : cnt ≤ 56 ∧ pos < data.size then
+    refill data (pos + 1) (bitBuf ||| ((data[pos]'h.2).toUInt64 <<< cnt.toUInt64)) (cnt + 8)
   else (pos, bitBuf, cnt)
 termination_by data.size - pos
 decreasing_by simp_wf; omega
@@ -986,7 +994,7 @@ def goFused (litTable distTable : HuffTree.DecodeTable)
     Except String (ByteArray × Nat × UInt64 × Nat × Nat) := do
   if hrc : cnt ≤ 56 ∧ pos < data.size then
     goFused litTable distTable data litTree distTree maxOut dataSize
-      (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) bitpos output
+      (pos + 1) (bitBuf ||| ((data[pos]'hrc.2).toUInt64 <<< cnt.toUInt64)) (cnt + 8) bitpos output
   else
   let cnt0 := cnt
   match decodeSym litTree litTable bitBuf cnt with
@@ -1050,7 +1058,7 @@ def goFusedP (litTable distTable : HuffTree.DecodeTable)
     Except String (ByteArray × Nat × UInt64 × Nat) := do
   if hrc : cnt ≤ 56 ∧ pos < data.size then
     goFusedP litTable distTable data litTree distTree maxOut
-      (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output
+      (pos + 1) (bitBuf ||| ((data[pos]'hrc.2).toUInt64 <<< cnt.toUInt64)) (cnt + 8) output
   else
   if hlit : (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≠ 0
       ∧ (litTable.lenAt (bitBuf &&& 0x7FF).toNat).toNat ≤ cnt

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -101,6 +101,8 @@ theorem refill_corr {data : ByteArray} {bitpos pos : Nat} {bitBuf : UInt64} {cnt
   split at heq
   · rename_i hcond
     obtain ⟨hc, hp⟩ := hcond
+    -- `refill`'s body now reads `data[pos]'hp`; normalise back to `!` to match `refill_step`
+    rw [← getElem!_pos data pos hp] at heq
     exact refill_corr (refill_step h hc hp) heq
   · rename_i hcond
     obtain ⟨rfl, rfl, rfl⟩ := Prod.ext_iff.mp heq |>.imp id Prod.ext_iff.mp
@@ -217,7 +219,8 @@ theorem mask_lt {bitBuf : UInt64} {n : Nat} (hn64 : n < 64) :
 open HuffTree in
 /-- `peekFast` is `(_ &&& 0x7FF)`, so its value is `< 2048`. -/
 theorem peekFast_lt (br : BitReader) : (peekFast br).toNat < 2048 := by
-  simp only [peekFast, UInt32.toNat_and]
+  rw [peekFast_eq]
+  simp only [UInt32.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
 
 open HuffTree in
@@ -463,7 +466,7 @@ theorem peekFast_testBit_eof (br : BitReader) (j : Nat) (hwf : br.bitOff < 8) (h
       ∧ (8 ≤ br.bitOff + j → br.bitOff + j < 16 → br.data.size ≤ br.pos + 1)
       ∧ (16 ≤ br.bitOff + j → br.data.size ≤ br.pos + 2) :=
     ⟨fun _ => by omega, fun _ _ => by omega, fun _ => by omega⟩
-  unfold peekFast
+  rw [peekFast_eq]
   rw [UInt32.toNat_and, Nat.testBit_and, UInt32.toNat_shiftRight, Nat.testBit_shiftRight,
     hmask, Bool.and_true, hshift, UInt32.toNat_or, UInt32.toNat_or, Nat.testBit_or,
     Nat.testBit_or, hb0eq,
@@ -1157,7 +1160,7 @@ theorem go_refill_step (litTable distTable : HuffTree.DecodeTable) (data : ByteA
         (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) bitpos output := by
   have hr : refill data pos bitBuf cnt
       = refill data (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) := by
-    rw [refill, if_pos hrc]
+    rw [refill, dif_pos hrc, getElem!_pos data pos hrc.2]
   rw [go, go, hr]
 
 /-- A short literal (`len ≠ 0`, `len ≤ cnt`) is decoded by `decodeSym` exactly as the
@@ -1201,7 +1204,7 @@ theorem goFused_absorb_refill (litTable distTable : HuffTree.DecodeTable) (data 
   rw [refill]
   split
   · rename_i hrc
-    rw [goFused, dif_pos hrc]
+    rw [goFused, dif_pos hrc, ← getElem!_pos data pos hrc.2]
     exact goFused_absorb_refill litTable distTable data litTree distTree maxOut dataSize bitpos output
       (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8)
   · rfl
@@ -1381,45 +1384,45 @@ theorem goFused_eq_go (litTable distTable : HuffTree.DecodeTable) (data : ByteAr
   | case1 pos bitBuf cnt bitpos output hrc ih =>
       rw [goFused, dif_pos hrc, ih,
         go_refill_step litTable distTable data litTree distTree maxOut dataSize
-          pos bitBuf cnt bitpos output hrc]
+          pos bitBuf cnt bitpos output hrc, getElem!_pos data pos hrc.2]
   | case2 pos bitBuf cnt bitpos output hrc e hde =>
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde]
   | case3 pos bitBuf cnt bitpos output hrc s bb c used hde hsym hmax =>
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_pos hsym, if_pos hmax]
   | case4 pos bitBuf cnt bitpos output hrc cnt0 s bb c used hde hsym hmax h1 =>
       have h1c : bitpos + (cnt - c) ≤ bitpos := h1
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_pos hsym, if_neg hmax, dif_pos h1c]
   | case5 pos bitBuf cnt bitpos output hrc cnt0 s bb c used hde hsym hmax h1 h2 =>
       have h1c : ¬ bitpos + (cnt - c) ≤ bitpos := h1
       have h2c : dataSize * 8 < bitpos + (cnt - c) := h2
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_pos hsym, if_neg hmax, dif_neg h1c, dif_pos h2c]
   | case6 pos bitBuf cnt bitpos output hrc cnt0 s bb c used hde hsym hmax h1 h2 ih =>
       have h1c : ¬ bitpos + (cnt - c) ≤ bitpos := h1
       have h2c : ¬ dataSize * 8 < bitpos + (cnt - c) := h2
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_pos hsym, if_neg hmax, dif_neg h1c, dif_neg h2c]
       exact ih
   | case7 pos bitBuf cnt bitpos output hrc s bb c used hde hsym heob =>
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_neg hsym, if_pos heob]
   | case8 pos bitBuf cnt bitpos output hrc s bb c used hde hns hneob idx hidx =>
       have hidxc : s.toNat - 257 ≥ Inflate.lengthBase.size := hidx
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       rw [goFused, dif_neg hrc, go, hrid]
       simp only [hde, if_neg hns, if_neg hneob, dif_pos hidxc]
   | case9 pos bitBuf cnt bitpos output hrc cnt0 s bb c used hde hns hneob idx hh base ih =>
       have hhc : ¬ s.toNat - 257 ≥ Inflate.lengthBase.size := hh
-      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, if_neg hrc]
+      have hrid : refill data pos bitBuf cnt = (pos, bitBuf, cnt) := by rw [refill, dif_neg hrc]
       simp only [show cnt0 = cnt from rfl] at ih
       have hext_lt : s.toNat - 257 < Inflate.lengthExtra.size := by
         simp only [Inflate.lengthExtra_size]
@@ -1495,7 +1498,7 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
         rw [USize.toNat_add, h8]; apply Nat.mod_eq_of_lt; omega
       rw [InflateBuf.goFusedPU, dif_pos hrc, InflateBuf.goFusedP, dif_pos hgN,
           ih (by rw [e1]; omega), e1, e2,
-          InflateBuf.uget_eq_getElem! data pos hpn, InflateBuf.usize_toUInt64_toNat]
+          InflateBuf.uget_eq_getElem data pos hpn, InflateBuf.usize_toUInt64_toNat]
   | case2 pos bitBuf cnt output hrc hlit hmax =>
       intro hpos
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_pos hlit, if_pos hmax,

--- a/Zip/Spec/InflateTable.lean
+++ b/Zip/Spec/InflateTable.lean
@@ -123,6 +123,28 @@ theorem bytesToBits_getElem? (data : ByteArray) (g : Nat) (hg : g < data.size * 
   rw [hgg] at hrest
   rw [← List.head?_drop, hrest, List.head?_cons, getElem!_pos data (g / 8) hq]
 
+/-- A proven-bounds byte read guarded by `i < data.size` equals the `!`-form ite:
+    bridges `peekFast`'s `dite`/`getElem` body back to the `ite`/`getElem!` shape
+    every `peekFast` proof below is written against. -/
+private theorem dite_getElem_toUInt32 (data : ByteArray) (i : Nat) :
+    (if h : i < data.size then (data[i]'h).toUInt32 else (0 : UInt32))
+      = (if i < data.size then data[i]!.toUInt32 else (0 : UInt32)) := by
+  by_cases h : i < data.size
+  · rw [dif_pos h, if_pos h, getElem!_pos data i h]
+  · rw [dif_neg h, if_neg h]
+
+/-- `peekFast` in `ite`/`getElem!` form. `peekFast` itself reads each byte with a
+    proven-bounds `dite` guard; this restates it with the panicking `!` reads so
+    the bit-correspondence proofs (which reason over the conditional bytes) keep
+    matching their `!`-based hypotheses. -/
+theorem peekFast_eq (br : BitReader) :
+    peekFast br =
+      ((((if br.pos < br.data.size then br.data[br.pos]!.toUInt32 else 0)
+          ||| ((if br.pos + 1 < br.data.size then br.data[br.pos + 1]!.toUInt32 else 0) <<< 8)
+          ||| ((if br.pos + 2 < br.data.size then br.data[br.pos + 2]!.toUInt32 else 0) <<< 16))
+        >>> br.bitOff.toUInt32) &&& 0x7FF) := by
+  simp only [peekFast, dite_getElem_toUInt32]
+
 /-- **peekFast bit correspondence.** Below `fastBits`, with enough bits left,
     the `j`-th peeked bit equals the `j`-th bit of the stream from the cursor. -/
 theorem peekFast_testBit (br : BitReader) (j : Nat)
@@ -160,7 +182,7 @@ theorem peekFast_testBit (br : BitReader) (j : Nat)
     split
     · have := UInt8.toNat_lt br.data[br.pos + 2]!; omega
     · decide
-  unfold peekFast
+  rw [peekFast_eq]
   -- Reduce to a single-bit query on the 24-bit window `b0 ||| (b1 <<< 8) ||| (b2 <<< 16)`.
   rw [UInt32.toNat_and, Nat.testBit_and, UInt32.toNat_shiftRight, Nat.testBit_shiftRight,
     hmask, Bool.and_true, hshift, UInt32.toNat_or, UInt32.toNat_or, Nat.testBit_or,
@@ -407,7 +429,7 @@ set_option maxRecDepth 4096 in
 theorem decodeWithTable_eq (tree : HuffTree) (br : BitReader) :
     tree.decodeWithTable tree.buildTable br = tree.decode br := by
   have hidx : (peekFast br).toNat < 2 ^ fastBits := by
-    unfold peekFast
+    rw [peekFast_eq]
     rw [UInt32.toNat_and]
     simp only [fastBits]
     exact Nat.and_lt_two_pow _ (by decide)

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -1421,7 +1421,9 @@ theorem goTreeFree_ok_iff_goFusedP (litTable distTable : HuffTree.DecodeTable)
         maxOut pos bitBuf cnt output = .ok r := by
   rw [goTreeFree, goFusedP]
   by_cases hrc : cnt ≤ 56 ∧ pos < data.size
-  · rw [dif_pos hrc, dif_pos hrc]
+  · -- `goFusedP`'s refill now reads `data[pos]'hrc.2`; normalise to `!` to match
+    -- `goTreeFree`'s (unchanged) `data[pos]!` refill read
+    rw [dif_pos hrc, dif_pos hrc, ← getElem!_pos data pos hrc.2]
     exact goTreeFree_ok_iff_goFusedP litTable distTable litLengths distLengths litLD distLD hlit_iff hdist_iff
       data maxOut (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output r
   · rw [dif_neg hrc, dif_neg hrc]

--- a/Zip/Spec/ReadBitsFastCorrect.lean
+++ b/Zip/Spec/ReadBitsFastCorrect.lean
@@ -24,8 +24,11 @@ theorem readBitsFast_go_eq (br : BitReader) (pos bitOff : Nat) (acc : UInt32) (s
   | succ k ih =>
     rw [readBitsFast.go, BitReader.readBits.go, BitReader.readBit]
     by_cases hp : pos ≥ br.data.size
-    · simp only [hp, ↓reduceIte, bind, Except.bind]
-    · simp only [hp, ↓reduceIte]
+    · simp only [hp, ↓reduceIte, ↓reduceDIte, bind, Except.bind]
+    · -- the proven-bounds read `br.data[pos]` (native side) matches the `!`-form
+      -- read of `BitReader.readBit` once normalised back to `getElem!`
+      rw [getElem!_pos br.data pos (by omega)]
+      simp only [hp, ↓reduceIte, ↓reduceDIte]
       by_cases hb : bitOff + 1 ≥ 8
       · simp only [hb, ↓reduceIte, bind, Except.bind]
         exact ih (pos + 1) 0 _ _


### PR DESCRIPTION
This PR converts the runtime-bounds-checked `]!` array reads on the pure-Lean RFC 1951 DEFLATE decode path — the reference decoder that consumes untrusted compressed input — to statically proven-bounds `]'h` access, removing the panic path while keeping behaviour identical. It closes #2581.

The six reads the issue enumerated are all converted: the per-bit byte read in `readBitsFast.go` (guarded by `if h : pos ≥ size`), the three window bytes in `peekFast` (`if` → `dite` capturing each bound), the `refill` byte read (from the loop guard), and the `DecodeTable.lenAt` / `symAt` packed-table lookups. The same guard-capture also covers the newer fused-loop refill reads in `goFused` and `goFusedP`.

For `lenAt` / `symAt` the read becomes `if h : idx < t.packed.size then unpackLen (t.packed[idx]'h) else 0`. The `0` sentinel is provably the same value the old `getElem!` returned out of bounds (`default = 0`, and `unpackLen 0 = unpackSym 0 = 0`); the rebuilt `lenAt_def` / `symAt_def` bridges certify `t.lenAt idx = unpackLen t.packed[idx]!` for every `idx`, so all downstream specs that name the `!`-form element are unaffected. This keeps `DecodeTable`'s signature stable (no structural change cascading into `InflateCanonical`), at the cost of leaving one `idx < size` comparison the original `]!` already paid. A follow-up could carry `packed.size = 2^fastBits` as a `DecodeTable` invariant to make the hot-path lookups branchless; that is a benchmark-driven decision, not needed for correctness.

The dependent specs are repaired with the standard bridges: `getElem!_pos` to normalise proven-bounds reads back to `!`-form so existing `!`-based hypotheses still apply, `getElem!_neg` for the sentinel branch, and `dif_pos` / `dif_neg` / `↓reduceDIte` where an `ite` became a `dite`. `InflateTable` gains a `peekFast_eq` lemma restating `peekFast` in `ite`/`!` form, used wherever a proof unfolded `peekFast`; `goFusedPU_eq` switches to the proven-form `uget_eq_getElem`; and `InflateTreeFreeCorrect` bridges `goFusedP`'s now-proven read back to `!` to match the unchanged `goTreeFree`.

Behaviour is identical and no bound is relaxed — the decode conformance and fuzz tests are the safety net. `lake build` is clean across all four dependent Spec files, `lake exe test` is green (1000-iteration fuzz, compress→FFI, differential header-mutation, truncated/concat/random decode-fuzz), and the sorry count is unchanged (0).

`grep -c ']!' Zip/Native/Inflate.lean` is now 9 (was 6 of these on the targeted reads). The 9 remaining are all justified: three sit inside the **statements** of the `lenAt_def` / `symAt_def` / `uget_eq_getElem!` bridge theorems (whose purpose is to relate proven access to `!`-form), and three are histogram-build helpers (`countLengthsFast` / `kraftSumFast` / `nextCodesFast`, from the later #2671 canonical-build work) that index internally-built arrays and were not among the issue's targeted decode-path reads. The other three are inside code comments.

🤖 Prepared with Claude Code