### PR TITLE
feat: connect Pareto levels with the achievable mixing frontier, not straight segments

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -79,6 +79,51 @@ stays current.
   committed dashboard half.
 - A PR touching both: produce both sets.
 
+## Reading the frontier honestly (mixing curves — do not skip)
+
+When a compression change lands a **new operating point** (a new tier, a new
+level, a knob that trades ratio for speed), the question is "is it *outside* our
+current Pareto frontier — a genuine gain — or could we already reach it by
+blending existing levels?" Answer it correctly or you will reject real wins.
+
+The achievable set between two adjacent levels is the **mixing curve**: compress
+a byte-fraction `f` at the higher level and `1-f` at the lower (exact per file;
+on the geomean dashboard it is a close proxy between the two geomean points). On
+that curve:
+
+- **ratio** is additive in bytes → linear in `f`;
+- **time** is additive → **1/throughput** is linear in `f` (throughput is a
+  rate; average the reciprocals, never the MB/s directly).
+
+So the curve is straight only in *(ratio, seconds-per-MiB)*. On the
+**log-MB/s Pareto we plot, a straight segment between two level dots sags *above*
+the real frontier** and overstates the achievable speed. `bench/plot.py` now
+draws the correct sagging mixing curve between levels (`_mix_curve`); the naive
+straight segment is a lie. (This bit us on #2638: a new L9-fast point looked
+"below the L8–L9 line, therefore useless" on the log plot, but against the true
+mixing curve it was +18–41% faster at equal ratio — a real point.)
+
+**The test, numerically:** interpolate the two bracketing levels to the new
+point's ratio in *time-per-byte*, i.e.
+
+    f       = (ratio_lo − ratio_new) / (ratio_lo − ratio_hi)
+    t_mix   = (1−f)/mbps_lo + f/mbps_hi        # seconds per MiB of the mix
+    outside = (1/mbps_new) < t_mix             # new point is faster at equal ratio
+
+If `outside`, it is a genuine Pareto gain. Compare in **seconds-per-MiB
+(`1/throughput`)**, not MB/s, and never eyeball it against the straight log-axis
+segment.
+
+**This is a within-native test — the bar for *our* progress.** It is separate
+from the C+SIMD references: libdeflate/zopfli set the absolute ceiling (context),
+not the pass/fail bar. A change that moves a point outside *our own* mixing curve
+is progress even while libdeflate stays ahead on both axes; do **not** gate
+incremental work on beating a SIMD C codec. When you write up a perf PR (or an
+issue proposing one), frame "moves us outside our frontier / a new top-left
+point" against this mixing test, not against the reference ceiling. (Cross-codec
+standing still matters as context, and for justifying a *new tier's* external
+reason to exist — it is just not the test for an incremental within-native gain.)
+
 ## Workflow
 
 Run from the repo root. On NixOS wrap commands in `nix-shell --run "…"` (see the

--- a/.claude/skills/perf-pr-graphs/plot_before_after.py
+++ b/.claude/skills/perf-pr-graphs/plot_before_after.py
@@ -99,29 +99,55 @@ def curve(rows, comp, corpus):
             pts.append((gr, gs))
     return sorted(pts)
 
+def mix_curve(x0, y0, x1, y1, n=40):
+    """Achievable frontier between two adjacent levels: compress a byte-fraction
+    `f` at one and `1-f` at the other. Ratio is additive (linear in `f`); time is
+    additive so **1/throughput** is linear (throughput, a rate, is not). A
+    straight segment on the log-MB/s axis sags *above* this curve and overstates
+    the achievable speed — so connectors must use this, not a straight line. See
+    bench/README.md and this skill's 'Reading the frontier honestly'."""
+    if not (y0 > 0 and y1 > 0):          # 1/speed undefined — fall back to a segment
+        return [x0, x1], [y0, y1]
+    xs, ys = [], []
+    for i in range(n + 1):
+        f = i / n
+        xs.append((1 - f) * x0 + f * x1)
+        ys.append(1.0 / ((1 - f) / y0 + f / y1))
+    return xs, ys
+
+def plot_series(ax, pts, *, color, mk, lw, ms, label, ls="-", zorder=4,
+                alpha=0.9, hollow=False):
+    """Markers at measured levels joined by mixing-frontier connectors."""
+    xs = [p[0] for p in pts]; ys = [p[1] for p in pts]
+    ax.plot(xs, ys, linestyle="none", marker=mk, ms=ms, color=color, zorder=zorder,
+            markerfacecolor=("none" if hollow else color), markeredgecolor=color,
+            label=label)
+    for a in range(len(pts) - 1):
+        cx, cy = mix_curve(xs[a], ys[a], xs[a + 1], ys[a + 1])
+        ax.plot(cx, cy, color=color, lw=lw, ls=ls, alpha=alpha, zorder=zorder)
+
 label_speed = "compression speed" if metric == "compress_mbps" else "decode throughput"
 
 for corpus in corpora(AFTER):
     fig, ax = plt.subplots(figsize=(10, 6.5))
-    # other-language context (reused), drawn as hollow rings underneath
+    # other-language context (reused), drawn as hollow rings underneath.
+    # Connectors are mixing frontiers (see `mix_curve`), not straight segments.
     for comp, lab, col, mk in REFS:
         pts = curve(LATEST, comp, corpus)
         if not pts:
             continue
-        ax.plot([p[0] for p in pts], [p[1] for p in pts], marker=mk, color=col,
-                lw=1.3, ms=5, alpha=0.9, zorder=4,
-                markerfacecolor="none", markeredgecolor=col, label=lab)
+        plot_series(ax, pts, color=col, mk=mk, lw=1.3, ms=5, zorder=4,
+                    hollow=True, label=lab)
     # native before (grey dashed) and after (solid red), on top
     pb = curve(BEFORE, "native", corpus)
     if pb:
-        ax.plot([p[0] for p in pb], [p[1] for p in pb], marker="o", color="#7f7f7f",
-                lw=2.2, ms=7, ls="--", zorder=11,
-                markerfacecolor="none", markeredgecolor="#7f7f7f",
-                label="lean-zip native — before")
+        plot_series(ax, pb, color="#7f7f7f", mk="o", lw=2.2, ms=7, ls="--",
+                    zorder=11, alpha=1.0, hollow=True,
+                    label="lean-zip native — before")
     pa = curve(AFTER, "native", corpus)
     if pa:
-        ax.plot([p[0] for p in pa], [p[1] for p in pa], marker="o", color="#d62728",
-                lw=2.6, ms=8, zorder=12, label="lean-zip native — AFTER")
+        plot_series(ax, pa, color="#d62728", mk="o", lw=2.6, ms=8, zorder=12,
+                    alpha=1.0, label="lean-zip native — AFTER")
     ax.set_yscale("log")
     ax.set_xlabel("compression ratio  (compressed / original — ← smaller = more compressed)")
     ax.set_ylabel(f"{label_speed}  (MB/s, log)")

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ Here is the interesting part.
 
 *[Silesia](https://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) corpus.
 x = compression ratio (← smaller is better), y = throughput
-(MB/s, log scale); each line is one codec swept across its levels, so up-and-to-the-left
-wins. The full dashboard (decode benchmarks, per-file heatmaps, and methodology)
-is in [`bench/`](bench/README.md).*
+(MB/s, log scale); each codec's levels are joined by its *achievable mixing
+frontier* — the ratio/speed points reachable by blending two adjacent levels —
+so up-and-to-the-left wins and a comparison at a matched ratio is honest (a
+straight segment on this log axis would overstate the achievable speed; see
+[`bench/README.md`](bench/README.md)). The full dashboard (decode benchmarks,
+per-file heatmaps, and methodology) is in [`bench/`](bench/README.md).*
 
 Once correctness is a *theorem*, you can ambitiously and aggressively optimize.
 Rewrite the hot loop, hand-roll the Huffman table walk,

--- a/bench/README.md
+++ b/bench/README.md
@@ -95,10 +95,11 @@ already-compressed file (a JPEG/PDF) — never synthetic noise.
 
 Each corpus gets a layered, corpus-generic set (a new corpus slots in with no
 code change). The **headline is the speed-vs-ratio Pareto scatter**: x = ratio
-(← smaller is better), y = speed (MB/s, log), and each codec is *one line tracing
-its levels*, so the whole speed/ratio tradeoff reads at a glance — top-left (fast
-*and* small) is best, and a dominated codec sits to the lower-right. Two
-complements give precise numbers and per-file detail:
+(← smaller is better), y = speed (MB/s, log), and each codec is markers at its
+measured levels joined by the **achievable mixing frontier** between adjacent
+levels (see *Reading the Pareto* below), so the whole speed/ratio tradeoff reads
+at a glance — top-left (fast *and* small) is best, and a dominated codec sits to
+the lower-right. Two complements give precise numbers and per-file detail:
 
 - `<corpus>_compress_pareto.svg` — **headline**: compression speed vs ratio,
   codecs as level-curves (replaces the whole per-level bar set).
@@ -112,6 +113,53 @@ complements give precise numbers and per-file detail:
   decompress per codec, level 6), sorted by speed.
 - `<corpus>_ratio_heatmap.svg` / `_compress_heatmap.svg` — per file, relative to
   zlib (red = worse), showing *where* a codec wins or loses without 100 bars.
+
+### Reading the Pareto (the mixing frontier — read this before judging a new tier)
+
+The line between a codec's two adjacent levels is **not** a straight segment. It
+is the **mixing curve**: the operating points you can actually reach by
+compressing a byte-fraction `f` of the input at the higher level and `1-f` at the
+lower one (e.g. per block). That is the real achievable set between two settings
+(exact for a single file; the plotted points are per-file geomeans, so between
+two geomean dots the curve is a close proxy for the corpus-geomean achievable
+set), so it is the honest connector. It joins *adjacent levels* — it is not a
+computed global upper envelope, so read it per codec, per neighbouring pair.
+
+The geometry matters, and it is easy to get wrong:
+
+- **Ratio** is additive in bytes, so it is *linear* in `f`.
+- **Wall-clock time** is additive, so **1/throughput** is *linear* in `f` —
+  throughput itself is not. Throughput is a rate; you average rates by averaging
+  their reciprocals (time), never the rates directly.
+- Therefore the frontier is a straight line **only** in *(ratio, time-per-byte)*
+  space. On the *(ratio, MB/s)* axis it is a curve, and on the **log-MB/s axis
+  (what we plot) a straight level-to-level segment sags *above* the true
+  frontier** — it overstates the speed reachable at an intermediate ratio. The
+  plot draws the correct sagging curve (`_mix_curve` in `plot.py`); trust it, not
+  a ruler laid between two dots.
+
+**Consequence for judging incremental progress.** A new operating point is a
+genuine improvement — *outside our own frontier* — iff, at its compression ratio,
+it is **faster than blending the two bracketing levels** (i.e. it sits *above*
+the codec's mixing curve at that ratio). Equivalently: interpolate the two
+adjacent levels to the new point's ratio; if that mix is slower, the new point is
+a real Pareto gain. Judging "inside/outside" by eye against the straight segment
+on the log axis is wrong and will reject real wins — this bit us once (issue
+#2638 measurement). To check it numerically, compare in **seconds-per-MiB
+(`1/throughput`)**, not MB/s:
+
+    f       = (ratio_lo − ratio_new) / (ratio_lo − ratio_hi)   # 0 at lo … 1 at hi
+    t_mix   = (1 − f)/mbps_lo + f/mbps_hi                       # s per MiB of the mix
+    outside = (1/mbps_new) < t_mix                              # new point faster at equal ratio
+
+**This is a within-codec test, and it is the bar for "did we make progress".** It
+is *not* the same as beating the C+SIMD references. libdeflate and zopfli set the
+absolute ratio/speed *ceiling* (the reference band), not the bar for our own
+incremental work: a change that pushes a point outside *our* mixing curve is
+progress even while the references remain ahead. Do not gate our own Pareto
+improvements on catching a SIMD C codec. (Cross-codec comparison still matters —
+as context, and for justifying a *new tier's* external reason to exist — it just
+is not the pass/fail test for an incremental within-native gain.)
 
 ### Canterbury corpus (11 small files, levels 1–9; libdeflate 1–12)
 

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m29a98c4e9f" d="M 0 0 
+       <path id="mc36641b3aa" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m29a98c4e9f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m29a98c4e9f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc36641b3aa" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5d5cd3a1de" d="M 0 0 
+       <path id="m66500a003c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66500a003c" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66500a003c" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5d5cd3a1de" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66500a003c" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="ma6858662ba" d="M 0 0 
+       <path id="m15f0745b20" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6858662ba" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m15f0745b20" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1739,130 +1739,1489 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.25942 
-L 308.273931 102.64095 
-L 271.230161 116.240058 
-L 217.83458 119.978674 
-L 177.077692 138.359262 
-L 162.880539 157.659557 
-L 160.741445 165.081439 
-L 153.966678 183.30847 
-L 151.589614 194.354473 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m366a485e49" d="M -2.5 2.5 
+     <path id="ma8b0475a2d" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m366a485e49" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m366a485e49" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#ma8b0475a2d" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8b0475a2d" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 75.906758 
-L 283.721324 98.757435 
-L 218.882044 120.902897 
-L 187.447228 126.710903 
-L 176.342474 138.212475 
-L 163.054314 161.207386 
-L 162.210539 168.678909 
-L 159.303811 175.634901 
-L 157.793928 179.408171 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.25942 
+L 354.496379 95.425534 
+L 353.512922 95.591068 
+L 352.529466 95.756025 
+L 351.54601 95.920411 
+L 350.562553 96.084228 
+L 349.579097 96.247481 
+L 348.595641 96.410174 
+L 347.612184 96.572309 
+L 346.628728 96.733892 
+L 345.645272 96.894926 
+L 344.661815 97.055415 
+L 343.678359 97.215362 
+L 342.694903 97.37477 
+L 341.711446 97.533645 
+L 340.72799 97.691988 
+L 339.744534 97.849804 
+L 338.761077 98.007097 
+L 337.777621 98.163869 
+L 336.794165 98.320124 
+L 335.810708 98.475865 
+L 334.827252 98.631097 
+L 333.843796 98.785821 
+L 332.860339 98.940042 
+L 331.876883 99.093763 
+L 330.893427 99.246987 
+L 329.90997 99.399717 
+L 328.926514 99.551956 
+L 327.943058 99.703708 
+L 326.959601 99.854975 
+L 325.976145 100.005761 
+L 324.992689 100.156069 
+L 324.009232 100.305902 
+L 323.025776 100.455262 
+L 322.04232 100.604153 
+L 321.058863 100.752577 
+L 320.075407 100.900539 
+L 319.091951 101.048039 
+L 318.108494 101.195082 
+L 317.125038 101.341671 
+L 316.141582 101.487807 
+L 315.158125 101.633494 
+L 314.174669 101.778734 
+L 313.191213 101.923531 
+L 312.207756 102.067886 
+L 311.2243 102.211803 
+L 310.240844 102.355284 
+L 309.257387 102.498333 
+L 308.273931 102.64095 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_77">
+    <path d="M 308.273931 102.64095 
+L 307.502186 102.96797 
+L 306.730441 103.292748 
+L 305.958695 103.615315 
+L 305.18695 103.935702 
+L 304.415205 104.253937 
+L 303.64346 104.570049 
+L 302.871714 104.884067 
+L 302.099969 105.196017 
+L 301.328224 105.505928 
+L 300.556479 105.813824 
+L 299.784734 106.119734 
+L 299.012988 106.423681 
+L 298.241243 106.725691 
+L 297.469498 107.025788 
+L 296.697753 107.323997 
+L 295.926008 107.620342 
+L 295.154262 107.914844 
+L 294.382517 108.207528 
+L 293.610772 108.498415 
+L 292.839027 108.787527 
+L 292.067281 109.074886 
+L 291.295536 109.360513 
+L 290.523791 109.644429 
+L 289.752046 109.926655 
+L 288.980301 110.207209 
+L 288.208555 110.486112 
+L 287.43681 110.763383 
+L 286.665065 111.039041 
+L 285.89332 111.313105 
+L 285.121575 111.585594 
+L 284.349829 111.856524 
+L 283.578084 112.125914 
+L 282.806339 112.393781 
+L 282.034594 112.660143 
+L 281.262849 112.925016 
+L 280.491103 113.188417 
+L 279.719358 113.450362 
+L 278.947613 113.710867 
+L 278.175868 113.969947 
+L 277.404122 114.227619 
+L 276.632377 114.483897 
+L 275.860632 114.738797 
+L 275.088887 114.992333 
+L 274.317142 115.24452 
+L 273.545396 115.495372 
+L 272.773651 115.744903 
+L 272.001906 115.993127 
+L 271.230161 116.240058 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 271.230161 116.240058 
+L 270.117753 116.321031 
+L 269.005345 116.401867 
+L 267.892937 116.482564 
+L 266.780529 116.563125 
+L 265.668121 116.643548 
+L 264.555713 116.723836 
+L 263.443305 116.803987 
+L 262.330897 116.884004 
+L 261.218489 116.963885 
+L 260.106081 117.043632 
+L 258.993673 117.123245 
+L 257.881265 117.202725 
+L 256.768858 117.282071 
+L 255.65645 117.361285 
+L 254.544042 117.440367 
+L 253.431634 117.519317 
+L 252.319226 117.598135 
+L 251.206818 117.676823 
+L 250.09441 117.75538 
+L 248.982002 117.833808 
+L 247.869594 117.912105 
+L 246.757186 117.990274 
+L 245.644778 118.068313 
+L 244.53237 118.146225 
+L 243.419962 118.224009 
+L 242.307554 118.301665 
+L 241.195146 118.379194 
+L 240.082738 118.456596 
+L 238.97033 118.533872 
+L 237.857923 118.611023 
+L 236.745515 118.688048 
+L 235.633107 118.764948 
+L 234.520699 118.841723 
+L 233.408291 118.918375 
+L 232.295883 118.994902 
+L 231.183475 119.071306 
+L 230.071067 119.147587 
+L 228.958659 119.223746 
+L 227.846251 119.299782 
+L 226.733843 119.375697 
+L 225.621435 119.45149 
+L 224.509027 119.527162 
+L 223.396619 119.602713 
+L 222.284211 119.678144 
+L 221.171803 119.753456 
+L 220.059395 119.828647 
+L 218.946988 119.90372 
+L 217.83458 119.978674 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 217.83458 119.978674 
+L 216.985478 120.444182 
+L 216.136376 120.905161 
+L 215.287274 121.361699 
+L 214.438172 121.813881 
+L 213.58907 122.261789 
+L 212.739969 122.705503 
+L 211.890867 123.145101 
+L 211.041765 123.580658 
+L 210.192663 124.012249 
+L 209.343561 124.439944 
+L 208.494459 124.863814 
+L 207.645358 125.283926 
+L 206.796256 125.700347 
+L 205.947154 126.11314 
+L 205.098052 126.522368 
+L 204.24895 126.928093 
+L 203.399848 127.330373 
+L 202.550747 127.729267 
+L 201.701645 128.124832 
+L 200.852543 128.517122 
+L 200.003441 128.906191 
+L 199.154339 129.292092 
+L 198.305237 129.674876 
+L 197.456136 130.054592 
+L 196.607034 130.431291 
+L 195.757932 130.805018 
+L 194.90883 131.175821 
+L 194.059728 131.543745 
+L 193.210626 131.908835 
+L 192.361525 132.271133 
+L 191.512423 132.630683 
+L 190.663321 132.987525 
+L 189.814219 133.3417 
+L 188.965117 133.693247 
+L 188.116016 134.042206 
+L 187.266914 134.388615 
+L 186.417812 134.732509 
+L 185.56871 135.073925 
+L 184.719608 135.4129 
+L 183.870506 135.749467 
+L 183.021405 136.08366 
+L 182.172303 136.415513 
+L 181.323201 136.745059 
+L 180.474099 137.072328 
+L 179.624997 137.397353 
+L 178.775895 137.720164 
+L 177.926794 138.04079 
+L 177.077692 138.359262 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_80">
+    <path d="M 177.077692 138.359262 
+L 176.781918 138.852998 
+L 176.486144 139.341643 
+L 176.19037 139.8253 
+L 175.894596 140.304071 
+L 175.598822 140.778053 
+L 175.303048 141.247341 
+L 175.007274 141.712028 
+L 174.7115 142.172202 
+L 174.415726 142.62795 
+L 174.119951 143.079357 
+L 173.824177 143.526505 
+L 173.528403 143.969473 
+L 173.232629 144.408339 
+L 172.936855 144.843177 
+L 172.641081 145.274062 
+L 172.345307 145.701064 
+L 172.049533 146.124253 
+L 171.753759 146.543697 
+L 171.457985 146.95946 
+L 171.162211 147.371607 
+L 170.866437 147.780201 
+L 170.570663 148.185302 
+L 170.274889 148.586969 
+L 169.979115 148.98526 
+L 169.683341 149.380232 
+L 169.387567 149.771939 
+L 169.091793 150.160434 
+L 168.796019 150.545771 
+L 168.500245 150.927999 
+L 168.204471 151.307169 
+L 167.908697 151.68333 
+L 167.612923 152.056528 
+L 167.317149 152.42681 
+L 167.021375 152.794221 
+L 166.725601 153.158805 
+L 166.429827 153.520606 
+L 166.134053 153.879665 
+L 165.838279 154.236025 
+L 165.542505 154.589724 
+L 165.246731 154.940804 
+L 164.950957 155.289301 
+L 164.655183 155.635254 
+L 164.359409 155.9787 
+L 164.063635 156.319675 
+L 163.767861 156.658214 
+L 163.472087 156.994351 
+L 163.176313 157.328121 
+L 162.880539 157.659557 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_81">
+    <path d="M 162.880539 157.659557 
+L 162.835974 157.82665 
+L 162.79141 157.993157 
+L 162.746845 158.15908 
+L 162.702281 158.324425 
+L 162.657716 158.489194 
+L 162.613152 158.653393 
+L 162.568588 158.817025 
+L 162.524023 158.980093 
+L 162.479459 159.142603 
+L 162.434894 159.304557 
+L 162.39033 159.465959 
+L 162.345765 159.626814 
+L 162.301201 159.787124 
+L 162.256636 159.946894 
+L 162.212072 160.106127 
+L 162.167508 160.264827 
+L 162.122943 160.422997 
+L 162.078379 160.580641 
+L 162.033814 160.737763 
+L 161.98925 160.894365 
+L 161.944685 161.050451 
+L 161.900121 161.206025 
+L 161.855556 161.361089 
+L 161.810992 161.515648 
+L 161.766428 161.669705 
+L 161.721863 161.823262 
+L 161.677299 161.976324 
+L 161.632734 162.128892 
+L 161.58817 162.280971 
+L 161.543605 162.432564 
+L 161.499041 162.583673 
+L 161.454477 162.734302 
+L 161.409912 162.884453 
+L 161.365348 163.034131 
+L 161.320783 163.183337 
+L 161.276219 163.332074 
+L 161.231654 163.480347 
+L 161.18709 163.628157 
+L 161.142525 163.775507 
+L 161.097961 163.9224 
+L 161.053397 164.06884 
+L 161.008832 164.214828 
+L 160.964268 164.360368 
+L 160.919703 164.505463 
+L 160.875139 164.650114 
+L 160.830574 164.794326 
+L 160.78601 164.9381 
+L 160.741445 165.081439 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_82">
+    <path d="M 160.741445 165.081439 
+L 160.600304 165.542285 
+L 160.459163 165.998692 
+L 160.318022 166.450746 
+L 160.176881 166.898528 
+L 160.03574 167.342119 
+L 159.894599 167.781595 
+L 159.753458 168.217034 
+L 159.612317 168.648508 
+L 159.471176 169.076088 
+L 159.330035 169.499846 
+L 159.188894 169.919847 
+L 159.047754 170.336159 
+L 158.906613 170.748845 
+L 158.765472 171.157968 
+L 158.624331 171.56359 
+L 158.48319 171.965769 
+L 158.342049 172.364563 
+L 158.200908 172.76003 
+L 158.059767 173.152223 
+L 157.918626 173.541198 
+L 157.777485 173.927005 
+L 157.636344 174.309697 
+L 157.495203 174.689324 
+L 157.354062 175.065933 
+L 157.212921 175.439573 
+L 157.07178 175.810289 
+L 156.930639 176.178129 
+L 156.789498 176.543135 
+L 156.648357 176.905351 
+L 156.507216 177.264819 
+L 156.366075 177.621582 
+L 156.224934 177.975678 
+L 156.083793 178.327148 
+L 155.942652 178.676031 
+L 155.801511 179.022364 
+L 155.66037 179.366184 
+L 155.519229 179.707527 
+L 155.378088 180.04643 
+L 155.236947 180.382926 
+L 155.095806 180.717049 
+L 154.954665 181.048833 
+L 154.813524 181.37831 
+L 154.672383 181.705513 
+L 154.531242 182.030471 
+L 154.390101 182.353217 
+L 154.24896 182.673779 
+L 154.107819 182.992187 
+L 153.966678 183.30847 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_83">
+    <path d="M 153.966678 183.30847 
+L 153.917156 183.566921 
+L 153.867633 183.823969 
+L 153.818111 184.079631 
+L 153.768589 184.333921 
+L 153.719067 184.586854 
+L 153.669545 184.838444 
+L 153.620023 185.088705 
+L 153.5705 185.337651 
+L 153.520978 185.585297 
+L 153.471456 185.831655 
+L 153.421934 186.076739 
+L 153.372412 186.320562 
+L 153.322889 186.563137 
+L 153.273367 186.804476 
+L 153.223845 187.044593 
+L 153.174323 187.283499 
+L 153.124801 187.521207 
+L 153.075279 187.757728 
+L 153.025756 187.993075 
+L 152.976234 188.227258 
+L 152.926712 188.460291 
+L 152.87719 188.692182 
+L 152.827668 188.922945 
+L 152.778146 189.152589 
+L 152.728623 189.381126 
+L 152.679101 189.608566 
+L 152.629579 189.834919 
+L 152.580057 190.060197 
+L 152.530535 190.284409 
+L 152.481013 190.507564 
+L 152.43149 190.729674 
+L 152.381968 190.950748 
+L 152.332446 191.170795 
+L 152.282924 191.389825 
+L 152.233402 191.607848 
+L 152.18388 191.824872 
+L 152.134357 192.040906 
+L 152.084835 192.255961 
+L 152.035313 192.470043 
+L 151.985791 192.683163 
+L 151.936269 192.895329 
+L 151.886747 193.106549 
+L 151.837224 193.316832 
+L 151.787702 193.526186 
+L 151.73818 193.734619 
+L 151.688658 193.942139 
+L 151.639136 194.148754 
+L 151.589614 194.354473 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_84">
     <defs>
-     <path id="m02f854e414" d="M 0 -2.5 
+     <path id="md472f5d34f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m02f854e414" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m02f854e414" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#md472f5d34f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md472f5d34f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_77">
-    <path d="M 251.559581 64.890426 
-L 203.775848 81.892474 
-L 186.982691 88.798621 
-L 179.779306 91.094902 
-L 157.610419 99.337194 
-L 148.722526 107.793132 
-L 144.388162 121.197738 
-L 127.071247 144.456083 
-L 124.491988 152.059912 
-L 92.613662 207.455314 
-L 87.348715 224.984992 
-L 86.053433 241.561213 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_85">
+    <path d="M 531.649087 75.906758 
+L 526.483926 76.51458 
+L 521.318764 77.114705 
+L 516.153602 77.707324 
+L 510.988441 78.292624 
+L 505.823279 78.870784 
+L 500.658117 79.441974 
+L 495.492955 80.006362 
+L 490.327794 80.564107 
+L 485.162632 81.115363 
+L 479.99747 81.660281 
+L 474.832308 82.199004 
+L 469.667147 82.731672 
+L 464.501985 83.258419 
+L 459.336823 83.779375 
+L 454.171662 84.294666 
+L 449.0065 84.804414 
+L 443.841338 85.308738 
+L 438.676176 85.807751 
+L 433.511015 86.301563 
+L 428.345853 86.790283 
+L 423.180691 87.274015 
+L 418.015529 87.752858 
+L 412.850368 88.226911 
+L 407.685206 88.696269 
+L 402.520044 89.161024 
+L 397.354882 89.621265 
+L 392.189721 90.077079 
+L 387.024559 90.528551 
+L 381.859397 90.975762 
+L 376.694236 91.418792 
+L 371.529074 91.857718 
+L 366.363912 92.292616 
+L 361.19875 92.72356 
+L 356.033589 93.15062 
+L 350.868427 93.573865 
+L 345.703265 93.993364 
+L 340.538103 94.409182 
+L 335.372942 94.821383 
+L 330.20778 95.23003 
+L 325.042618 95.635182 
+L 319.877457 96.036901 
+L 314.712295 96.435242 
+L 309.547133 96.830263 
+L 304.381971 97.222018 
+L 299.21681 97.610561 
+L 294.051648 97.995945 
+L 288.886486 98.37822 
+L 283.721324 98.757435 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_86">
+    <path d="M 283.721324 98.757435 
+L 282.370506 99.341933 
+L 281.019688 99.91931 
+L 279.668869 100.489736 
+L 278.318051 101.053378 
+L 276.967233 101.610394 
+L 275.616414 102.16094 
+L 274.265596 102.705162 
+L 272.914778 103.243206 
+L 271.563959 103.775209 
+L 270.213141 104.301306 
+L 268.862323 104.821626 
+L 267.511504 105.336296 
+L 266.160686 105.845436 
+L 264.809868 106.349163 
+L 263.459049 106.847593 
+L 262.108231 107.340835 
+L 260.757413 107.828995 
+L 259.406594 108.312179 
+L 258.055776 108.790485 
+L 256.704958 109.264012 
+L 255.354139 109.732854 
+L 254.003321 110.197103 
+L 252.652503 110.656848 
+L 251.301684 111.112175 
+L 249.950866 111.563169 
+L 248.600048 112.009912 
+L 247.249229 112.452482 
+L 245.898411 112.890957 
+L 244.547593 113.325413 
+L 243.196774 113.755921 
+L 241.845956 114.182554 
+L 240.495138 114.60538 
+L 239.144319 115.024467 
+L 237.793501 115.43988 
+L 236.442683 115.851683 
+L 235.091864 116.259938 
+L 233.741046 116.664706 
+L 232.390228 117.066046 
+L 231.039409 117.464016 
+L 229.688591 117.858671 
+L 228.337773 118.250067 
+L 226.986954 118.638257 
+L 225.636136 119.023292 
+L 224.285318 119.405225 
+L 222.934499 119.784103 
+L 221.583681 120.159977 
+L 220.232863 120.532893 
+L 218.882044 120.902897 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_87">
+    <path d="M 218.882044 120.902897 
+L 218.227152 121.03145 
+L 217.57226 121.159655 
+L 216.917368 121.287514 
+L 216.262476 121.415029 
+L 215.607584 121.542202 
+L 214.952692 121.669035 
+L 214.2978 121.795529 
+L 213.642908 121.921687 
+L 212.988016 122.047509 
+L 212.333124 122.172998 
+L 211.678232 122.298156 
+L 211.02334 122.422984 
+L 210.368448 122.547484 
+L 209.713556 122.671658 
+L 209.058664 122.795508 
+L 208.403772 122.919034 
+L 207.74888 123.04224 
+L 207.093988 123.165126 
+L 206.439096 123.287694 
+L 205.784204 123.409946 
+L 205.129312 123.531883 
+L 204.47442 123.653507 
+L 203.819528 123.77482 
+L 203.164636 123.895824 
+L 202.509744 124.016519 
+L 201.854852 124.136907 
+L 201.19996 124.25699 
+L 200.545068 124.37677 
+L 199.890176 124.496248 
+L 199.235284 124.615426 
+L 198.580392 124.734304 
+L 197.9255 124.852885 
+L 197.270608 124.97117 
+L 196.615716 125.08916 
+L 195.960824 125.206858 
+L 195.305932 125.324264 
+L 194.65104 125.441379 
+L 193.996148 125.558206 
+L 193.341256 125.674746 
+L 192.686364 125.791 
+L 192.031472 125.906969 
+L 191.37658 126.022655 
+L 190.721688 126.13806 
+L 190.066796 126.253184 
+L 189.411904 126.368029 
+L 188.757012 126.482596 
+L 188.10212 126.596887 
+L 187.447228 126.710903 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_88">
+    <path d="M 187.447228 126.710903 
+L 187.215878 126.981327 
+L 186.984529 127.250216 
+L 186.75318 127.517588 
+L 186.521831 127.783461 
+L 186.290482 128.047849 
+L 186.059133 128.310771 
+L 185.827784 128.572242 
+L 185.596435 128.832279 
+L 185.365086 129.090896 
+L 185.133737 129.34811 
+L 184.902388 129.603935 
+L 184.671039 129.858386 
+L 184.43969 130.111478 
+L 184.208341 130.363226 
+L 183.976992 130.613644 
+L 183.745643 130.862745 
+L 183.514294 131.110544 
+L 183.282945 131.357053 
+L 183.051596 131.602287 
+L 182.820247 131.846259 
+L 182.588898 132.08898 
+L 182.357549 132.330465 
+L 182.1262 132.570726 
+L 181.894851 132.809775 
+L 181.663502 133.047623 
+L 181.432153 133.284284 
+L 181.200804 133.519769 
+L 180.969455 133.75409 
+L 180.738106 133.987258 
+L 180.506757 134.219284 
+L 180.275408 134.450179 
+L 180.044058 134.679955 
+L 179.812709 134.908622 
+L 179.58136 135.136191 
+L 179.350011 135.362673 
+L 179.118662 135.588077 
+L 178.887313 135.812414 
+L 178.655964 136.035694 
+L 178.424615 136.257928 
+L 178.193266 136.479123 
+L 177.961917 136.699291 
+L 177.730568 136.918441 
+L 177.499219 137.136582 
+L 177.26787 137.353724 
+L 177.036521 137.569875 
+L 176.805172 137.785045 
+L 176.573823 137.999242 
+L 176.342474 138.212475 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_89">
+    <path d="M 176.342474 138.212475 
+L 176.065637 138.825109 
+L 175.788801 139.429924 
+L 175.511964 140.027117 
+L 175.235127 140.616878 
+L 174.958291 141.199389 
+L 174.681454 141.774826 
+L 174.404617 142.34336 
+L 174.127781 142.905154 
+L 173.850944 143.460366 
+L 173.574107 144.009148 
+L 173.297271 144.551648 
+L 173.020434 145.088007 
+L 172.743597 145.618364 
+L 172.466761 146.142851 
+L 172.189924 146.661596 
+L 171.913087 147.174724 
+L 171.636251 147.682356 
+L 171.359414 148.184607 
+L 171.082577 148.681591 
+L 170.805741 149.173417 
+L 170.528904 149.660191 
+L 170.252067 150.142016 
+L 169.975231 150.618991 
+L 169.698394 151.091213 
+L 169.421557 151.558776 
+L 169.144721 152.02177 
+L 168.867884 152.480285 
+L 168.591047 152.934406 
+L 168.314211 153.384216 
+L 168.037374 153.829797 
+L 167.760537 154.271227 
+L 167.483701 154.708583 
+L 167.206864 155.14194 
+L 166.930027 155.57137 
+L 166.653191 155.996943 
+L 166.376354 156.418728 
+L 166.099517 156.836792 
+L 165.82268 157.251201 
+L 165.545844 157.662017 
+L 165.269007 158.069302 
+L 164.99217 158.473116 
+L 164.715334 158.873518 
+L 164.438497 159.270566 
+L 164.16166 159.664314 
+L 163.884824 160.054818 
+L 163.607987 160.442131 
+L 163.33115 160.826303 
+L 163.054314 161.207386 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_90">
+    <path d="M 163.054314 161.207386 
+L 163.036735 161.375685 
+L 163.019157 161.543389 
+L 163.001578 161.710502 
+L 162.983999 161.877027 
+L 162.966421 162.042969 
+L 162.948842 162.208332 
+L 162.931263 162.37312 
+L 162.913685 162.537337 
+L 162.896106 162.700987 
+L 162.878527 162.864073 
+L 162.860949 163.0266 
+L 162.84337 163.188572 
+L 162.825791 163.349992 
+L 162.808213 163.510864 
+L 162.790634 163.671192 
+L 162.773056 163.83098 
+L 162.755477 163.99023 
+L 162.737898 164.148947 
+L 162.72032 164.307134 
+L 162.702741 164.464795 
+L 162.685162 164.621933 
+L 162.667584 164.778551 
+L 162.650005 164.934654 
+L 162.632426 165.090244 
+L 162.614848 165.245325 
+L 162.597269 165.399901 
+L 162.579691 165.553973 
+L 162.562112 165.707546 
+L 162.544533 165.860624 
+L 162.526955 166.013208 
+L 162.509376 166.165303 
+L 162.491797 166.316911 
+L 162.474219 166.468035 
+L 162.45664 166.61868 
+L 162.439061 166.768846 
+L 162.421483 166.918539 
+L 162.403904 167.06776 
+L 162.386326 167.216513 
+L 162.368747 167.3648 
+L 162.351168 167.512624 
+L 162.33359 167.659989 
+L 162.316011 167.806898 
+L 162.298432 167.953352 
+L 162.280854 168.099355 
+L 162.263275 168.244909 
+L 162.245696 168.390018 
+L 162.228118 168.534683 
+L 162.210539 168.678909 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_91">
+    <path d="M 162.210539 168.678909 
+L 162.149982 168.834745 
+L 162.089425 168.99007 
+L 162.028869 169.144888 
+L 161.968312 169.299201 
+L 161.907755 169.453014 
+L 161.847198 169.606329 
+L 161.786641 169.759149 
+L 161.726084 169.911479 
+L 161.665528 170.06332 
+L 161.604971 170.214676 
+L 161.544414 170.365551 
+L 161.483857 170.515947 
+L 161.4233 170.665866 
+L 161.362743 170.815313 
+L 161.302187 170.964291 
+L 161.24163 171.112801 
+L 161.181073 171.260847 
+L 161.120516 171.408433 
+L 161.059959 171.55556 
+L 160.999402 171.702232 
+L 160.938846 171.848451 
+L 160.878289 171.99422 
+L 160.817732 172.139543 
+L 160.757175 172.284421 
+L 160.696618 172.428857 
+L 160.636061 172.572855 
+L 160.575504 172.716416 
+L 160.514948 172.859544 
+L 160.454391 173.002241 
+L 160.393834 173.144509 
+L 160.333277 173.286352 
+L 160.27272 173.427771 
+L 160.212163 173.56877 
+L 160.151607 173.70935 
+L 160.09105 173.849514 
+L 160.030493 173.989265 
+L 159.969936 174.128606 
+L 159.909379 174.267537 
+L 159.848822 174.406063 
+L 159.788266 174.544185 
+L 159.727709 174.681905 
+L 159.667152 174.819226 
+L 159.606595 174.956151 
+L 159.546038 175.092681 
+L 159.485481 175.228819 
+L 159.424925 175.364567 
+L 159.364368 175.499927 
+L 159.303811 175.634901 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_92">
+    <path d="M 159.303811 175.634901 
+L 159.272355 175.716655 
+L 159.240899 175.798268 
+L 159.209443 175.87974 
+L 159.177987 175.961073 
+L 159.146531 176.042266 
+L 159.115076 176.12332 
+L 159.08362 176.204236 
+L 159.052164 176.285014 
+L 159.020708 176.365655 
+L 158.989252 176.446159 
+L 158.957796 176.526526 
+L 158.92634 176.606757 
+L 158.894884 176.686852 
+L 158.863428 176.766813 
+L 158.831973 176.846638 
+L 158.800517 176.92633 
+L 158.769061 177.005887 
+L 158.737605 177.085311 
+L 158.706149 177.164603 
+L 158.674693 177.243762 
+L 158.643237 177.322788 
+L 158.611781 177.401684 
+L 158.580325 177.480448 
+L 158.54887 177.559081 
+L 158.517414 177.637585 
+L 158.485958 177.715958 
+L 158.454502 177.794202 
+L 158.423046 177.872317 
+L 158.39159 177.950303 
+L 158.360134 178.028162 
+L 158.328678 178.105892 
+L 158.297222 178.183496 
+L 158.265767 178.260972 
+L 158.234311 178.338322 
+L 158.202855 178.415546 
+L 158.171399 178.492644 
+L 158.139943 178.569617 
+L 158.108487 178.646466 
+L 158.077031 178.72319 
+L 158.045575 178.799789 
+L 158.014119 178.876266 
+L 157.982664 178.952619 
+L 157.951208 179.028849 
+L 157.919752 179.104956 
+L 157.888296 179.180942 
+L 157.85684 179.256806 
+L 157.825384 179.332549 
+L 157.793928 179.408171 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_93">
     <defs>
-     <path id="m9e50b830b3" d="M -0 3.535534 
+     <path id="mbc0e668acc" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m9e50b830b3" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9e50b830b3" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#mbc0e668acc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc0e668acc" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_78">
-    <path d="M 75.810937 396.236449 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_94">
+    <path d="M 251.559581 64.890426 
+L 250.564087 65.314605 
+L 249.568592 65.735021 
+L 248.573098 66.15174 
+L 247.577604 66.564826 
+L 246.582109 66.974343 
+L 245.586615 67.380351 
+L 244.59112 67.78291 
+L 243.595626 68.182078 
+L 242.600131 68.577912 
+L 241.604637 68.970467 
+L 240.609142 69.359797 
+L 239.613648 69.745954 
+L 238.618153 70.12899 
+L 237.622659 70.508955 
+L 236.627165 70.885897 
+L 235.63167 71.259865 
+L 234.636176 71.630905 
+L 233.640681 71.999062 
+L 232.645187 72.364381 
+L 231.649692 72.726905 
+L 230.654198 73.086677 
+L 229.658703 73.443739 
+L 228.663209 73.79813 
+L 227.667715 74.14989 
+L 226.67222 74.499059 
+L 225.676726 74.845673 
+L 224.681231 75.189771 
+L 223.685737 75.531388 
+L 222.690242 75.87056 
+L 221.694748 76.207322 
+L 220.699253 76.541708 
+L 219.703759 76.873751 
+L 218.708264 77.203483 
+L 217.71277 77.530937 
+L 216.717276 77.856143 
+L 215.721781 78.179134 
+L 214.726287 78.499937 
+L 213.730792 78.818584 
+L 212.735298 79.135102 
+L 211.739803 79.44952 
+L 210.744309 79.761866 
+L 209.748814 80.072166 
+L 208.75332 80.380448 
+L 207.757825 80.686737 
+L 206.762331 80.99106 
+L 205.766837 81.29344 
+L 204.771342 81.593904 
+L 203.775848 81.892474 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_95">
+    <path d="M 203.775848 81.892474 
+L 203.42599 82.047112 
+L 203.076133 82.201247 
+L 202.726275 82.354882 
+L 202.376418 82.508021 
+L 202.026561 82.660666 
+L 201.676703 82.812821 
+L 201.326846 82.96449 
+L 200.976988 83.115674 
+L 200.627131 83.266378 
+L 200.277273 83.416604 
+L 199.927416 83.566355 
+L 199.577559 83.715634 
+L 199.227701 83.864445 
+L 198.877844 84.01279 
+L 198.527986 84.160672 
+L 198.178129 84.308094 
+L 197.828271 84.455058 
+L 197.478414 84.601569 
+L 197.128557 84.747627 
+L 196.778699 84.893237 
+L 196.428842 85.038401 
+L 196.078984 85.183122 
+L 195.729127 85.327402 
+L 195.37927 85.471244 
+L 195.029412 85.614651 
+L 194.679555 85.757625 
+L 194.329697 85.900169 
+L 193.97984 86.042285 
+L 193.629982 86.183977 
+L 193.280125 86.325246 
+L 192.930268 86.466095 
+L 192.58041 86.606527 
+L 192.230553 86.746544 
+L 191.880695 86.886149 
+L 191.530838 87.025344 
+L 191.18098 87.16413 
+L 190.831123 87.302512 
+L 190.481266 87.440491 
+L 190.131408 87.578069 
+L 189.781551 87.715248 
+L 189.431693 87.852032 
+L 189.081836 87.988422 
+L 188.731978 88.124421 
+L 188.382121 88.260031 
+L 188.032264 88.395253 
+L 187.682406 88.530091 
+L 187.332549 88.664546 
+L 186.982691 88.798621 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_96">
+    <path d="M 186.982691 88.798621 
+L 186.832621 88.847613 
+L 186.68255 88.896554 
+L 186.53248 88.945445 
+L 186.382409 88.994286 
+L 186.232339 89.043076 
+L 186.082268 89.091816 
+L 185.932198 89.140505 
+L 185.782127 89.189145 
+L 185.632057 89.237735 
+L 185.481986 89.286276 
+L 185.331916 89.334766 
+L 185.181845 89.383207 
+L 185.031774 89.431599 
+L 184.881704 89.479941 
+L 184.731633 89.528234 
+L 184.581563 89.576477 
+L 184.431492 89.624672 
+L 184.281422 89.672818 
+L 184.131351 89.720914 
+L 183.981281 89.768963 
+L 183.83121 89.816962 
+L 183.68114 89.864913 
+L 183.531069 89.912815 
+L 183.380999 89.960669 
+L 183.230928 90.008475 
+L 183.080858 90.056232 
+L 182.930787 90.103942 
+L 182.780717 90.151603 
+L 182.630646 90.199217 
+L 182.480575 90.246783 
+L 182.330505 90.294301 
+L 182.180434 90.341771 
+L 182.030364 90.389194 
+L 181.880293 90.43657 
+L 181.730223 90.483898 
+L 181.580152 90.531179 
+L 181.430082 90.578413 
+L 181.280011 90.6256 
+L 181.129941 90.67274 
+L 180.97987 90.719833 
+L 180.8298 90.766879 
+L 180.679729 90.813879 
+L 180.529659 90.860832 
+L 180.379588 90.907739 
+L 180.229518 90.954599 
+L 180.079447 91.001413 
+L 179.929376 91.048181 
+L 179.779306 91.094902 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_97">
+    <path d="M 179.779306 91.094902 
+L 179.317454 91.282084 
+L 178.855602 91.46853 
+L 178.39375 91.654245 
+L 177.931899 91.839235 
+L 177.470047 92.023506 
+L 177.008195 92.207063 
+L 176.546343 92.389911 
+L 176.084491 92.572057 
+L 175.62264 92.753505 
+L 175.160788 92.934262 
+L 174.698936 93.114331 
+L 174.237084 93.293719 
+L 173.775232 93.47243 
+L 173.31338 93.65047 
+L 172.851529 93.827844 
+L 172.389677 94.004556 
+L 171.927825 94.180611 
+L 171.465973 94.356015 
+L 171.004121 94.530772 
+L 170.54227 94.704887 
+L 170.080418 94.878365 
+L 169.618566 95.05121 
+L 169.156714 95.223427 
+L 168.694862 95.39502 
+L 168.23301 95.565994 
+L 167.771159 95.736353 
+L 167.309307 95.906102 
+L 166.847455 96.075246 
+L 166.385603 96.243787 
+L 165.923751 96.411732 
+L 165.4619 96.579083 
+L 165.000048 96.745845 
+L 164.538196 96.912023 
+L 164.076344 97.07762 
+L 163.614492 97.24264 
+L 163.15264 97.407088 
+L 162.690789 97.570967 
+L 162.228937 97.734281 
+L 161.767085 97.897034 
+L 161.305233 98.05923 
+L 160.843381 98.220873 
+L 160.38153 98.381967 
+L 159.919678 98.542515 
+L 159.457826 98.70252 
+L 158.995974 98.861987 
+L 158.534122 99.02092 
+L 158.07227 99.179321 
+L 157.610419 99.337194 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_98">
+    <path d="M 157.610419 99.337194 
+L 157.425254 99.529664 
+L 157.24009 99.721354 
+L 157.054925 99.912273 
+L 156.869761 100.102425 
+L 156.684597 100.291818 
+L 156.499432 100.480456 
+L 156.314268 100.668347 
+L 156.129103 100.855496 
+L 155.943939 101.041908 
+L 155.758774 101.22759 
+L 155.57361 101.412547 
+L 155.388446 101.596785 
+L 155.203281 101.78031 
+L 155.018117 101.963127 
+L 154.832952 102.145241 
+L 154.647788 102.326658 
+L 154.462623 102.507383 
+L 154.277459 102.687422 
+L 154.092295 102.866779 
+L 153.90713 103.045459 
+L 153.721966 103.223469 
+L 153.536801 103.400812 
+L 153.351637 103.577495 
+L 153.166472 103.753521 
+L 152.981308 103.928895 
+L 152.796144 104.103623 
+L 152.610979 104.277709 
+L 152.425815 104.451158 
+L 152.24065 104.623974 
+L 152.055486 104.796163 
+L 151.870321 104.967728 
+L 151.685157 105.138674 
+L 151.499993 105.309005 
+L 151.314828 105.478727 
+L 151.129664 105.647843 
+L 150.944499 105.816358 
+L 150.759335 105.984275 
+L 150.57417 106.1516 
+L 150.389006 106.318335 
+L 150.203842 106.484487 
+L 150.018677 106.650057 
+L 149.833513 106.815052 
+L 149.648348 106.979473 
+L 149.463184 107.143327 
+L 149.27802 107.306615 
+L 149.092855 107.469343 
+L 148.907691 107.631514 
+L 148.722526 107.793132 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_99">
+    <path d="M 148.722526 107.793132 
+L 148.632227 108.1148 
+L 148.541928 108.4343 
+L 148.451628 108.75166 
+L 148.361329 109.066908 
+L 148.27103 109.380074 
+L 148.180731 109.691183 
+L 148.090431 110.000263 
+L 148.000132 110.307341 
+L 147.909833 110.612441 
+L 147.819534 110.91559 
+L 147.729234 111.216811 
+L 147.638935 111.51613 
+L 147.548636 111.813571 
+L 147.458337 112.109156 
+L 147.368038 112.402908 
+L 147.277738 112.694852 
+L 147.187439 112.985007 
+L 147.09714 113.273397 
+L 147.006841 113.560042 
+L 146.916541 113.844964 
+L 146.826242 114.128183 
+L 146.735943 114.40972 
+L 146.645644 114.689593 
+L 146.555344 114.967824 
+L 146.465045 115.244431 
+L 146.374746 115.519432 
+L 146.284447 115.792847 
+L 146.194147 116.064693 
+L 146.103848 116.334988 
+L 146.013549 116.603751 
+L 145.92325 116.870998 
+L 145.83295 117.136746 
+L 145.742651 117.401013 
+L 145.652352 117.663814 
+L 145.562053 117.925165 
+L 145.471753 118.185083 
+L 145.381454 118.443583 
+L 145.291155 118.700681 
+L 145.200856 118.956392 
+L 145.110556 119.21073 
+L 145.020257 119.46371 
+L 144.929958 119.715347 
+L 144.839659 119.965655 
+L 144.749359 120.214647 
+L 144.65906 120.462338 
+L 144.568761 120.708742 
+L 144.478462 120.95387 
+L 144.388162 121.197738 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_100">
+    <path d="M 144.388162 121.197738 
+L 144.027393 121.819197 
+L 143.666624 122.432611 
+L 143.305855 123.038187 
+L 142.945086 123.636122 
+L 142.584317 124.226606 
+L 142.223548 124.809823 
+L 141.862779 125.385949 
+L 141.50201 125.955155 
+L 141.141241 126.517606 
+L 140.780472 127.073458 
+L 140.419703 127.622867 
+L 140.058934 128.165979 
+L 139.698165 128.702936 
+L 139.337395 129.233878 
+L 138.976626 129.758937 
+L 138.615857 130.278242 
+L 138.255088 130.791918 
+L 137.894319 131.300085 
+L 137.53355 131.802861 
+L 137.172781 132.300359 
+L 136.812012 132.792688 
+L 136.451243 133.279955 
+L 136.090474 133.762262 
+L 135.729705 134.23971 
+L 135.368936 134.712396 
+L 135.008167 135.180413 
+L 134.647398 135.643853 
+L 134.286629 136.102805 
+L 133.92586 136.557355 
+L 133.56509 137.007586 
+L 133.204321 137.45358 
+L 132.843552 137.895415 
+L 132.482783 138.333169 
+L 132.122014 138.766916 
+L 131.761245 139.196729 
+L 131.400476 139.622679 
+L 131.039707 140.044834 
+L 130.678938 140.463262 
+L 130.318169 140.878027 
+L 129.9574 141.289194 
+L 129.596631 141.696824 
+L 129.235862 142.100977 
+L 128.875093 142.501713 
+L 128.514324 142.899088 
+L 128.153555 143.293159 
+L 127.792786 143.68398 
+L 127.432016 144.071604 
+L 127.071247 144.456083 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_101">
+    <path d="M 127.071247 144.456083 
+L 127.017513 144.627603 
+L 126.963778 144.798504 
+L 126.910044 144.96879 
+L 126.856309 145.138467 
+L 126.802575 145.307539 
+L 126.74884 145.47601 
+L 126.695105 145.643883 
+L 126.641371 145.811165 
+L 126.587636 145.977858 
+L 126.533902 146.143966 
+L 126.480167 146.309494 
+L 126.426433 146.474446 
+L 126.372698 146.638826 
+L 126.318963 146.802638 
+L 126.265229 146.965886 
+L 126.211494 147.128572 
+L 126.15776 147.290703 
+L 126.104025 147.45228 
+L 126.050291 147.613309 
+L 125.996556 147.773792 
+L 125.942822 147.933734 
+L 125.889087 148.093137 
+L 125.835352 148.252006 
+L 125.781618 148.410345 
+L 125.727883 148.568156 
+L 125.674149 148.725443 
+L 125.620414 148.88221 
+L 125.56668 149.03846 
+L 125.512945 149.194197 
+L 125.45921 149.349423 
+L 125.405476 149.504143 
+L 125.351741 149.658359 
+L 125.298007 149.812075 
+L 125.244272 149.965294 
+L 125.190538 150.118019 
+L 125.136803 150.270253 
+L 125.083068 150.422 
+L 125.029334 150.573263 
+L 124.975599 150.724044 
+L 124.921865 150.874347 
+L 124.86813 151.024175 
+L 124.814396 151.173531 
+L 124.760661 151.322417 
+L 124.706926 151.470837 
+L 124.653192 151.618794 
+L 124.599457 151.76629 
+L 124.545723 151.913329 
+L 124.491988 152.059912 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_102">
+    <path d="M 124.491988 152.059912 
+L 123.827856 154.201178 
+L 123.163725 156.249859 
+L 122.499593 158.21363 
+L 121.835461 160.099252 
+L 121.171329 161.912706 
+L 120.507197 163.659314 
+L 119.843066 165.343829 
+L 119.178934 166.970515 
+L 118.514802 168.54321 
+L 117.85067 170.065385 
+L 117.186538 171.540184 
+L 116.522407 172.970467 
+L 115.858275 174.358843 
+L 115.194143 175.707698 
+L 114.530011 177.01922 
+L 113.86588 178.29542 
+L 113.201748 179.538151 
+L 112.537616 180.749123 
+L 111.873484 181.92992 
+L 111.209352 183.082008 
+L 110.545221 184.206751 
+L 109.881089 185.305417 
+L 109.216957 186.379187 
+L 108.552825 187.429165 
+L 107.888693 188.456382 
+L 107.224562 189.461805 
+L 106.56043 190.446338 
+L 105.896298 191.410833 
+L 105.232166 192.356089 
+L 104.568034 193.282858 
+L 103.903903 194.191849 
+L 103.239771 195.083732 
+L 102.575639 195.959139 
+L 101.911507 196.818668 
+L 101.247375 197.662884 
+L 100.583244 198.492323 
+L 99.919112 199.307494 
+L 99.25498 200.10888 
+L 98.590848 200.896939 
+L 97.926717 201.672106 
+L 97.262585 202.434797 
+L 96.598453 203.185408 
+L 95.934321 203.924315 
+L 95.270189 204.651876 
+L 94.606058 205.368437 
+L 93.941926 206.074323 
+L 93.277794 206.769849 
+L 92.613662 207.455314 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_103">
+    <path d="M 92.613662 207.455314 
+L 92.503976 207.895174 
+L 92.394289 208.330988 
+L 92.284603 208.762831 
+L 92.174917 209.190775 
+L 92.06523 209.614888 
+L 91.955544 210.035239 
+L 91.845857 210.451895 
+L 91.736171 210.864919 
+L 91.626485 211.274374 
+L 91.516798 211.680322 
+L 91.407112 212.082821 
+L 91.297425 212.481931 
+L 91.187739 212.877708 
+L 91.078053 213.270206 
+L 90.968366 213.659481 
+L 90.85868 214.045583 
+L 90.748993 214.428566 
+L 90.639307 214.808478 
+L 90.529621 215.185368 
+L 90.419934 215.559285 
+L 90.310248 215.930274 
+L 90.200562 216.298382 
+L 90.090875 216.663652 
+L 89.981189 217.026128 
+L 89.871502 217.385853 
+L 89.761816 217.742867 
+L 89.65213 218.097212 
+L 89.542443 218.448928 
+L 89.432757 218.798051 
+L 89.32307 219.144622 
+L 89.213384 219.488677 
+L 89.103698 219.830251 
+L 88.994011 220.169381 
+L 88.884325 220.506102 
+L 88.774638 220.840446 
+L 88.664952 221.172449 
+L 88.555266 221.502141 
+L 88.445579 221.829556 
+L 88.335893 222.154724 
+L 88.226206 222.477676 
+L 88.11652 222.798442 
+L 88.006834 223.117051 
+L 87.897147 223.433533 
+L 87.787461 223.747915 
+L 87.677774 224.060225 
+L 87.568088 224.37049 
+L 87.458402 224.678737 
+L 87.348715 224.984992 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_104">
+    <path d="M 87.348715 224.984992 
+L 87.32173 225.396639 
+L 87.294745 225.804741 
+L 87.26776 226.209358 
+L 87.240775 226.61055 
+L 87.21379 227.008374 
+L 87.186805 227.402886 
+L 87.15982 227.794141 
+L 87.132835 228.182192 
+L 87.10585 228.567091 
+L 87.078865 228.948889 
+L 87.05188 229.327635 
+L 87.024895 229.703379 
+L 86.99791 230.076167 
+L 86.970925 230.446044 
+L 86.94394 230.813058 
+L 86.916955 231.177251 
+L 86.889969 231.538666 
+L 86.862984 231.897345 
+L 86.835999 232.253331 
+L 86.809014 232.606662 
+L 86.782029 232.957378 
+L 86.755044 233.305517 
+L 86.728059 233.651118 
+L 86.701074 233.994216 
+L 86.674089 234.334849 
+L 86.647104 234.67305 
+L 86.620119 235.008854 
+L 86.593134 235.342296 
+L 86.566149 235.673408 
+L 86.539164 236.002223 
+L 86.512179 236.328771 
+L 86.485194 236.653085 
+L 86.458209 236.975195 
+L 86.431224 237.295129 
+L 86.404239 237.612919 
+L 86.377254 237.928591 
+L 86.350269 238.242174 
+L 86.323283 238.553697 
+L 86.296298 238.863184 
+L 86.269313 239.170664 
+L 86.242328 239.476161 
+L 86.215343 239.779701 
+L 86.188358 240.08131 
+L 86.161373 240.381011 
+L 86.134388 240.678828 
+L 86.107403 240.974786 
+L 86.080418 241.268907 
+L 86.053433 241.561213 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_105">
     <defs>
-     <path id="m8063323e4d" d="M -0 2.5 
+     <path id="m6a3f3ce72a" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m8063323e4d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#m6a3f3ce72a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_79">
-    <path d="M 362.865999 178.157653 
-L 278.798176 181.06557 
-L 251.17632 188.680634 
-L 200.806828 186.322161 
-L 169.803221 202.757761 
-L 161.916638 211.158991 
-L 158.697104 214.041592 
-L 154.26679 230.364582 
-L 153.096464 236.337782 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_106">
     <defs>
-     <path id="m36d8200e3c" d="M -0.833333 2.5 
+     <path id="m8172be00a2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1877,31 +3236,437 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m36d8200e3c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m36d8200e3c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#m8172be00a2" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8172be00a2" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_80">
-    <path d="M 301.619021 144.650944 
-L 250.236474 147.192871 
-L 225.418659 152.799409 
-L 212.328936 158.91628 
-L 209.030149 156.82091 
-L 197.547749 167.982576 
-L 194.819287 169.49094 
-L 193.12279 177.004847 
-L 192.79794 181.853352 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_107">
+    <path d="M 362.865999 178.157653 
+L 361.114586 178.220091 
+L 359.363173 178.282447 
+L 357.61176 178.344721 
+L 355.860347 178.406913 
+L 354.108934 178.469023 
+L 352.357521 178.531052 
+L 350.606108 178.593 
+L 348.854695 178.654867 
+L 347.103282 178.716654 
+L 345.351869 178.77836 
+L 343.600456 178.839986 
+L 341.849043 178.901532 
+L 340.09763 178.962998 
+L 338.346217 179.024384 
+L 336.594804 179.085691 
+L 334.843391 179.146919 
+L 333.091978 179.208067 
+L 331.340565 179.269137 
+L 329.589152 179.330129 
+L 327.837739 179.391042 
+L 326.086326 179.451876 
+L 324.334913 179.512633 
+L 322.5835 179.573312 
+L 320.832087 179.633913 
+L 319.080674 179.694437 
+L 317.329262 179.754884 
+L 315.577849 179.815254 
+L 313.826436 179.875547 
+L 312.075023 179.935763 
+L 310.32361 179.995903 
+L 308.572197 180.055966 
+L 306.820784 180.115954 
+L 305.069371 180.175866 
+L 303.317958 180.235702 
+L 301.566545 180.295463 
+L 299.815132 180.355148 
+L 298.063719 180.414758 
+L 296.312306 180.474294 
+L 294.560893 180.533755 
+L 292.80948 180.593141 
+L 291.058067 180.652453 
+L 289.306654 180.711691 
+L 287.555241 180.770854 
+L 285.803828 180.829944 
+L 284.052415 180.888961 
+L 282.301002 180.947904 
+L 280.549589 181.006774 
+L 278.798176 181.06557 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_108">
+    <path d="M 278.798176 181.06557 
+L 278.222721 181.237364 
+L 277.647265 181.408536 
+L 277.07181 181.579093 
+L 276.496355 181.749038 
+L 275.920899 181.918376 
+L 275.345444 182.087111 
+L 274.769989 182.255247 
+L 274.194533 182.422788 
+L 273.619078 182.58974 
+L 273.043623 182.756105 
+L 272.468168 182.921889 
+L 271.892712 183.087094 
+L 271.317257 183.251725 
+L 270.741802 183.415787 
+L 270.166346 183.579282 
+L 269.590891 183.742215 
+L 269.015436 183.904591 
+L 268.43998 184.066411 
+L 267.864525 184.227681 
+L 267.28907 184.388404 
+L 266.713614 184.548583 
+L 266.138159 184.708223 
+L 265.562704 184.867328 
+L 264.987248 185.025899 
+L 264.411793 185.183942 
+L 263.836338 185.341459 
+L 263.260882 185.498455 
+L 262.685427 185.654932 
+L 262.109972 185.810895 
+L 261.534516 185.966345 
+L 260.959061 186.121288 
+L 260.383606 186.275725 
+L 259.80815 186.429661 
+L 259.232695 186.583098 
+L 258.65724 186.73604 
+L 258.081784 186.888491 
+L 257.506329 187.040452 
+L 256.930874 187.191927 
+L 256.355418 187.34292 
+L 255.779963 187.493434 
+L 255.204508 187.64347 
+L 254.629052 187.793034 
+L 254.053597 187.942126 
+L 253.478142 188.090751 
+L 252.902686 188.238912 
+L 252.327231 188.386611 
+L 251.751776 188.53385 
+L 251.17632 188.680634 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_109">
+    <path d="M 251.17632 188.680634 
+L 250.126956 188.632677 
+L 249.077592 188.584672 
+L 248.028227 188.536619 
+L 246.978863 188.488516 
+L 245.929498 188.440365 
+L 244.880134 188.392164 
+L 243.830769 188.343915 
+L 242.781405 188.295616 
+L 241.732041 188.247269 
+L 240.682676 188.198871 
+L 239.633312 188.150425 
+L 238.583947 188.101928 
+L 237.534583 188.053382 
+L 236.485218 188.004787 
+L 235.435854 187.956141 
+L 234.38649 187.907445 
+L 233.337125 187.858699 
+L 232.287761 187.809904 
+L 231.238396 187.761057 
+L 230.189032 187.712161 
+L 229.139667 187.663214 
+L 228.090303 187.614216 
+L 227.040939 187.565167 
+L 225.991574 187.516068 
+L 224.94221 187.466918 
+L 223.892845 187.417717 
+L 222.843481 187.368464 
+L 221.794116 187.319161 
+L 220.744752 187.269806 
+L 219.695388 187.220399 
+L 218.646023 187.170941 
+L 217.596659 187.121432 
+L 216.547294 187.07187 
+L 215.49793 187.022257 
+L 214.448565 186.972592 
+L 213.399201 186.922874 
+L 212.349836 186.873105 
+L 211.300472 186.823283 
+L 210.251108 186.773408 
+L 209.201743 186.723481 
+L 208.152379 186.673502 
+L 207.103014 186.623469 
+L 206.05365 186.573384 
+L 205.004285 186.523246 
+L 203.954921 186.473055 
+L 202.905557 186.42281 
+L 201.856192 186.372512 
+L 200.806828 186.322161 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_110">
+    <path d="M 200.806828 186.322161 
+L 200.160919 186.729693 
+L 199.515011 187.133751 
+L 198.869102 187.534392 
+L 198.223194 187.931675 
+L 197.577285 188.325655 
+L 196.931377 188.716386 
+L 196.285468 189.103922 
+L 195.63956 189.488314 
+L 194.993652 189.869614 
+L 194.347743 190.24787 
+L 193.701835 190.62313 
+L 193.055926 190.995443 
+L 192.410018 191.364853 
+L 191.764109 191.731405 
+L 191.118201 192.095145 
+L 190.472292 192.456113 
+L 189.826384 192.814353 
+L 189.180475 193.169905 
+L 188.534567 193.522809 
+L 187.888658 193.873104 
+L 187.24275 194.220829 
+L 186.596841 194.566021 
+L 185.950933 194.908717 
+L 185.305024 195.248952 
+L 184.659116 195.586762 
+L 184.013208 195.922181 
+L 183.367299 196.255242 
+L 182.721391 196.585979 
+L 182.075482 196.914424 
+L 181.429574 197.240608 
+L 180.783665 197.564562 
+L 180.137757 197.886316 
+L 179.491848 198.205901 
+L 178.84594 198.523345 
+L 178.200031 198.838676 
+L 177.554123 199.151924 
+L 176.908214 199.463114 
+L 176.262306 199.772274 
+L 175.616397 200.07943 
+L 174.970489 200.384608 
+L 174.32458 200.687833 
+L 173.678672 200.98913 
+L 173.032764 201.288524 
+L 172.386855 201.586038 
+L 171.740947 201.881696 
+L 171.095038 202.175521 
+L 170.44913 202.467535 
+L 169.803221 202.757761 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_111">
+    <path d="M 169.803221 202.757761 
+L 169.638917 202.948874 
+L 169.474614 203.13922 
+L 169.31031 203.328804 
+L 169.146006 203.517632 
+L 168.981702 203.705712 
+L 168.817398 203.893047 
+L 168.653094 204.079645 
+L 168.488791 204.265512 
+L 168.324487 204.450652 
+L 168.160183 204.635071 
+L 167.995879 204.818776 
+L 167.831575 205.001771 
+L 167.667272 205.184062 
+L 167.502968 205.365655 
+L 167.338664 205.546555 
+L 167.17436 205.726766 
+L 167.010056 205.906295 
+L 166.845752 206.085147 
+L 166.681449 206.263325 
+L 166.517145 206.440837 
+L 166.352841 206.617686 
+L 166.188537 206.793877 
+L 166.024233 206.969416 
+L 165.85993 207.144307 
+L 165.695626 207.318555 
+L 165.531322 207.492165 
+L 165.367018 207.66514 
+L 165.202714 207.837487 
+L 165.03841 208.009209 
+L 164.874107 208.180312 
+L 164.709803 208.350798 
+L 164.545499 208.520674 
+L 164.381195 208.689943 
+L 164.216891 208.858609 
+L 164.052588 209.026677 
+L 163.888284 209.194151 
+L 163.72398 209.361035 
+L 163.559676 209.527334 
+L 163.395372 209.693051 
+L 163.231068 209.858191 
+L 163.066765 210.022757 
+L 162.902461 210.186754 
+L 162.738157 210.350185 
+L 162.573853 210.513054 
+L 162.409549 210.675366 
+L 162.245246 210.837123 
+L 162.080942 210.99833 
+L 161.916638 211.158991 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_112">
+    <path d="M 161.916638 211.158991 
+L 161.849564 211.220869 
+L 161.782491 211.282666 
+L 161.715417 211.344383 
+L 161.648343 211.406019 
+L 161.58127 211.467576 
+L 161.514196 211.529052 
+L 161.447123 211.590449 
+L 161.380049 211.651766 
+L 161.312975 211.713005 
+L 161.245902 211.774164 
+L 161.178828 211.835244 
+L 161.111755 211.896246 
+L 161.044681 211.957169 
+L 160.977607 212.018014 
+L 160.910534 212.078781 
+L 160.84346 212.13947 
+L 160.776386 212.200082 
+L 160.709313 212.260616 
+L 160.642239 212.321073 
+L 160.575166 212.381453 
+L 160.508092 212.441756 
+L 160.441018 212.501983 
+L 160.373945 212.562133 
+L 160.306871 212.622206 
+L 160.239797 212.682204 
+L 160.172724 212.742126 
+L 160.10565 212.801972 
+L 160.038577 212.861743 
+L 159.971503 212.921438 
+L 159.904429 212.981058 
+L 159.837356 213.040604 
+L 159.770282 213.100074 
+L 159.703209 213.15947 
+L 159.636135 213.218792 
+L 159.569061 213.278039 
+L 159.501988 213.337213 
+L 159.434914 213.396313 
+L 159.36784 213.455339 
+L 159.300767 213.514292 
+L 159.233693 213.573171 
+L 159.16662 213.631978 
+L 159.099546 213.690711 
+L 159.032472 213.749372 
+L 158.965399 213.80796 
+L 158.898325 213.866476 
+L 158.831251 213.92492 
+L 158.764178 213.983292 
+L 158.697104 214.041592 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_113">
+    <path d="M 158.697104 214.041592 
+L 158.604806 214.445838 
+L 158.512508 214.846665 
+L 158.42021 215.244129 
+L 158.327911 215.638288 
+L 158.235613 216.029196 
+L 158.143315 216.416905 
+L 158.051017 216.801468 
+L 157.958718 217.182935 
+L 157.86642 217.561356 
+L 157.774122 217.936779 
+L 157.681824 218.309252 
+L 157.589526 218.678819 
+L 157.497227 219.045527 
+L 157.404929 219.409419 
+L 157.312631 219.770537 
+L 157.220333 220.128925 
+L 157.128034 220.484623 
+L 157.035736 220.83767 
+L 156.943438 221.188107 
+L 156.85114 221.535972 
+L 156.758842 221.881301 
+L 156.666543 222.224133 
+L 156.574245 222.564502 
+L 156.481947 222.902443 
+L 156.389649 223.237992 
+L 156.29735 223.571181 
+L 156.205052 223.902044 
+L 156.112754 224.230614 
+L 156.020456 224.55692 
+L 155.928158 224.880995 
+L 155.835859 225.202869 
+L 155.743561 225.522572 
+L 155.651263 225.840132 
+L 155.558965 226.155578 
+L 155.466666 226.468939 
+L 155.374368 226.78024 
+L 155.28207 227.089511 
+L 155.189772 227.396775 
+L 155.097474 227.702061 
+L 155.005175 228.005392 
+L 154.912877 228.306794 
+L 154.820579 228.606292 
+L 154.728281 228.903908 
+L 154.635982 229.199667 
+L 154.543684 229.493591 
+L 154.451386 229.785704 
+L 154.359088 230.076027 
+L 154.26679 230.364582 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_114">
+    <path d="M 154.26679 230.364582 
+L 154.242408 230.497021 
+L 154.218026 230.629091 
+L 154.193644 230.760794 
+L 154.169262 230.892133 
+L 154.144881 231.023108 
+L 154.120499 231.153722 
+L 154.096117 231.283977 
+L 154.071735 231.413875 
+L 154.047354 231.543418 
+L 154.022972 231.672608 
+L 153.99859 231.801447 
+L 153.974208 231.929936 
+L 153.949826 232.058078 
+L 153.925445 232.185874 
+L 153.901063 232.313327 
+L 153.876681 232.440438 
+L 153.852299 232.567208 
+L 153.827918 232.693641 
+L 153.803536 232.819737 
+L 153.779154 232.945498 
+L 153.754772 233.070927 
+L 153.730391 233.196024 
+L 153.706009 233.320792 
+L 153.681627 233.445233 
+L 153.657245 233.569347 
+L 153.632863 233.693137 
+L 153.608482 233.816605 
+L 153.5841 233.939752 
+L 153.559718 234.06258 
+L 153.535336 234.18509 
+L 153.510955 234.307284 
+L 153.486573 234.429164 
+L 153.462191 234.550732 
+L 153.437809 234.671988 
+L 153.413427 234.792935 
+L 153.389046 234.913574 
+L 153.364664 235.033906 
+L 153.340282 235.153934 
+L 153.3159 235.273659 
+L 153.291519 235.393081 
+L 153.267137 235.512204 
+L 153.242755 235.631028 
+L 153.218373 235.749555 
+L 153.193992 235.867786 
+L 153.16961 235.985723 
+L 153.145228 236.103367 
+L 153.120846 236.220719 
+L 153.096464 236.337782 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_115">
     <defs>
-     <path id="me7e7c6836c" d="M -1.25 2.5 
+     <path id="m1c50d60c68" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1916,31 +3681,437 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#me7e7c6836c" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me7e7c6836c" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#m1c50d60c68" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1c50d60c68" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_81">
-    <path d="M 206.45578 118.264704 
-L 206.45578 117.943158 
-L 206.45578 118.023409 
-L 206.45578 118.008666 
-L 171.767499 133.507746 
-L 163.54283 144.396316 
-L 160.174881 150.295858 
-L 154.179217 168.595905 
-L 152.4406 178.324207 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_116">
+    <path d="M 301.619021 144.650944 
+L 300.548551 144.705316 
+L 299.478081 144.759625 
+L 298.407612 144.813872 
+L 297.337142 144.868057 
+L 296.266672 144.922181 
+L 295.196202 144.976242 
+L 294.125733 145.030242 
+L 293.055263 145.08418 
+L 291.984793 145.138057 
+L 290.914323 145.191873 
+L 289.843854 145.245628 
+L 288.773384 145.299322 
+L 287.702914 145.352955 
+L 286.632445 145.406528 
+L 285.561975 145.46004 
+L 284.491505 145.513492 
+L 283.421035 145.566883 
+L 282.350566 145.620215 
+L 281.280096 145.673486 
+L 280.209626 145.726698 
+L 279.139157 145.77985 
+L 278.068687 145.832942 
+L 276.998217 145.885975 
+L 275.927747 145.938949 
+L 274.857278 145.991863 
+L 273.786808 146.044719 
+L 272.716338 146.097516 
+L 271.645868 146.150253 
+L 270.575399 146.202933 
+L 269.504929 146.255553 
+L 268.434459 146.308116 
+L 267.36399 146.36062 
+L 266.29352 146.413066 
+L 265.22305 146.465454 
+L 264.15258 146.517784 
+L 263.082111 146.570057 
+L 262.011641 146.622272 
+L 260.941171 146.674429 
+L 259.870702 146.726529 
+L 258.800232 146.778572 
+L 257.729762 146.830558 
+L 256.659292 146.882487 
+L 255.588823 146.934359 
+L 254.518353 146.986174 
+L 253.447883 147.037933 
+L 252.377414 147.089635 
+L 251.306944 147.141281 
+L 250.236474 147.192871 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_117">
+    <path d="M 250.236474 147.192871 
+L 249.719436 147.316702 
+L 249.202398 147.44021 
+L 248.685361 147.563397 
+L 248.168323 147.686265 
+L 247.651285 147.808815 
+L 247.134247 147.93105 
+L 246.617209 148.052969 
+L 246.100172 148.174576 
+L 245.583134 148.295871 
+L 245.066096 148.416857 
+L 244.549058 148.537535 
+L 244.03202 148.657906 
+L 243.514982 148.777972 
+L 242.997945 148.897735 
+L 242.480907 149.017196 
+L 241.963869 149.136356 
+L 241.446831 149.255218 
+L 240.929793 149.373782 
+L 240.412756 149.49205 
+L 239.895718 149.610024 
+L 239.37868 149.727705 
+L 238.861642 149.845095 
+L 238.344604 149.962194 
+L 237.827566 150.079005 
+L 237.310529 150.195528 
+L 236.793491 150.311766 
+L 236.276453 150.427719 
+L 235.759415 150.543389 
+L 235.242377 150.658778 
+L 234.72534 150.773886 
+L 234.208302 150.888715 
+L 233.691264 151.003267 
+L 233.174226 151.117542 
+L 232.657188 151.231543 
+L 232.14015 151.34527 
+L 231.623113 151.458725 
+L 231.106075 151.571909 
+L 230.589037 151.684823 
+L 230.071999 151.797468 
+L 229.554961 151.909847 
+L 229.037924 152.02196 
+L 228.520886 152.133808 
+L 228.003848 152.245392 
+L 227.48681 152.356715 
+L 226.969772 152.467777 
+L 226.452735 152.578579 
+L 225.935697 152.689122 
+L 225.418659 152.799409 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_118">
+    <path d="M 225.418659 152.799409 
+L 225.145956 152.935239 
+L 224.873254 153.070681 
+L 224.600551 153.205737 
+L 224.327849 153.340409 
+L 224.055146 153.474699 
+L 223.782444 153.60861 
+L 223.509741 153.742144 
+L 223.237038 153.875302 
+L 222.964336 154.008087 
+L 222.691633 154.140502 
+L 222.418931 154.272547 
+L 222.146228 154.404225 
+L 221.873526 154.535539 
+L 221.600823 154.66649 
+L 221.328121 154.797079 
+L 221.055418 154.92731 
+L 220.782715 155.057184 
+L 220.510013 155.186703 
+L 220.23731 155.315869 
+L 219.964608 155.444684 
+L 219.691905 155.57315 
+L 219.419203 155.701268 
+L 219.1465 155.829041 
+L 218.873798 155.956471 
+L 218.601095 156.083558 
+L 218.328392 156.210306 
+L 218.05569 156.336715 
+L 217.782987 156.462789 
+L 217.510285 156.588528 
+L 217.237582 156.713934 
+L 216.96488 156.839009 
+L 216.692177 156.963754 
+L 216.419475 157.088173 
+L 216.146772 157.212265 
+L 215.874069 157.336034 
+L 215.601367 157.45948 
+L 215.328664 157.582605 
+L 215.055962 157.705411 
+L 214.783259 157.8279 
+L 214.510557 157.950073 
+L 214.237854 158.071932 
+L 213.965152 158.193478 
+L 213.692449 158.314713 
+L 213.419746 158.435639 
+L 213.147044 158.556257 
+L 212.874341 158.676569 
+L 212.601639 158.796576 
+L 212.328936 158.91628 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_119">
+    <path d="M 212.328936 158.91628 
+L 212.260212 158.873558 
+L 212.191487 158.830798 
+L 212.122762 158.787999 
+L 212.054037 158.745162 
+L 211.985313 158.702285 
+L 211.916588 158.65937 
+L 211.847863 158.616416 
+L 211.779138 158.573423 
+L 211.710414 158.530391 
+L 211.641689 158.48732 
+L 211.572964 158.444209 
+L 211.504239 158.40106 
+L 211.435515 158.357871 
+L 211.36679 158.314642 
+L 211.298065 158.271374 
+L 211.229341 158.228067 
+L 211.160616 158.18472 
+L 211.091891 158.141333 
+L 211.023166 158.097907 
+L 210.954442 158.05444 
+L 210.885717 158.010934 
+L 210.816992 157.967388 
+L 210.748267 157.923802 
+L 210.679543 157.880176 
+L 210.610818 157.836509 
+L 210.542093 157.792802 
+L 210.473369 157.749055 
+L 210.404644 157.705267 
+L 210.335919 157.661439 
+L 210.267194 157.617571 
+L 210.19847 157.573661 
+L 210.129745 157.529711 
+L 210.06102 157.485721 
+L 209.992295 157.441689 
+L 209.923571 157.397616 
+L 209.854846 157.353503 
+L 209.786121 157.309348 
+L 209.717396 157.265152 
+L 209.648672 157.220915 
+L 209.579947 157.176636 
+L 209.511222 157.132316 
+L 209.442498 157.087955 
+L 209.373773 157.043552 
+L 209.305048 156.999107 
+L 209.236323 156.954621 
+L 209.167599 156.910092 
+L 209.098874 156.865522 
+L 209.030149 156.82091 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_120">
+    <path d="M 209.030149 156.82091 
+L 208.790932 157.08239 
+L 208.551716 157.342435 
+L 208.312499 157.60106 
+L 208.073282 157.858282 
+L 207.834066 158.114115 
+L 207.594849 158.368575 
+L 207.355632 158.621675 
+L 207.116416 158.873431 
+L 206.877199 159.123857 
+L 206.637982 159.372966 
+L 206.398766 159.620772 
+L 206.159549 159.867289 
+L 205.920332 160.112531 
+L 205.681116 160.356509 
+L 205.441899 160.599239 
+L 205.202682 160.840731 
+L 204.963466 161.080999 
+L 204.724249 161.320055 
+L 204.485032 161.55791 
+L 204.245816 161.794578 
+L 204.006599 162.03007 
+L 203.767382 162.264398 
+L 203.528166 162.497572 
+L 203.288949 162.729605 
+L 203.049732 162.960507 
+L 202.810516 163.19029 
+L 202.571299 163.418963 
+L 202.332082 163.646539 
+L 202.092866 163.873027 
+L 201.853649 164.098437 
+L 201.614432 164.322781 
+L 201.375216 164.546067 
+L 201.135999 164.768307 
+L 200.896782 164.989508 
+L 200.657566 165.209683 
+L 200.418349 165.428839 
+L 200.179132 165.646986 
+L 199.939916 165.864133 
+L 199.700699 166.08029 
+L 199.461482 166.295465 
+L 199.222266 166.509668 
+L 198.983049 166.722907 
+L 198.743832 166.935191 
+L 198.504616 167.146528 
+L 198.265399 167.356927 
+L 198.026182 167.566396 
+L 197.786966 167.774943 
+L 197.547749 167.982576 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_121">
+    <path d="M 197.547749 167.982576 
+L 197.490906 168.014495 
+L 197.434063 168.046392 
+L 197.37722 168.078268 
+L 197.320377 168.110123 
+L 197.263534 168.141956 
+L 197.206691 168.173768 
+L 197.149848 168.205558 
+L 197.093005 168.237327 
+L 197.036162 168.269075 
+L 196.979319 168.300802 
+L 196.922476 168.332507 
+L 196.865633 168.364192 
+L 196.80879 168.395855 
+L 196.751947 168.427497 
+L 196.695104 168.459117 
+L 196.638261 168.490717 
+L 196.581418 168.522296 
+L 196.524576 168.553853 
+L 196.467733 168.58539 
+L 196.41089 168.616906 
+L 196.354047 168.6484 
+L 196.297204 168.679874 
+L 196.240361 168.711327 
+L 196.183518 168.742759 
+L 196.126675 168.77417 
+L 196.069832 168.805561 
+L 196.012989 168.83693 
+L 195.956146 168.868279 
+L 195.899303 168.899607 
+L 195.84246 168.930915 
+L 195.785617 168.962201 
+L 195.728774 168.993468 
+L 195.671931 169.024713 
+L 195.615088 169.055938 
+L 195.558245 169.087142 
+L 195.501402 169.118326 
+L 195.444559 169.14949 
+L 195.387716 169.180632 
+L 195.330873 169.211755 
+L 195.27403 169.242857 
+L 195.217187 169.273938 
+L 195.160344 169.305 
+L 195.103501 169.33604 
+L 195.046658 169.367061 
+L 194.989815 169.398061 
+L 194.932972 169.429041 
+L 194.876129 169.460001 
+L 194.819287 169.49094 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_122">
+    <path d="M 194.819287 169.49094 
+L 194.783943 169.66027 
+L 194.748599 169.828997 
+L 194.713256 169.997126 
+L 194.677912 170.16466 
+L 194.642568 170.331604 
+L 194.607224 170.497962 
+L 194.571881 170.663738 
+L 194.536537 170.828936 
+L 194.501193 170.99356 
+L 194.46585 171.157614 
+L 194.430506 171.321102 
+L 194.395162 171.484028 
+L 194.359819 171.646396 
+L 194.324475 171.808209 
+L 194.289131 171.969472 
+L 194.253788 172.130188 
+L 194.218444 172.290361 
+L 194.1831 172.449994 
+L 194.147757 172.609091 
+L 194.112413 172.767656 
+L 194.077069 172.925692 
+L 194.041726 173.083203 
+L 194.006382 173.240192 
+L 193.971038 173.396663 
+L 193.935695 173.552618 
+L 193.900351 173.708062 
+L 193.865007 173.862998 
+L 193.829664 174.017429 
+L 193.79432 174.171359 
+L 193.758976 174.32479 
+L 193.723633 174.477725 
+L 193.688289 174.630169 
+L 193.652945 174.782124 
+L 193.617602 174.933594 
+L 193.582258 175.08458 
+L 193.546914 175.235088 
+L 193.511571 175.385118 
+L 193.476227 175.534675 
+L 193.440883 175.683762 
+L 193.40554 175.832381 
+L 193.370196 175.980536 
+L 193.334852 176.128228 
+L 193.299509 176.275462 
+L 193.264165 176.42224 
+L 193.228821 176.568565 
+L 193.193478 176.714439 
+L 193.158134 176.859866 
+L 193.12279 177.004847 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_123">
+    <path d="M 193.12279 177.004847 
+L 193.116023 177.111087 
+L 193.109255 177.217089 
+L 193.102487 177.322854 
+L 193.095719 177.428384 
+L 193.088952 177.533679 
+L 193.082184 177.638741 
+L 193.075416 177.74357 
+L 193.068649 177.848168 
+L 193.061881 177.952536 
+L 193.055113 178.056675 
+L 193.048345 178.160585 
+L 193.041578 178.264267 
+L 193.03481 178.367724 
+L 193.028042 178.470954 
+L 193.021274 178.573961 
+L 193.014507 178.676744 
+L 193.007739 178.779305 
+L 193.000971 178.881644 
+L 192.994204 178.983763 
+L 192.987436 179.085662 
+L 192.980668 179.187342 
+L 192.9739 179.288805 
+L 192.967133 179.390051 
+L 192.960365 179.491081 
+L 192.953597 179.591896 
+L 192.94683 179.692497 
+L 192.940062 179.792886 
+L 192.933294 179.893061 
+L 192.926526 179.993026 
+L 192.919759 180.09278 
+L 192.912991 180.192325 
+L 192.906223 180.29166 
+L 192.899456 180.390789 
+L 192.892688 180.48971 
+L 192.88592 180.588425 
+L 192.879152 180.686935 
+L 192.872385 180.78524 
+L 192.865617 180.883342 
+L 192.858849 180.981242 
+L 192.852082 181.078939 
+L 192.845314 181.176436 
+L 192.838546 181.273732 
+L 192.831778 181.370829 
+L 192.825011 181.467728 
+L 192.818243 181.564429 
+L 192.811475 181.660932 
+L 192.804707 181.75724 
+L 192.79794 181.853352 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_124">
     <defs>
-     <path id="mdc78908ea3" d="M 0 -2.5 
+     <path id="ma0e4067efa" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1953,31 +4124,437 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdc78908ea3" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#ma0e4067efa" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_82">
-    <path d="M 610.467188 173.595159 
-L 592.067397 175.027997 
-L 534.807821 181.390376 
-L 327.802209 176.703263 
-L 275.83761 187.043834 
-L 258.25125 199.15685 
-L 256.777056 204.107569 
-L 248.769854 218.250617 
-L 246.264594 228.00198 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_125">
+    <path d="M 206.45578 118.264704 
+L 206.45578 118.258027 
+L 206.45578 118.25135 
+L 206.45578 118.244671 
+L 206.45578 118.237992 
+L 206.45578 118.231311 
+L 206.45578 118.22463 
+L 206.45578 118.217948 
+L 206.45578 118.211264 
+L 206.45578 118.20458 
+L 206.45578 118.197895 
+L 206.45578 118.191209 
+L 206.45578 118.184522 
+L 206.45578 118.177834 
+L 206.45578 118.171145 
+L 206.45578 118.164455 
+L 206.45578 118.157764 
+L 206.45578 118.151072 
+L 206.45578 118.14438 
+L 206.45578 118.137686 
+L 206.45578 118.130992 
+L 206.45578 118.124296 
+L 206.45578 118.1176 
+L 206.45578 118.110902 
+L 206.45578 118.104204 
+L 206.45578 118.097504 
+L 206.45578 118.090804 
+L 206.45578 118.084103 
+L 206.45578 118.077401 
+L 206.45578 118.070698 
+L 206.45578 118.063994 
+L 206.45578 118.057289 
+L 206.45578 118.050583 
+L 206.45578 118.043876 
+L 206.45578 118.037168 
+L 206.45578 118.030459 
+L 206.45578 118.023749 
+L 206.45578 118.017039 
+L 206.45578 118.010327 
+L 206.45578 118.003614 
+L 206.45578 117.996901 
+L 206.45578 117.990186 
+L 206.45578 117.983471 
+L 206.45578 117.976754 
+L 206.45578 117.970037 
+L 206.45578 117.963319 
+L 206.45578 117.9566 
+L 206.45578 117.949879 
+L 206.45578 117.943158 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_126">
+    <path d="M 206.45578 117.943158 
+L 206.45578 117.944831 
+L 206.45578 117.946505 
+L 206.45578 117.948178 
+L 206.45578 117.949851 
+L 206.45578 117.951524 
+L 206.45578 117.953197 
+L 206.45578 117.95487 
+L 206.45578 117.956543 
+L 206.45578 117.958216 
+L 206.45578 117.959888 
+L 206.45578 117.961561 
+L 206.45578 117.963234 
+L 206.45578 117.964906 
+L 206.45578 117.966579 
+L 206.45578 117.968251 
+L 206.45578 117.969924 
+L 206.45578 117.971596 
+L 206.45578 117.973268 
+L 206.45578 117.97494 
+L 206.45578 117.976612 
+L 206.45578 117.978285 
+L 206.45578 117.979957 
+L 206.45578 117.981629 
+L 206.45578 117.983301 
+L 206.45578 117.984972 
+L 206.45578 117.986644 
+L 206.45578 117.988316 
+L 206.45578 117.989988 
+L 206.45578 117.991659 
+L 206.45578 117.993331 
+L 206.45578 117.995002 
+L 206.45578 117.996674 
+L 206.45578 117.998345 
+L 206.45578 118.000017 
+L 206.45578 118.001688 
+L 206.45578 118.003359 
+L 206.45578 118.00503 
+L 206.45578 118.006701 
+L 206.45578 118.008372 
+L 206.45578 118.010043 
+L 206.45578 118.011714 
+L 206.45578 118.013385 
+L 206.45578 118.015056 
+L 206.45578 118.016727 
+L 206.45578 118.018397 
+L 206.45578 118.020068 
+L 206.45578 118.021738 
+L 206.45578 118.023409 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_127">
+    <path d="M 206.45578 118.023409 
+L 206.45578 118.023102 
+L 206.45578 118.022795 
+L 206.45578 118.022488 
+L 206.45578 118.022181 
+L 206.45578 118.021873 
+L 206.45578 118.021566 
+L 206.45578 118.021259 
+L 206.45578 118.020952 
+L 206.45578 118.020645 
+L 206.45578 118.020338 
+L 206.45578 118.020031 
+L 206.45578 118.019724 
+L 206.45578 118.019417 
+L 206.45578 118.019109 
+L 206.45578 118.018802 
+L 206.45578 118.018495 
+L 206.45578 118.018188 
+L 206.45578 118.017881 
+L 206.45578 118.017574 
+L 206.45578 118.017267 
+L 206.45578 118.016959 
+L 206.45578 118.016652 
+L 206.45578 118.016345 
+L 206.45578 118.016038 
+L 206.45578 118.015731 
+L 206.45578 118.015424 
+L 206.45578 118.015117 
+L 206.45578 118.014809 
+L 206.45578 118.014502 
+L 206.45578 118.014195 
+L 206.45578 118.013888 
+L 206.45578 118.013581 
+L 206.45578 118.013274 
+L 206.45578 118.012966 
+L 206.45578 118.012659 
+L 206.45578 118.012352 
+L 206.45578 118.012045 
+L 206.45578 118.011738 
+L 206.45578 118.011431 
+L 206.45578 118.011123 
+L 206.45578 118.010816 
+L 206.45578 118.010509 
+L 206.45578 118.010202 
+L 206.45578 118.009895 
+L 206.45578 118.009588 
+L 206.45578 118.00928 
+L 206.45578 118.008973 
+L 206.45578 118.008666 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_128">
+    <path d="M 206.45578 118.008666 
+L 205.733108 118.389096 
+L 205.010435 118.766496 
+L 204.287763 119.140915 
+L 203.56509 119.512398 
+L 202.842418 119.880992 
+L 202.119745 120.246742 
+L 201.397073 120.609689 
+L 200.6744 120.969879 
+L 199.951728 121.327351 
+L 199.229055 121.682147 
+L 198.506383 122.034306 
+L 197.78371 122.383867 
+L 197.061038 122.730869 
+L 196.338365 123.075348 
+L 195.615693 123.417342 
+L 194.89302 123.756885 
+L 194.170348 124.094012 
+L 193.447675 124.428758 
+L 192.725003 124.761156 
+L 192.00233 125.091239 
+L 191.279657 125.419038 
+L 190.556985 125.744585 
+L 189.834312 126.067912 
+L 189.11164 126.389047 
+L 188.388967 126.708021 
+L 187.666295 127.024862 
+L 186.943622 127.339598 
+L 186.22095 127.652258 
+L 185.498277 127.962869 
+L 184.775605 128.271457 
+L 184.052932 128.578049 
+L 183.33026 128.88267 
+L 182.607587 129.185345 
+L 181.884915 129.486099 
+L 181.162242 129.784957 
+L 180.43957 130.081941 
+L 179.716897 130.377076 
+L 178.994225 130.670385 
+L 178.271552 130.961889 
+L 177.54888 131.25161 
+L 176.826207 131.539572 
+L 176.103535 131.825794 
+L 175.380862 132.110298 
+L 174.658189 132.393103 
+L 173.935517 132.674231 
+L 173.212844 132.953702 
+L 172.490172 133.231533 
+L 171.767499 133.507746 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_129">
+    <path d="M 171.767499 133.507746 
+L 171.596152 133.762085 
+L 171.424805 134.015066 
+L 171.253458 134.266703 
+L 171.08211 134.517012 
+L 170.910763 134.766005 
+L 170.739416 135.013697 
+L 170.568068 135.260101 
+L 170.396721 135.505231 
+L 170.225374 135.749099 
+L 170.054027 135.991718 
+L 169.882679 136.233102 
+L 169.711332 136.473262 
+L 169.539985 136.712212 
+L 169.368637 136.949962 
+L 169.19729 137.186526 
+L 169.025943 137.421914 
+L 168.854596 137.65614 
+L 168.683248 137.889213 
+L 168.511901 138.121145 
+L 168.340554 138.351948 
+L 168.169206 138.581632 
+L 167.997859 138.810209 
+L 167.826512 139.037688 
+L 167.655165 139.26408 
+L 167.483817 139.489396 
+L 167.31247 139.713646 
+L 167.141123 139.936839 
+L 166.969775 140.158986 
+L 166.798428 140.380097 
+L 166.627081 140.600181 
+L 166.455734 140.819247 
+L 166.284386 141.037306 
+L 166.113039 141.254365 
+L 165.941692 141.470435 
+L 165.770344 141.685525 
+L 165.598997 141.899642 
+L 165.42765 142.112796 
+L 165.256303 142.324996 
+L 165.084955 142.53625 
+L 164.913608 142.746566 
+L 164.742261 142.955953 
+L 164.570913 143.164419 
+L 164.399566 143.371972 
+L 164.228219 143.57862 
+L 164.056872 143.78437 
+L 163.885524 143.989231 
+L 163.714177 144.193211 
+L 163.54283 144.396316 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_130">
+    <path d="M 163.54283 144.396316 
+L 163.472664 144.527021 
+L 163.402498 144.657366 
+L 163.332333 144.787354 
+L 163.262167 144.916986 
+L 163.192002 145.046264 
+L 163.121836 145.175191 
+L 163.051671 145.303768 
+L 162.981505 145.431997 
+L 162.911339 145.55988 
+L 162.841174 145.687419 
+L 162.771008 145.814616 
+L 162.700843 145.941472 
+L 162.630677 146.067989 
+L 162.560511 146.19417 
+L 162.490346 146.320015 
+L 162.42018 146.445527 
+L 162.350015 146.570708 
+L 162.279849 146.695559 
+L 162.209683 146.820081 
+L 162.139518 146.944278 
+L 162.069352 147.068149 
+L 161.999187 147.191698 
+L 161.929021 147.314926 
+L 161.858855 147.437834 
+L 161.78869 147.560424 
+L 161.718524 147.682697 
+L 161.648359 147.804656 
+L 161.578193 147.926302 
+L 161.508027 148.047636 
+L 161.437862 148.168661 
+L 161.367696 148.289377 
+L 161.297531 148.409787 
+L 161.227365 148.529891 
+L 161.157199 148.649692 
+L 161.087034 148.76919 
+L 161.016868 148.888388 
+L 160.946703 149.007287 
+L 160.876537 149.125889 
+L 160.806372 149.244194 
+L 160.736206 149.362205 
+L 160.66604 149.479922 
+L 160.595875 149.597348 
+L 160.525709 149.714484 
+L 160.455544 149.831331 
+L 160.385378 149.94789 
+L 160.315212 150.064163 
+L 160.245047 150.180152 
+L 160.174881 150.295858 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_131">
+    <path d="M 160.174881 150.295858 
+L 160.049972 150.758919 
+L 159.925062 151.217498 
+L 159.800152 151.671683 
+L 159.675242 152.121555 
+L 159.550333 152.567198 
+L 159.425423 153.008688 
+L 159.300513 153.446103 
+L 159.175604 153.879518 
+L 159.050694 154.309005 
+L 158.925784 154.734634 
+L 158.800875 155.156474 
+L 158.675965 155.574592 
+L 158.551055 155.989053 
+L 158.426146 156.399921 
+L 158.301236 156.807257 
+L 158.176326 157.211122 
+L 158.051417 157.611574 
+L 157.926507 158.00867 
+L 157.801597 158.402467 
+L 157.676688 158.793018 
+L 157.551778 159.180376 
+L 157.426868 159.564594 
+L 157.301959 159.945722 
+L 157.177049 160.323809 
+L 157.052139 160.698903 
+L 156.92723 161.071052 
+L 156.80232 161.440301 
+L 156.67741 161.806695 
+L 156.552501 162.170278 
+L 156.427591 162.531092 
+L 156.302681 162.88918 
+L 156.177772 163.244583 
+L 156.052862 163.59734 
+L 155.927952 163.94749 
+L 155.803043 164.295072 
+L 155.678133 164.640124 
+L 155.553223 164.982681 
+L 155.428313 165.322779 
+L 155.303404 165.660454 
+L 155.178494 165.99574 
+L 155.053584 166.328671 
+L 154.928675 166.659279 
+L 154.803765 166.987596 
+L 154.678855 167.313654 
+L 154.553946 167.637484 
+L 154.429036 167.959116 
+L 154.304126 168.27858 
+L 154.179217 168.595905 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_132">
+    <path d="M 154.179217 168.595905 
+L 154.142996 168.820349 
+L 154.106774 169.043734 
+L 154.070553 169.266071 
+L 154.034332 169.48737 
+L 153.998111 169.707641 
+L 153.96189 169.926892 
+L 153.925669 170.145133 
+L 153.889447 170.362374 
+L 153.853226 170.578624 
+L 153.817005 170.793892 
+L 153.780784 171.008186 
+L 153.744563 171.221515 
+L 153.708342 171.433888 
+L 153.67212 171.645314 
+L 153.635899 171.8558 
+L 153.599678 172.065356 
+L 153.563457 172.273989 
+L 153.527236 172.481708 
+L 153.491014 172.68852 
+L 153.454793 172.894434 
+L 153.418572 173.099457 
+L 153.382351 173.303596 
+L 153.34613 173.50686 
+L 153.309909 173.709256 
+L 153.273687 173.910791 
+L 153.237466 174.111472 
+L 153.201245 174.311308 
+L 153.165024 174.510304 
+L 153.128803 174.708468 
+L 153.092582 174.905807 
+L 153.05636 175.102327 
+L 153.020139 175.298036 
+L 152.983918 175.49294 
+L 152.947697 175.687045 
+L 152.911476 175.880359 
+L 152.875255 176.072888 
+L 152.839033 176.264637 
+L 152.802812 176.455614 
+L 152.766591 176.645824 
+L 152.73037 176.835273 
+L 152.694149 177.023969 
+L 152.657928 177.211915 
+L 152.621706 177.39912 
+L 152.585485 177.585588 
+L 152.549264 177.771325 
+L 152.513043 177.956336 
+L 152.476822 178.140629 
+L 152.4406 178.324207 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_133">
     <defs>
-     <path id="m2751a69b6d" d="M 0 -2.5 
+     <path id="mb9f69ca509" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1986,17 +4563,433 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m2751a69b6d" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2751a69b6d" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#mb9f69ca509" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb9f69ca509" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
+   </g>
+   <g id="line2d_134">
+    <path d="M 610.467188 173.595159 
+L 610.083859 173.625456 
+L 609.70053 173.655734 
+L 609.317201 173.685992 
+L 608.933872 173.716231 
+L 608.550543 173.746451 
+L 608.167214 173.776651 
+L 607.783885 173.806832 
+L 607.400556 173.836994 
+L 607.017227 173.867137 
+L 606.633898 173.897261 
+L 606.250569 173.927365 
+L 605.86724 173.957451 
+L 605.483911 173.987517 
+L 605.100582 174.017564 
+L 604.717253 174.047592 
+L 604.333924 174.077601 
+L 603.950595 174.107592 
+L 603.567266 174.137563 
+L 603.183937 174.167515 
+L 602.800608 174.197449 
+L 602.417279 174.227363 
+L 602.03395 174.257259 
+L 601.650621 174.287135 
+L 601.267292 174.316993 
+L 600.883963 174.346832 
+L 600.500634 174.376653 
+L 600.117305 174.406454 
+L 599.733976 174.436237 
+L 599.350647 174.466001 
+L 598.967318 174.495747 
+L 598.583989 174.525474 
+L 598.20066 174.555182 
+L 597.817331 174.584871 
+L 597.434002 174.614542 
+L 597.050673 174.644195 
+L 596.667344 174.673829 
+L 596.284015 174.703444 
+L 595.900686 174.733041 
+L 595.517357 174.762619 
+L 595.134028 174.792179 
+L 594.750699 174.821721 
+L 594.367371 174.851244 
+L 593.984042 174.880748 
+L 593.600713 174.910235 
+L 593.217384 174.939703 
+L 592.834055 174.969152 
+L 592.450726 174.998584 
+L 592.067397 175.027997 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_135">
+    <path d="M 592.067397 175.027997 
+L 590.874489 175.169645 
+L 589.681581 175.31087 
+L 588.488673 175.451676 
+L 587.295765 175.592065 
+L 586.102857 175.732039 
+L 584.90995 175.8716 
+L 583.717042 176.010752 
+L 582.524134 176.149497 
+L 581.331226 176.287837 
+L 580.138318 176.425773 
+L 578.94541 176.56331 
+L 577.752503 176.700449 
+L 576.559595 176.837191 
+L 575.366687 176.973541 
+L 574.173779 177.109499 
+L 572.980871 177.245068 
+L 571.787963 177.380251 
+L 570.595056 177.515049 
+L 569.402148 177.649464 
+L 568.20924 177.7835 
+L 567.016332 177.917157 
+L 565.823424 178.050439 
+L 564.630516 178.183346 
+L 563.437609 178.315882 
+L 562.244701 178.448048 
+L 561.051793 178.579847 
+L 559.858885 178.71128 
+L 558.665977 178.84235 
+L 557.473069 178.973058 
+L 556.280162 179.103407 
+L 555.087254 179.233398 
+L 553.894346 179.363033 
+L 552.701438 179.492315 
+L 551.50853 179.621245 
+L 550.315622 179.749826 
+L 549.122715 179.878058 
+L 547.929807 180.005944 
+L 546.736899 180.133486 
+L 545.543991 180.260686 
+L 544.351083 180.387545 
+L 543.158175 180.514066 
+L 541.965268 180.640249 
+L 540.77236 180.766098 
+L 539.579452 180.891613 
+L 538.386544 181.016797 
+L 537.193636 181.14165 
+L 536.000728 181.266176 
+L 534.807821 181.390376 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_136">
+    <path d="M 534.807821 181.390376 
+L 530.495204 181.29731 
+L 526.182587 181.204061 
+L 521.86997 181.110628 
+L 517.557353 181.017011 
+L 513.244736 180.923208 
+L 508.932119 180.829219 
+L 504.619502 180.735044 
+L 500.306885 180.640681 
+L 495.994268 180.54613 
+L 491.681651 180.451389 
+L 487.369035 180.356459 
+L 483.056418 180.261339 
+L 478.743801 180.166027 
+L 474.431184 180.070523 
+L 470.118567 179.974826 
+L 465.80595 179.878935 
+L 461.493333 179.78285 
+L 457.180716 179.68657 
+L 452.868099 179.590094 
+L 448.555482 179.493421 
+L 444.242865 179.39655 
+L 439.930249 179.299481 
+L 435.617632 179.202213 
+L 431.305015 179.104745 
+L 426.992398 179.007075 
+L 422.679781 178.909204 
+L 418.367164 178.811131 
+L 414.054547 178.712854 
+L 409.74193 178.614373 
+L 405.429313 178.515687 
+L 401.116696 178.416794 
+L 396.804079 178.317696 
+L 392.491462 178.218389 
+L 388.178846 178.118874 
+L 383.866229 178.019149 
+L 379.553612 177.919214 
+L 375.240995 177.819068 
+L 370.928378 177.71871 
+L 366.615761 177.618139 
+L 362.303144 177.517354 
+L 357.990527 177.416354 
+L 353.67791 177.315138 
+L 349.365293 177.213706 
+L 345.052676 177.112057 
+L 340.74006 177.010188 
+L 336.427443 176.9081 
+L 332.114826 176.805792 
+L 327.802209 176.703263 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_137">
+    <path d="M 327.802209 176.703263 
+L 326.719613 176.943393 
+L 325.637017 177.182313 
+L 324.554421 177.420034 
+L 323.471826 177.656568 
+L 322.38923 177.891928 
+L 321.306634 178.126124 
+L 320.224038 178.359169 
+L 319.141442 178.591074 
+L 318.058846 178.821849 
+L 316.976251 179.051506 
+L 315.893655 179.280055 
+L 314.811059 179.507507 
+L 313.728463 179.733872 
+L 312.645867 179.959162 
+L 311.563272 180.183385 
+L 310.480676 180.406553 
+L 309.39808 180.628674 
+L 308.315484 180.84976 
+L 307.232888 181.069818 
+L 306.150292 181.28886 
+L 305.067697 181.506893 
+L 303.985101 181.723928 
+L 302.902505 181.939974 
+L 301.819909 182.155039 
+L 300.737313 182.369132 
+L 299.654718 182.582263 
+L 298.572122 182.794439 
+L 297.489526 183.00567 
+L 296.40693 183.215963 
+L 295.324334 183.425327 
+L 294.241738 183.633771 
+L 293.159143 183.841301 
+L 292.076547 184.047926 
+L 290.993951 184.253655 
+L 289.911355 184.458494 
+L 288.828759 184.662452 
+L 287.746164 184.865535 
+L 286.663568 185.067752 
+L 285.580972 185.26911 
+L 284.498376 185.469616 
+L 283.41578 185.669277 
+L 282.333184 185.8681 
+L 281.250589 186.066093 
+L 280.167993 186.263261 
+L 279.085397 186.459613 
+L 278.002801 186.655155 
+L 276.920205 186.849893 
+L 275.83761 187.043834 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_138">
+    <path d="M 275.83761 187.043834 
+L 275.471227 187.330505 
+L 275.104845 187.615452 
+L 274.738462 187.898695 
+L 274.37208 188.180256 
+L 274.005697 188.460154 
+L 273.639315 188.738409 
+L 273.272932 189.015039 
+L 272.90655 189.290063 
+L 272.540167 189.563501 
+L 272.173785 189.83537 
+L 271.807402 190.105688 
+L 271.44102 190.374473 
+L 271.074637 190.641742 
+L 270.708255 190.907513 
+L 270.341872 191.1718 
+L 269.97549 191.434623 
+L 269.609107 191.695995 
+L 269.242725 191.955934 
+L 268.876342 192.214455 
+L 268.50996 192.471573 
+L 268.143577 192.727304 
+L 267.777195 192.981662 
+L 267.410812 193.234662 
+L 267.04443 193.486318 
+L 266.678047 193.736645 
+L 266.311665 193.985657 
+L 265.945282 194.233367 
+L 265.5789 194.479789 
+L 265.212517 194.724936 
+L 264.846135 194.968822 
+L 264.479753 195.211458 
+L 264.11337 195.452859 
+L 263.746988 195.693037 
+L 263.380605 195.932003 
+L 263.014223 196.16977 
+L 262.64784 196.40635 
+L 262.281458 196.641755 
+L 261.915075 196.875997 
+L 261.548693 197.109086 
+L 261.18231 197.341034 
+L 260.815928 197.571853 
+L 260.449545 197.801553 
+L 260.083163 198.030144 
+L 259.71678 198.257639 
+L 259.350398 198.484046 
+L 258.984015 198.709377 
+L 258.617633 198.933642 
+L 258.25125 199.15685 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_139">
+    <path d="M 258.25125 199.15685 
+L 258.220538 199.265446 
+L 258.189826 199.373793 
+L 258.159113 199.481893 
+L 258.128401 199.589747 
+L 258.097688 199.697356 
+L 258.066976 199.804722 
+L 258.036264 199.911845 
+L 258.005551 200.018726 
+L 257.974839 200.125366 
+L 257.944127 200.231767 
+L 257.913414 200.33793 
+L 257.882702 200.443856 
+L 257.851989 200.549545 
+L 257.821277 200.654999 
+L 257.790565 200.760219 
+L 257.759852 200.865206 
+L 257.72914 200.969961 
+L 257.698427 201.074484 
+L 257.667715 201.178778 
+L 257.637003 201.282842 
+L 257.60629 201.386679 
+L 257.575578 201.490289 
+L 257.544866 201.593672 
+L 257.514153 201.696831 
+L 257.483441 201.799765 
+L 257.452728 201.902476 
+L 257.422016 202.004965 
+L 257.391304 202.107233 
+L 257.360591 202.209281 
+L 257.329879 202.31111 
+L 257.299167 202.41272 
+L 257.268454 202.514113 
+L 257.237742 202.615289 
+L 257.207029 202.71625 
+L 257.176317 202.816996 
+L 257.145605 202.917528 
+L 257.114892 203.017848 
+L 257.08418 203.117955 
+L 257.053467 203.217852 
+L 257.022755 203.317538 
+L 256.992043 203.417015 
+L 256.96133 203.516284 
+L 256.930618 203.615345 
+L 256.899906 203.7142 
+L 256.869193 203.812849 
+L 256.838481 203.911293 
+L 256.807768 204.009533 
+L 256.777056 204.107569 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_140">
+    <path d="M 256.777056 204.107569 
+L 256.610239 204.449667 
+L 256.443423 204.789314 
+L 256.276606 205.126543 
+L 256.109789 205.46139 
+L 255.942972 205.793887 
+L 255.776156 206.124067 
+L 255.609339 206.451963 
+L 255.442522 206.777605 
+L 255.275706 207.101025 
+L 255.108889 207.422253 
+L 254.942072 207.741318 
+L 254.775255 208.058249 
+L 254.608439 208.373075 
+L 254.441622 208.685822 
+L 254.274805 208.99652 
+L 254.107989 209.305193 
+L 253.941172 209.611869 
+L 253.774355 209.916573 
+L 253.607538 210.21933 
+L 253.440722 210.520166 
+L 253.273905 210.819103 
+L 253.107088 211.116167 
+L 252.940272 211.41138 
+L 252.773455 211.704766 
+L 252.606638 211.996346 
+L 252.439821 212.286143 
+L 252.273005 212.574179 
+L 252.106188 212.860474 
+L 251.939371 213.14505 
+L 251.772555 213.427928 
+L 251.605738 213.709127 
+L 251.438921 213.988667 
+L 251.272104 214.266568 
+L 251.105288 214.542849 
+L 250.938471 214.817528 
+L 250.771654 215.090625 
+L 250.604837 215.362156 
+L 250.438021 215.632141 
+L 250.271204 215.900596 
+L 250.104387 216.167539 
+L 249.937571 216.432986 
+L 249.770754 216.696955 
+L 249.603937 216.959462 
+L 249.43712 217.220523 
+L 249.270304 217.480153 
+L 249.103487 217.738369 
+L 248.93667 217.995185 
+L 248.769854 218.250617 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_141">
+    <path d="M 248.769854 218.250617 
+L 248.717661 218.475648 
+L 248.665468 218.699615 
+L 248.613275 218.922528 
+L 248.561082 219.144398 
+L 248.508889 219.365234 
+L 248.456696 219.585046 
+L 248.404503 219.803843 
+L 248.35231 220.021634 
+L 248.300117 220.238429 
+L 248.247924 220.454236 
+L 248.195731 220.669065 
+L 248.143539 220.882925 
+L 248.091346 221.095824 
+L 248.039153 221.307771 
+L 247.98696 221.518774 
+L 247.934767 221.728842 
+L 247.882574 221.937982 
+L 247.830381 222.146204 
+L 247.778188 222.353515 
+L 247.725995 222.559922 
+L 247.673802 222.765435 
+L 247.621609 222.97006 
+L 247.569416 223.173806 
+L 247.517224 223.376679 
+L 247.465031 223.578687 
+L 247.412838 223.779838 
+L 247.360645 223.980139 
+L 247.308452 224.179597 
+L 247.256259 224.378218 
+L 247.204066 224.576011 
+L 247.151873 224.772981 
+L 247.09968 224.969137 
+L 247.047487 225.164483 
+L 246.995294 225.359028 
+L 246.943101 225.552777 
+L 246.890909 225.745737 
+L 246.838716 225.937915 
+L 246.786523 226.129317 
+L 246.73433 226.319949 
+L 246.682137 226.509816 
+L 246.629944 226.698927 
+L 246.577751 226.887285 
+L 246.525558 227.074898 
+L 246.473365 227.261771 
+L 246.421172 227.44791 
+L 246.368979 227.633321 
+L 246.316786 227.818009 
+L 246.264594 228.00198 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -2012,13 +5005,9 @@ Q 422.84625 408.80375 424.44625 408.80375
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_83">
-     <path d="M 426.04625 353.9475 
-L 434.04625 353.9475 
-L 442.04625 353.9475 
-" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g id="line2d_142">
      <defs>
-      <path id="m40d7fa8cc6" d="M 0 3.5 
+      <path id="m326bc9c49d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2031,7 +5020,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m40d7fa8cc6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m326bc9c49d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,13 +5077,9 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_84">
-     <path d="M 426.04625 365.69 
-L 434.04625 365.69 
-L 442.04625 365.69 
-" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_143">
      <g>
-      <use xlink:href="#m366a485e49" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8b0475a2d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,13 +5091,9 @@ L 442.04625 365.69
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_85">
-     <path d="M 426.04625 377.4325 
-L 434.04625 377.4325 
-L 442.04625 377.4325 
-" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_144">
      <g>
-      <use xlink:href="#m02f854e414" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md472f5d34f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,13 +5136,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_86">
-     <path d="M 426.04625 389.3975 
-L 434.04625 389.3975 
-L 442.04625 389.3975 
-" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_145">
      <g>
-      <use xlink:href="#m9e50b830b3" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbc0e668acc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,13 +5179,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_87">
-     <path d="M 426.04625 401.14 
-L 434.04625 401.14 
-L 442.04625 401.14 
-" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_146">
      <g>
-      <use xlink:href="#m8063323e4d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6a3f3ce72a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,13 +5195,9 @@ L 442.04625 401.14
       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
      </g>
     </g>
-    <g id="line2d_88">
-     <path d="M 529.72375 353.9475 
-L 537.72375 353.9475 
-L 545.72375 353.9475 
-" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_147">
      <g>
-      <use xlink:href="#m36d8200e3c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8172be00a2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,13 +5249,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_89">
-     <path d="M 529.72375 365.69 
-L 537.72375 365.69 
-L 545.72375 365.69 
-" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_148">
      <g>
-      <use xlink:href="#me7e7c6836c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1c50d60c68" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,13 +5314,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_90">
-     <path d="M 529.72375 377.4325 
-L 537.72375 377.4325 
-L 545.72375 377.4325 
-" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_149">
      <g>
-      <use xlink:href="#mdc78908ea3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#ma0e4067efa" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,13 +5352,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_91">
-     <path d="M 529.72375 389.175 
-L 537.72375 389.175 
-L 545.72375 389.175 
-" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_150">
      <g>
-      <use xlink:href="#m2751a69b6d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb9f69ca509" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2466,33 +5423,439 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_92">
-    <path d="M 226.647908 179.618486 
-L 214.084819 182.356552 
-L 206.266533 184.821312 
-L 187.75787 192.089877 
-L 186.58897 192.797576 
-L 184.505355 194.997697 
-L 164.72409 206.439744 
-L 150.950891 251.438009 
-L 98.348822 318.908823 
-" clip-path="url(#pd91135d0bf)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pd91135d0bf)">
-     <use xlink:href="#m40d7fa8cc6" x="226.647908" y="179.618486" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="214.084819" y="182.356552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="206.266533" y="184.821312" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="187.75787" y="192.089877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="186.58897" y="192.797576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="184.505355" y="194.997697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="164.72409" y="206.439744" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="150.950891" y="251.438009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m40d7fa8cc6" x="98.348822" y="318.908823" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_151">
+    <g clip-path="url(#p14f9c3d880)">
+     <use xlink:href="#m326bc9c49d" x="226.647908" y="179.618486" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="214.084819" y="182.356552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="206.266533" y="184.821312" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="187.75787" y="192.089877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="186.58897" y="192.797576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="184.505355" y="194.997697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="164.72409" y="206.439744" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="150.950891" y="251.438009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m326bc9c49d" x="98.348822" y="318.908823" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
+   </g>
+   <g id="line2d_152">
+    <path d="M 226.647908 179.618486 
+L 226.386177 179.677173 
+L 226.124446 179.735788 
+L 225.862715 179.794329 
+L 225.600984 179.852799 
+L 225.339253 179.911196 
+L 225.077522 179.969522 
+L 224.815791 180.027776 
+L 224.55406 180.085959 
+L 224.292329 180.14407 
+L 224.030598 180.20211 
+L 223.768867 180.260078 
+L 223.507136 180.317977 
+L 223.245405 180.375804 
+L 222.983674 180.433561 
+L 222.721943 180.491248 
+L 222.460212 180.548864 
+L 222.198481 180.606411 
+L 221.93675 180.663887 
+L 221.675019 180.721295 
+L 221.413288 180.778632 
+L 221.151557 180.835901 
+L 220.889826 180.8931 
+L 220.628095 180.95023 
+L 220.366363 181.007292 
+L 220.104632 181.064285 
+L 219.842901 181.121209 
+L 219.58117 181.178065 
+L 219.319439 181.234853 
+L 219.057708 181.291573 
+L 218.795977 181.348225 
+L 218.534246 181.40481 
+L 218.272515 181.461327 
+L 218.010784 181.517777 
+L 217.749053 181.574159 
+L 217.487322 181.630475 
+L 217.225591 181.686724 
+L 216.96386 181.742906 
+L 216.702129 181.799021 
+L 216.440398 181.85507 
+L 216.178667 181.911053 
+L 215.916936 181.96697 
+L 215.655205 182.022821 
+L 215.393474 182.078606 
+L 215.131743 182.134326 
+L 214.870012 182.18998 
+L 214.608281 182.245569 
+L 214.34655 182.301093 
+L 214.084819 182.356552 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_153">
+    <path d="M 214.084819 182.356552 
+L 213.921938 182.409231 
+L 213.759057 182.461851 
+L 213.596176 182.514413 
+L 213.433295 182.566916 
+L 213.270414 182.619362 
+L 213.107533 182.671749 
+L 212.944652 182.724079 
+L 212.781771 182.776351 
+L 212.61889 182.828565 
+L 212.456009 182.880722 
+L 212.293128 182.932822 
+L 212.130247 182.984864 
+L 211.967366 183.036849 
+L 211.804485 183.088778 
+L 211.641604 183.140649 
+L 211.478723 183.192464 
+L 211.315843 183.244222 
+L 211.152962 183.295924 
+L 210.990081 183.347569 
+L 210.8272 183.399158 
+L 210.664319 183.450691 
+L 210.501438 183.502168 
+L 210.338557 183.553589 
+L 210.175676 183.604955 
+L 210.012795 183.656265 
+L 209.849914 183.707519 
+L 209.687033 183.758718 
+L 209.524152 183.809862 
+L 209.361271 183.86095 
+L 209.19839 183.911984 
+L 209.035509 183.962962 
+L 208.872628 184.013886 
+L 208.709747 184.064755 
+L 208.546866 184.11557 
+L 208.383985 184.16633 
+L 208.221104 184.217036 
+L 208.058223 184.267688 
+L 207.895342 184.318285 
+L 207.732462 184.368829 
+L 207.569581 184.419319 
+L 207.4067 184.469755 
+L 207.243819 184.520137 
+L 207.080938 184.570466 
+L 206.918057 184.620742 
+L 206.755176 184.670964 
+L 206.592295 184.721133 
+L 206.429414 184.771249 
+L 206.266533 184.821312 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_154">
+    <path d="M 206.266533 184.821312 
+L 205.880936 184.984689 
+L 205.495339 185.147505 
+L 205.109742 185.309763 
+L 204.724144 185.471467 
+L 204.338547 185.632622 
+L 203.95295 185.79323 
+L 203.567353 185.953296 
+L 203.181756 186.112823 
+L 202.796159 186.271815 
+L 202.410562 186.430275 
+L 202.024964 186.588207 
+L 201.639367 186.745614 
+L 201.25377 186.902501 
+L 200.868173 187.058869 
+L 200.482576 187.214724 
+L 200.096979 187.370067 
+L 199.711382 187.524903 
+L 199.325784 187.679235 
+L 198.940187 187.833065 
+L 198.55459 187.986398 
+L 198.168993 188.139236 
+L 197.783396 188.291584 
+L 197.397799 188.443442 
+L 197.012202 188.594816 
+L 196.626605 188.745708 
+L 196.241007 188.896121 
+L 195.85541 189.046058 
+L 195.469813 189.195522 
+L 195.084216 189.344516 
+L 194.698619 189.493043 
+L 194.313022 189.641106 
+L 193.927425 189.788708 
+L 193.541827 189.935851 
+L 193.15623 190.082539 
+L 192.770633 190.228775 
+L 192.385036 190.37456 
+L 191.999439 190.519899 
+L 191.613842 190.664793 
+L 191.228245 190.809245 
+L 190.842647 190.953259 
+L 190.45705 191.096836 
+L 190.071453 191.239979 
+L 189.685856 191.382692 
+L 189.300259 191.524975 
+L 188.914662 191.666833 
+L 188.529065 191.808268 
+L 188.143468 191.949281 
+L 187.75787 192.089877 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_155">
+    <path d="M 187.75787 192.089877 
+L 187.733518 192.104729 
+L 187.709166 192.119576 
+L 187.684814 192.134419 
+L 187.660462 192.149257 
+L 187.63611 192.16409 
+L 187.611758 192.178919 
+L 187.587406 192.193743 
+L 187.563054 192.208563 
+L 187.538702 192.223378 
+L 187.514349 192.238188 
+L 187.489997 192.252994 
+L 187.465645 192.267795 
+L 187.441293 192.282591 
+L 187.416941 192.297383 
+L 187.392589 192.31217 
+L 187.368237 192.326953 
+L 187.343885 192.341731 
+L 187.319533 192.356504 
+L 187.295181 192.371273 
+L 187.270829 192.386037 
+L 187.246476 192.400796 
+L 187.222124 192.415551 
+L 187.197772 192.430302 
+L 187.17342 192.445047 
+L 187.149068 192.459788 
+L 187.124716 192.474525 
+L 187.100364 192.489257 
+L 187.076012 192.503984 
+L 187.05166 192.518707 
+L 187.027308 192.533426 
+L 187.002956 192.548139 
+L 186.978603 192.562848 
+L 186.954251 192.577553 
+L 186.929899 192.592253 
+L 186.905547 192.606948 
+L 186.881195 192.621639 
+L 186.856843 192.636326 
+L 186.832491 192.651007 
+L 186.808139 192.665685 
+L 186.783787 192.680357 
+L 186.759435 192.695026 
+L 186.735083 192.709689 
+L 186.71073 192.724348 
+L 186.686378 192.739003 
+L 186.662026 192.753653 
+L 186.637674 192.768298 
+L 186.613322 192.782939 
+L 186.58897 192.797576 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_156">
+    <path d="M 186.58897 192.797576 
+L 186.545561 192.844469 
+L 186.502153 192.891316 
+L 186.458744 192.938117 
+L 186.415335 192.984871 
+L 186.371927 193.03158 
+L 186.328518 193.078242 
+L 186.285109 193.124859 
+L 186.241701 193.171429 
+L 186.198292 193.217954 
+L 186.154883 193.264434 
+L 186.111475 193.310868 
+L 186.068066 193.357256 
+L 186.024658 193.403599 
+L 185.981249 193.449897 
+L 185.93784 193.496149 
+L 185.894432 193.542357 
+L 185.851023 193.588519 
+L 185.807614 193.634637 
+L 185.764206 193.680709 
+L 185.720797 193.726737 
+L 185.677388 193.77272 
+L 185.63398 193.818659 
+L 185.590571 193.864553 
+L 185.547162 193.910403 
+L 185.503754 193.956209 
+L 185.460345 194.00197 
+L 185.416936 194.047687 
+L 185.373528 194.09336 
+L 185.330119 194.138989 
+L 185.28671 194.184574 
+L 185.243302 194.230116 
+L 185.199893 194.275613 
+L 185.156484 194.321067 
+L 185.113076 194.366478 
+L 185.069667 194.411845 
+L 185.026258 194.457168 
+L 184.98285 194.502448 
+L 184.939441 194.547685 
+L 184.896033 194.592879 
+L 184.852624 194.63803 
+L 184.809215 194.683138 
+L 184.765807 194.728203 
+L 184.722398 194.773225 
+L 184.678989 194.818205 
+L 184.635581 194.863141 
+L 184.592172 194.908036 
+L 184.548763 194.952887 
+L 184.505355 194.997697 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_157">
+    <path d="M 184.505355 194.997697 
+L 184.093245 195.26655 
+L 183.681135 195.533886 
+L 183.269026 195.799722 
+L 182.856916 196.064076 
+L 182.444806 196.326963 
+L 182.032697 196.5884 
+L 181.620587 196.848402 
+L 181.208477 197.106986 
+L 180.796368 197.364166 
+L 180.384258 197.619958 
+L 179.972148 197.874377 
+L 179.560039 198.127437 
+L 179.147929 198.379153 
+L 178.735819 198.629539 
+L 178.323709 198.878609 
+L 177.9116 199.126377 
+L 177.49949 199.372856 
+L 177.08738 199.61806 
+L 176.675271 199.862001 
+L 176.263161 200.104693 
+L 175.851051 200.346149 
+L 175.438942 200.58638 
+L 175.026832 200.8254 
+L 174.614722 201.063221 
+L 174.202613 201.299854 
+L 173.790503 201.535311 
+L 173.378393 201.769604 
+L 172.966284 202.002744 
+L 172.554174 202.234743 
+L 172.142064 202.465611 
+L 171.729955 202.695361 
+L 171.317845 202.924002 
+L 170.905735 203.151545 
+L 170.493626 203.378 
+L 170.081516 203.603379 
+L 169.669406 203.827691 
+L 169.257297 204.050946 
+L 168.845187 204.273154 
+L 168.433077 204.494325 
+L 168.020968 204.714469 
+L 167.608858 204.933595 
+L 167.196748 205.151712 
+L 166.784639 205.36883 
+L 166.372529 205.584958 
+L 165.960419 205.800104 
+L 165.54831 206.014278 
+L 165.1362 206.227488 
+L 164.72409 206.439744 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_158">
+    <path d="M 164.72409 206.439744 
+L 164.437149 207.97886 
+L 164.150207 209.469555 
+L 163.863265 210.914786 
+L 163.576324 212.317241 
+L 163.289382 213.679382 
+L 163.00244 215.003461 
+L 162.715499 216.291548 
+L 162.428557 217.545547 
+L 162.141615 218.767217 
+L 161.854674 219.958182 
+L 161.567732 221.119949 
+L 161.28079 222.253914 
+L 160.993849 223.361377 
+L 160.706907 224.44355 
+L 160.419966 225.50156 
+L 160.133024 226.536464 
+L 159.846082 227.54925 
+L 159.559141 228.540842 
+L 159.272199 229.512111 
+L 158.985257 230.463871 
+L 158.698316 231.396893 
+L 158.411374 232.311898 
+L 158.124432 233.20957 
+L 157.837491 234.090554 
+L 157.550549 234.955458 
+L 157.263608 235.804859 
+L 156.976666 236.639302 
+L 156.689724 237.459307 
+L 156.402783 238.265363 
+L 156.115841 239.057938 
+L 155.828899 239.837475 
+L 155.541958 240.604396 
+L 155.255016 241.359102 
+L 154.968074 242.101978 
+L 154.681133 242.833387 
+L 154.394191 243.553679 
+L 154.10725 244.263187 
+L 153.820308 244.962228 
+L 153.533366 245.651108 
+L 153.246425 246.330117 
+L 152.959483 246.999533 
+L 152.672541 247.659626 
+L 152.3856 248.310649 
+L 152.098658 248.95285 
+L 151.811716 249.586465 
+L 151.524775 250.211719 
+L 151.237833 250.828831 
+L 150.950891 251.438009 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_159">
+    <path d="M 150.950891 251.438009 
+L 149.855015 254.452662 
+L 148.759139 257.286954 
+L 147.663262 259.961252 
+L 146.567386 262.49266 
+L 145.471509 264.895674 
+L 144.375633 267.182693 
+L 143.279756 269.364402 
+L 142.18388 271.450074 
+L 141.088003 273.447808 
+L 139.992127 275.36472 
+L 138.89625 277.207097 
+L 137.800374 278.980519 
+L 136.704498 280.689962 
+L 135.608621 282.339881 
+L 134.512745 283.934283 
+L 133.416868 285.476782 
+L 132.320992 286.970653 
+L 131.225115 288.418866 
+L 130.129239 289.824131 
+L 129.033362 291.188922 
+L 127.937486 292.515504 
+L 126.84161 293.80596 
+L 125.745733 295.062205 
+L 124.649857 296.286006 
+L 123.55398 297.478996 
+L 122.458104 298.64269 
+L 121.362227 299.778491 
+L 120.266351 300.887705 
+L 119.170474 301.971549 
+L 118.074598 303.031158 
+L 116.978721 304.067591 
+L 115.882845 305.08184 
+L 114.786969 306.074836 
+L 113.691092 307.047451 
+L 112.595216 308.000505 
+L 111.499339 308.934768 
+L 110.403463 309.850969 
+L 109.307586 310.749791 
+L 108.21171 311.631882 
+L 107.115833 312.497853 
+L 106.019957 313.348284 
+L 104.92408 314.183721 
+L 103.828204 315.004685 
+L 102.732328 315.811669 
+L 101.636451 316.60514 
+L 100.540575 317.385544 
+L 99.444698 318.153304 
+L 98.348822 318.908823 
+" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
-   <!-- Compression speed vs ratio  (canterbury — geomean over 11 files; line = level sweep) -->
-   <g transform="translate(7.704922 19.237969) scale(0.13 -0.13)">
+   <!-- Compression speed vs ratio  (canterbury — geomean over 11 files) -->
+   <g transform="translate(79.150078 19.237969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-43" d="M 4288 256 
 Q 3956 84 3597 -3 
@@ -2765,37 +6128,6 @@ Q 2919 2259 2725 2515
 Q 2531 2772 2181 2772 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-3b" d="M 716 1209 
-L 1844 1209 
-L 1844 256 
-L 1069 -909 
-L 403 -909 
-L 716 256 
-L 716 1209 
-z
-M 716 3500 
-L 1844 3500 
-L 1844 2291 
-L 716 2291 
-L 716 3500 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-77" d="M 225 3500 
-L 1313 3500 
-L 1900 1088 
-L 2491 3500 
-L 3425 3500 
-L 4013 1113 
-L 4603 3500 
-L 5691 3500 
-L 4769 0 
-L 3547 0 
-L 2956 2406 
-L 2369 0 
-L 1147 0 
-L 225 3500 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-29" d="M 513 -844 
 Q 913 -100 1113 609 
 Q 1313 1319 1313 2009 
@@ -2873,27 +6205,7 @@ z
     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3559.619141 0)"/>
     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3593.896484 0)"/>
     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3661.71875 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-3b" transform="translate(3721.240234 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3761.230469 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3796.044922 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3830.322266 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3864.599609 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3935.791016 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4003.613281 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(4038.427734 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4122.216797 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(4157.03125 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4191.308594 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(4259.130859 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4324.316406 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(4392.138672 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4426.416016 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(4461.230469 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(4520.751953 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4613.134766 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4680.957031 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(4748.779297 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(4820.361328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3721.240234 0)"/>
    </g>
   </g>
   <g id="text_26">
@@ -3204,7 +6516,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd91135d0bf">
+  <clipPath id="p14f9c3d880">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m21eccd11d5" d="M 0 0 
+       <path id="meea3c14122" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m21eccd11d5" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m21eccd11d5" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m21eccd11d5" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m21eccd11d5" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m21eccd11d5" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m21eccd11d5" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m21eccd11d5" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#meea3c14122" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m0e7cf36816" d="M 0 0 
+       <path id="mf49654e385" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e7cf36816" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf49654e385" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e7cf36816" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf49654e385" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e7cf36816" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf49654e385" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7b0f6ce7cb" d="M 0 0 
+       <path id="m849dcf40d0" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7b0f6ce7cb" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m849dcf40d0" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1693,130 +1693,1489 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 377.110281 107.572658 
-L 323.801439 112.143178 
-L 272.665744 128.289861 
-L 235.168828 129.778148 
-L 186.228265 150.062022 
-L 158.303164 172.157864 
-L 149.489547 182.173164 
-L 140.563162 202.575355 
-L 138.984853 209.263476 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8e4da0fa55" d="M -2.5 2.5 
+     <path id="m632e8cdad7" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#m8e4da0fa55" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e4da0fa55" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#m632e8cdad7" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m632e8cdad7" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 610.467187 71.829514 
-L 319.880958 101.654884 
-L 210.281253 129.793447 
-L 196.287076 133.571842 
-L 176.054419 147.433896 
-L 152.161413 174.830826 
-L 146.720208 186.628416 
-L 143.994022 196.353927 
-L 142.666037 200.270771 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 107.572658 
+L 375.99968 107.671923 
+L 374.889079 107.771005 
+L 373.778478 107.869907 
+L 372.667878 107.968628 
+L 371.557277 108.06717 
+L 370.446676 108.165532 
+L 369.336075 108.263716 
+L 368.225474 108.361722 
+L 367.114873 108.459551 
+L 366.004272 108.557204 
+L 364.893671 108.65468 
+L 363.78307 108.751982 
+L 362.67247 108.849108 
+L 361.561869 108.946061 
+L 360.451268 109.04284 
+L 359.340667 109.139447 
+L 358.230066 109.235881 
+L 357.119465 109.332144 
+L 356.008864 109.428236 
+L 354.898263 109.524158 
+L 353.787662 109.61991 
+L 352.677062 109.715493 
+L 351.566461 109.810907 
+L 350.45586 109.906153 
+L 349.345259 110.001232 
+L 348.234658 110.096145 
+L 347.124057 110.190891 
+L 346.013456 110.285471 
+L 344.902855 110.379887 
+L 343.792255 110.474138 
+L 342.681654 110.568225 
+L 341.571053 110.662149 
+L 340.460452 110.75591 
+L 339.349851 110.849509 
+L 338.23925 110.942947 
+L 337.128649 111.036223 
+L 336.018048 111.129339 
+L 334.907447 111.222295 
+L 333.796847 111.315092 
+L 332.686246 111.407729 
+L 331.575645 111.500209 
+L 330.465044 111.592531 
+L 329.354443 111.684695 
+L 328.243842 111.776703 
+L 327.133241 111.868554 
+L 326.02264 111.96025 
+L 324.91204 112.051791 
+L 323.801439 112.143178 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_69">
+    <path d="M 323.801439 112.143178 
+L 322.736112 112.533723 
+L 321.670785 112.92147 
+L 320.605458 113.306458 
+L 319.540131 113.688728 
+L 318.474804 114.068316 
+L 317.409477 114.44526 
+L 316.34415 114.819597 
+L 315.278823 115.191362 
+L 314.213496 115.560591 
+L 313.148169 115.927318 
+L 312.082842 116.291576 
+L 311.017515 116.653399 
+L 309.952188 117.012819 
+L 308.886861 117.369868 
+L 307.821534 117.724577 
+L 306.756207 118.076976 
+L 305.69088 118.427095 
+L 304.625553 118.774963 
+L 303.560226 119.12061 
+L 302.494899 119.464063 
+L 301.429572 119.80535 
+L 300.364245 120.144499 
+L 299.298918 120.481535 
+L 298.233591 120.816485 
+L 297.168264 121.149375 
+L 296.102937 121.48023 
+L 295.03761 121.809074 
+L 293.972283 122.135933 
+L 292.906956 122.460829 
+L 291.84163 122.783786 
+L 290.776303 123.104827 
+L 289.710976 123.423975 
+L 288.645649 123.741252 
+L 287.580322 124.05668 
+L 286.514995 124.37028 
+L 285.449668 124.682073 
+L 284.384341 124.99208 
+L 283.319014 125.300322 
+L 282.253687 125.606818 
+L 281.18836 125.911587 
+L 280.123033 126.21465 
+L 279.057706 126.516026 
+L 277.992379 126.815732 
+L 276.927052 127.113788 
+L 275.861725 127.410211 
+L 274.796398 127.705019 
+L 273.731071 127.99823 
+L 272.665744 128.289861 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_70">
+    <path d="M 272.665744 128.289861 
+L 271.884558 128.321288 
+L 271.103373 128.352697 
+L 270.322187 128.384088 
+L 269.541001 128.41546 
+L 268.759815 128.446815 
+L 267.97863 128.478151 
+L 267.197444 128.509469 
+L 266.416258 128.540769 
+L 265.635072 128.572051 
+L 264.853887 128.603314 
+L 264.072701 128.63456 
+L 263.291515 128.665788 
+L 262.510329 128.696997 
+L 261.729144 128.728189 
+L 260.947958 128.759363 
+L 260.166772 128.790518 
+L 259.385586 128.821656 
+L 258.604401 128.852776 
+L 257.823215 128.883878 
+L 257.042029 128.914962 
+L 256.260843 128.946028 
+L 255.479658 128.977077 
+L 254.698472 129.008108 
+L 253.917286 129.039121 
+L 253.1361 129.070116 
+L 252.354915 129.101093 
+L 251.573729 129.132053 
+L 250.792543 129.162995 
+L 250.011357 129.193919 
+L 249.230172 129.224826 
+L 248.448986 129.255715 
+L 247.6678 129.286586 
+L 246.886614 129.31744 
+L 246.105429 129.348276 
+L 245.324243 129.379095 
+L 244.543057 129.409896 
+L 243.761871 129.440679 
+L 242.980686 129.471445 
+L 242.1995 129.502194 
+L 241.418314 129.532925 
+L 240.637128 129.563639 
+L 239.855943 129.594335 
+L 239.074757 129.625014 
+L 238.293571 129.655676 
+L 237.512385 129.68632 
+L 236.7312 129.716946 
+L 235.950014 129.747556 
+L 235.168828 129.778148 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_71">
+    <path d="M 235.168828 129.778148 
+L 234.149233 130.288403 
+L 233.129638 130.793893 
+L 232.110043 131.294704 
+L 231.090448 131.790924 
+L 230.070853 132.282634 
+L 229.051258 132.769918 
+L 228.031663 133.252853 
+L 227.012068 133.731517 
+L 225.992473 134.205984 
+L 224.972877 134.676327 
+L 223.953282 135.142618 
+L 222.933687 135.604926 
+L 221.914092 136.063317 
+L 220.894497 136.517859 
+L 219.874902 136.968615 
+L 218.855307 137.415647 
+L 217.835712 137.859017 
+L 216.816117 138.298784 
+L 215.796522 138.735007 
+L 214.776927 139.167741 
+L 213.757332 139.597043 
+L 212.737737 140.022966 
+L 211.718142 140.445563 
+L 210.698547 140.864885 
+L 209.678952 141.280984 
+L 208.659356 141.693907 
+L 207.639761 142.103704 
+L 206.620166 142.510422 
+L 205.600571 142.914105 
+L 204.580976 143.314799 
+L 203.561381 143.712549 
+L 202.541786 144.107396 
+L 201.522191 144.499384 
+L 200.502596 144.888553 
+L 199.483001 145.274943 
+L 198.463406 145.658594 
+L 197.443811 146.039544 
+L 196.424216 146.417832 
+L 195.404621 146.793494 
+L 194.385026 147.166566 
+L 193.365431 147.537083 
+L 192.345835 147.905082 
+L 191.32624 148.270595 
+L 190.306645 148.633656 
+L 189.28705 148.994297 
+L 188.267455 149.352551 
+L 187.24786 149.708449 
+L 186.228265 150.062022 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_72">
+    <path d="M 186.228265 150.062022 
+L 185.646492 150.627569 
+L 185.064719 151.187267 
+L 184.482946 151.741235 
+L 183.901173 152.289591 
+L 183.3194 152.832446 
+L 182.737627 153.36991 
+L 182.155854 153.902088 
+L 181.574082 154.429084 
+L 180.992309 154.950998 
+L 180.410536 155.467927 
+L 179.828763 155.979965 
+L 179.24699 156.487203 
+L 178.665217 156.989732 
+L 178.083444 157.487637 
+L 177.501671 157.981003 
+L 176.919898 158.469911 
+L 176.338125 158.954443 
+L 175.756352 159.434675 
+L 175.174579 159.910682 
+L 174.592806 160.38254 
+L 174.011033 160.850319 
+L 173.42926 161.314089 
+L 172.847487 161.773919 
+L 172.265714 162.229874 
+L 171.683941 162.682021 
+L 171.102169 163.13042 
+L 170.520396 163.575136 
+L 169.938623 164.016226 
+L 169.35685 164.453751 
+L 168.775077 164.887766 
+L 168.193304 165.318329 
+L 167.611531 165.745493 
+L 167.029758 166.169312 
+L 166.447985 166.589837 
+L 165.866212 167.00712 
+L 165.284439 167.421211 
+L 164.702666 167.832156 
+L 164.120893 168.240005 
+L 163.53912 168.644803 
+L 162.957347 169.046596 
+L 162.375574 169.445428 
+L 161.793801 169.841342 
+L 161.212029 170.234381 
+L 160.630256 170.624585 
+L 160.048483 171.011997 
+L 159.46671 171.396655 
+L 158.884937 171.778598 
+L 158.303164 172.157864 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_73">
+    <path d="M 158.303164 172.157864 
+L 158.119547 172.386587 
+L 157.93593 172.614348 
+L 157.752313 172.841154 
+L 157.568696 173.067013 
+L 157.385079 173.291934 
+L 157.201462 173.515924 
+L 157.017845 173.73899 
+L 156.834228 173.961141 
+L 156.650611 174.182384 
+L 156.466994 174.402726 
+L 156.283377 174.622174 
+L 156.09976 174.840736 
+L 155.916143 175.058419 
+L 155.732525 175.27523 
+L 155.548908 175.491176 
+L 155.365291 175.706264 
+L 155.181674 175.9205 
+L 154.998057 176.133891 
+L 154.81444 176.346445 
+L 154.630823 176.558166 
+L 154.447206 176.769063 
+L 154.263589 176.979141 
+L 154.079972 177.188407 
+L 153.896355 177.396866 
+L 153.712738 177.604526 
+L 153.529121 177.811392 
+L 153.345504 178.01747 
+L 153.161887 178.222766 
+L 152.97827 178.427287 
+L 152.794653 178.631038 
+L 152.611036 178.834024 
+L 152.427419 179.036252 
+L 152.243802 179.237727 
+L 152.060185 179.438455 
+L 151.876568 179.638441 
+L 151.692951 179.83769 
+L 151.509334 180.036209 
+L 151.325717 180.234002 
+L 151.1421 180.431075 
+L 150.958483 180.627433 
+L 150.774866 180.823081 
+L 150.591249 181.018025 
+L 150.407632 181.212268 
+L 150.224015 181.405817 
+L 150.040398 181.598676 
+L 149.856781 181.790851 
+L 149.673164 181.982345 
+L 149.489547 182.173164 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_74">
+    <path d="M 149.489547 182.173164 
+L 149.30358 182.686976 
+L 149.117614 183.195954 
+L 148.931648 183.700191 
+L 148.745681 184.199773 
+L 148.559715 184.694785 
+L 148.373749 185.18531 
+L 148.187782 185.671429 
+L 148.001816 186.153221 
+L 147.81585 186.630761 
+L 147.629883 187.104124 
+L 147.443917 187.573383 
+L 147.257951 188.038607 
+L 147.071984 188.499867 
+L 146.886018 188.957228 
+L 146.700052 189.410757 
+L 146.514085 189.860516 
+L 146.328119 190.306568 
+L 146.142153 190.748974 
+L 145.956186 191.187793 
+L 145.77022 191.623082 
+L 145.584254 192.054898 
+L 145.398287 192.483296 
+L 145.212321 192.908329 
+L 145.026354 193.33005 
+L 144.840388 193.74851 
+L 144.654422 194.163759 
+L 144.468455 194.575847 
+L 144.282489 194.98482 
+L 144.096523 195.390726 
+L 143.910556 195.79361 
+L 143.72459 196.193516 
+L 143.538624 196.59049 
+L 143.352657 196.984573 
+L 143.166691 197.375806 
+L 142.980725 197.764232 
+L 142.794758 198.14989 
+L 142.608792 198.532819 
+L 142.422826 198.913058 
+L 142.236859 199.290643 
+L 142.050893 199.665612 
+L 141.864927 200.038002 
+L 141.67896 200.407846 
+L 141.492994 200.77518 
+L 141.307028 201.140037 
+L 141.121061 201.502451 
+L 140.935095 201.862455 
+L 140.749129 202.220079 
+L 140.563162 202.575355 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_75">
+    <path d="M 140.563162 202.575355 
+L 140.530281 202.723464 
+L 140.497399 202.871169 
+L 140.464518 203.018471 
+L 140.431636 203.165373 
+L 140.398755 203.311878 
+L 140.365874 203.457988 
+L 140.332992 203.603704 
+L 140.300111 203.749028 
+L 140.267229 203.893964 
+L 140.234348 204.038512 
+L 140.201466 204.182675 
+L 140.168585 204.326456 
+L 140.135703 204.469855 
+L 140.102822 204.612875 
+L 140.069941 204.755518 
+L 140.037059 204.897787 
+L 140.004178 205.039682 
+L 139.971296 205.181206 
+L 139.938415 205.322362 
+L 139.905533 205.46315 
+L 139.872652 205.603572 
+L 139.83977 205.743631 
+L 139.806889 205.883329 
+L 139.774008 206.022667 
+L 139.741126 206.161647 
+L 139.708245 206.300271 
+L 139.675363 206.438541 
+L 139.642482 206.576459 
+L 139.6096 206.714026 
+L 139.576719 206.851244 
+L 139.543837 206.988115 
+L 139.510956 207.124641 
+L 139.478075 207.260824 
+L 139.445193 207.396664 
+L 139.412312 207.532165 
+L 139.37943 207.667327 
+L 139.346549 207.802152 
+L 139.313667 207.936642 
+L 139.280786 208.070799 
+L 139.247904 208.204624 
+L 139.215023 208.338119 
+L 139.182142 208.471286 
+L 139.14926 208.604125 
+L 139.116379 208.73664 
+L 139.083497 208.86883 
+L 139.050616 209.000699 
+L 139.017734 209.132247 
+L 138.984853 209.263476 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
     <defs>
-     <path id="m7afd972a80" d="M 0 -2.5 
+     <path id="m445c51c97c" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#m7afd972a80" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7afd972a80" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#m445c51c97c" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m445c51c97c" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_69">
-    <path d="M 292.033351 64.890426 
-L 242.839153 80.520583 
-L 218.251194 86.060539 
-L 197.814984 90.141422 
-L 166.378359 98.767475 
-L 145.830392 110.20084 
-L 134.598477 125.76687 
-L 124.077268 149.129162 
-L 122.462976 157.203722 
-L 81.012077 219.378594 
-L 77.44276 238.815213 
-L 76.953425 251.874777 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_77">
+    <path d="M 610.467187 71.829514 
+L 604.413308 72.652125 
+L 598.359428 73.462419 
+L 592.305548 74.260759 
+L 586.251668 75.047494 
+L 580.197789 75.822955 
+L 574.143909 76.587462 
+L 568.090029 77.341319 
+L 562.036149 78.084819 
+L 555.98227 78.818243 
+L 549.92839 79.54186 
+L 543.87451 80.25593 
+L 537.82063 80.9607 
+L 531.76675 81.65641 
+L 525.712871 82.343289 
+L 519.658991 83.02156 
+L 513.605111 83.691435 
+L 507.551231 84.35312 
+L 501.497352 85.006812 
+L 495.443472 85.652703 
+L 489.389592 86.290976 
+L 483.335712 86.921809 
+L 477.281832 87.545373 
+L 471.227953 88.161834 
+L 465.174073 88.771352 
+L 459.120193 89.374081 
+L 453.066313 89.970172 
+L 447.012434 90.559768 
+L 440.958554 91.143011 
+L 434.904674 91.720034 
+L 428.850794 92.29097 
+L 422.796914 92.855946 
+L 416.743035 93.415084 
+L 410.689155 93.968505 
+L 404.635275 94.516323 
+L 398.581395 95.058652 
+L 392.527516 95.5956 
+L 386.473636 96.127272 
+L 380.419756 96.653773 
+L 374.365876 97.1752 
+L 368.311997 97.691651 
+L 362.258117 98.203221 
+L 356.204237 98.71 
+L 350.150357 99.212077 
+L 344.096477 99.709539 
+L 338.042598 100.20247 
+L 331.988718 100.690952 
+L 325.934838 101.175064 
+L 319.880958 101.654884 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 319.880958 101.654884 
+L 317.597631 102.418331 
+L 315.314304 103.171158 
+L 313.030977 103.913656 
+L 310.74765 104.646105 
+L 308.464322 105.368773 
+L 306.180995 106.081918 
+L 303.897668 106.785788 
+L 301.614341 107.48062 
+L 299.331014 108.166645 
+L 297.047686 108.844082 
+L 294.764359 109.513143 
+L 292.481032 110.174034 
+L 290.197705 110.826952 
+L 287.914378 111.472086 
+L 285.631051 112.10962 
+L 283.347723 112.739732 
+L 281.064396 113.362591 
+L 278.781069 113.978363 
+L 276.497742 114.587207 
+L 274.214415 115.189278 
+L 271.931087 115.784724 
+L 269.64776 116.373691 
+L 267.364433 116.956316 
+L 265.081106 117.532736 
+L 262.797779 118.103081 
+L 260.514451 118.667478 
+L 258.231124 119.226049 
+L 255.947797 119.778915 
+L 253.66447 120.326189 
+L 251.381143 120.867984 
+L 249.097816 121.404409 
+L 246.814488 121.935569 
+L 244.531161 122.461567 
+L 242.247834 122.982501 
+L 239.964507 123.498469 
+L 237.68118 124.009564 
+L 235.397852 124.515877 
+L 233.114525 125.017497 
+L 230.831198 125.51451 
+L 228.547871 126.007001 
+L 226.264544 126.49505 
+L 223.981216 126.978737 
+L 221.697889 127.458139 
+L 219.414562 127.933332 
+L 217.131235 128.404389 
+L 214.847908 128.871381 
+L 212.564581 129.334377 
+L 210.281253 129.793447 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 210.281253 129.793447 
+L 209.989708 129.874915 
+L 209.698163 129.95626 
+L 209.406617 130.037484 
+L 209.115072 130.118586 
+L 208.823527 130.199567 
+L 208.531981 130.280426 
+L 208.240436 130.361165 
+L 207.94889 130.441784 
+L 207.657345 130.522282 
+L 207.3658 130.602662 
+L 207.074254 130.682922 
+L 206.782709 130.763063 
+L 206.491164 130.843085 
+L 206.199618 130.92299 
+L 205.908073 131.002776 
+L 205.616527 131.082446 
+L 205.324982 131.161998 
+L 205.033437 131.241433 
+L 204.741891 131.320752 
+L 204.450346 131.399955 
+L 204.158801 131.479042 
+L 203.867255 131.558014 
+L 203.57571 131.63687 
+L 203.284165 131.715612 
+L 202.992619 131.794239 
+L 202.701074 131.872753 
+L 202.409528 131.951152 
+L 202.117983 132.029439 
+L 201.826438 132.107612 
+L 201.534892 132.185672 
+L 201.243347 132.26362 
+L 200.951802 132.341456 
+L 200.660256 132.41918 
+L 200.368711 132.496793 
+L 200.077166 132.574294 
+L 199.78562 132.651685 
+L 199.494075 132.728965 
+L 199.202529 132.806135 
+L 198.910984 132.883195 
+L 198.619439 132.960145 
+L 198.327893 133.036987 
+L 198.036348 133.113719 
+L 197.744803 133.190343 
+L 197.453257 133.266858 
+L 197.161712 133.343265 
+L 196.870166 133.419565 
+L 196.578621 133.495757 
+L 196.287076 133.571842 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_80">
+    <path d="M 196.287076 133.571842 
+L 195.865562 133.899995 
+L 195.444048 134.22617 
+L 195.022535 134.550391 
+L 194.601021 134.872681 
+L 194.179507 135.193063 
+L 193.757994 135.51156 
+L 193.33648 135.828193 
+L 192.914966 136.142984 
+L 192.493453 136.455955 
+L 192.071939 136.767127 
+L 191.650425 137.076519 
+L 191.228912 137.384153 
+L 190.807398 137.690048 
+L 190.385884 137.994224 
+L 189.964371 138.296699 
+L 189.542857 138.597494 
+L 189.121343 138.896626 
+L 188.69983 139.194113 
+L 188.278316 139.489974 
+L 187.856802 139.784227 
+L 187.435289 140.076888 
+L 187.013775 140.367975 
+L 186.592261 140.657505 
+L 186.170748 140.945494 
+L 185.749234 141.231958 
+L 185.32772 141.516915 
+L 184.906207 141.800378 
+L 184.484693 142.082365 
+L 184.063179 142.36289 
+L 183.641666 142.641969 
+L 183.220152 142.919615 
+L 182.798638 143.195845 
+L 182.377125 143.470671 
+L 181.955611 143.74411 
+L 181.534097 144.016173 
+L 181.112583 144.286876 
+L 180.69107 144.556231 
+L 180.269556 144.824252 
+L 179.848042 145.090953 
+L 179.426529 145.356346 
+L 179.005015 145.620443 
+L 178.583501 145.883258 
+L 178.161988 146.144803 
+L 177.740474 146.40509 
+L 177.31896 146.664131 
+L 176.897447 146.921938 
+L 176.475933 147.178523 
+L 176.054419 147.433896 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_81">
+    <path d="M 176.054419 147.433896 
+L 175.556648 148.17189 
+L 175.058877 148.899954 
+L 174.561106 149.618354 
+L 174.063336 150.327342 
+L 173.565565 151.027162 
+L 173.067794 151.718047 
+L 172.570023 152.400224 
+L 172.072252 153.073909 
+L 171.574481 153.73931 
+L 171.07671 154.39663 
+L 170.578939 155.046061 
+L 170.081168 155.687792 
+L 169.583397 156.322002 
+L 169.085626 156.948865 
+L 168.587855 157.568551 
+L 168.090084 158.181221 
+L 167.592313 158.787033 
+L 167.094542 159.386138 
+L 166.596771 159.978684 
+L 166.099 160.564812 
+L 165.601229 161.14466 
+L 165.103458 161.718361 
+L 164.605687 162.286044 
+L 164.107916 162.847834 
+L 163.610145 163.403852 
+L 163.112374 163.954216 
+L 162.614603 164.499039 
+L 162.116832 165.038432 
+L 161.619061 165.572501 
+L 161.12129 166.101352 
+L 160.623519 166.625084 
+L 160.125748 167.143797 
+L 159.627977 167.657585 
+L 159.130206 168.166541 
+L 158.632435 168.670756 
+L 158.134664 169.170316 
+L 157.636893 169.665307 
+L 157.139122 170.155811 
+L 156.641351 170.641909 
+L 156.14358 171.123681 
+L 155.645809 171.601201 
+L 155.148039 172.074544 
+L 154.650268 172.543784 
+L 154.152497 173.00899 
+L 153.654726 173.470231 
+L 153.156955 173.927574 
+L 152.659184 174.381084 
+L 152.161413 174.830826 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_82">
+    <path d="M 152.161413 174.830826 
+L 152.048054 175.104762 
+L 151.934696 175.377318 
+L 151.821337 175.648509 
+L 151.707979 175.918347 
+L 151.594621 176.186847 
+L 151.481262 176.454021 
+L 151.367904 176.719883 
+L 151.254545 176.984445 
+L 151.141187 177.247719 
+L 151.027828 177.50972 
+L 150.91447 177.770458 
+L 150.801111 178.029946 
+L 150.687753 178.288195 
+L 150.574395 178.545218 
+L 150.461036 178.801026 
+L 150.347678 179.055631 
+L 150.234319 179.309044 
+L 150.120961 179.561275 
+L 150.007602 179.812336 
+L 149.894244 180.062238 
+L 149.780886 180.310991 
+L 149.667527 180.558607 
+L 149.554169 180.805094 
+L 149.44081 181.050464 
+L 149.327452 181.294726 
+L 149.214093 181.537891 
+L 149.100735 181.779968 
+L 148.987376 182.020967 
+L 148.874018 182.260898 
+L 148.76066 182.499769 
+L 148.647301 182.737591 
+L 148.533943 182.974373 
+L 148.420584 183.210122 
+L 148.307226 183.44485 
+L 148.193867 183.678564 
+L 148.080509 183.911272 
+L 147.967151 184.142985 
+L 147.853792 184.373709 
+L 147.740434 184.603454 
+L 147.627075 184.832228 
+L 147.513717 185.060039 
+L 147.400358 185.286895 
+L 147.287 185.512804 
+L 147.173642 185.737774 
+L 147.060283 185.961812 
+L 146.946925 186.184927 
+L 146.833566 186.407126 
+L 146.720208 186.628416 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_83">
+    <path d="M 146.720208 186.628416 
+L 146.663412 186.849924 
+L 146.606617 187.070529 
+L 146.549821 187.290238 
+L 146.493026 187.509059 
+L 146.43623 187.726999 
+L 146.379435 187.944065 
+L 146.322639 188.160263 
+L 146.265843 188.375602 
+L 146.209048 188.590086 
+L 146.152252 188.803725 
+L 146.095457 189.016523 
+L 146.038661 189.228487 
+L 145.981866 189.439625 
+L 145.92507 189.649942 
+L 145.868275 189.859445 
+L 145.811479 190.06814 
+L 145.754684 190.276034 
+L 145.697888 190.483131 
+L 145.641093 190.68944 
+L 145.584297 190.894965 
+L 145.527501 191.099712 
+L 145.470706 191.303687 
+L 145.41391 191.506897 
+L 145.357115 191.709347 
+L 145.300319 191.911042 
+L 145.243524 192.111988 
+L 145.186728 192.31219 
+L 145.129933 192.511655 
+L 145.073137 192.710387 
+L 145.016342 192.908393 
+L 144.959546 193.105676 
+L 144.902751 193.302243 
+L 144.845955 193.498098 
+L 144.789159 193.693248 
+L 144.732364 193.887696 
+L 144.675568 194.081448 
+L 144.618773 194.274508 
+L 144.561977 194.466883 
+L 144.505182 194.658576 
+L 144.448386 194.849592 
+L 144.391591 195.039937 
+L 144.334795 195.229614 
+L 144.278 195.418629 
+L 144.221204 195.606986 
+L 144.164409 195.79469 
+L 144.107613 195.981745 
+L 144.050817 196.168156 
+L 143.994022 196.353927 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_84">
+    <path d="M 143.994022 196.353927 
+L 143.966356 196.438487 
+L 143.938689 196.522916 
+L 143.911023 196.607213 
+L 143.883357 196.691378 
+L 143.85569 196.775413 
+L 143.828024 196.859318 
+L 143.800357 196.943093 
+L 143.772691 197.026739 
+L 143.745025 197.110255 
+L 143.717358 197.193643 
+L 143.689692 197.276902 
+L 143.662026 197.360033 
+L 143.634359 197.443037 
+L 143.606693 197.525914 
+L 143.579027 197.608664 
+L 143.55136 197.691288 
+L 143.523694 197.773786 
+L 143.496028 197.856158 
+L 143.468361 197.938405 
+L 143.440695 198.020528 
+L 143.413029 198.102526 
+L 143.385362 198.184399 
+L 143.357696 198.26615 
+L 143.33003 198.347776 
+L 143.302363 198.42928 
+L 143.274697 198.510662 
+L 143.247031 198.591921 
+L 143.219364 198.673058 
+L 143.191698 198.754074 
+L 143.164031 198.834969 
+L 143.136365 198.915743 
+L 143.108699 198.996396 
+L 143.081032 199.07693 
+L 143.053366 199.157344 
+L 143.0257 199.237639 
+L 142.998033 199.317814 
+L 142.970367 199.397871 
+L 142.942701 199.47781 
+L 142.915034 199.557631 
+L 142.887368 199.637335 
+L 142.859702 199.716921 
+L 142.832035 199.79639 
+L 142.804369 199.875743 
+L 142.776703 199.954979 
+L 142.749036 200.0341 
+L 142.72137 200.113105 
+L 142.693704 200.191995 
+L 142.666037 200.270771 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_85">
     <defs>
-     <path id="md5c3e9c0bc" d="M -0 3.535534 
+     <path id="m99692eaeda" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#md5c3e9c0bc" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md5c3e9c0bc" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#m99692eaeda" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m99692eaeda" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_70">
-    <path d="M 75.810937 396.236449 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_86">
+    <path d="M 292.033351 64.890426 
+L 291.008471 65.26664 
+L 289.983592 65.640257 
+L 288.958713 66.011312 
+L 287.933834 66.379841 
+L 286.908955 66.745877 
+L 285.884076 67.109453 
+L 284.859197 67.470604 
+L 283.834318 67.82936 
+L 282.809439 68.185754 
+L 281.784559 68.539816 
+L 280.75968 68.891577 
+L 279.734801 69.241066 
+L 278.709922 69.588313 
+L 277.685043 69.933346 
+L 276.660164 70.276193 
+L 275.635285 70.616881 
+L 274.610406 70.955439 
+L 273.585526 71.291891 
+L 272.560647 71.626265 
+L 271.535768 71.958585 
+L 270.510889 72.288878 
+L 269.48601 72.617167 
+L 268.461131 72.943476 
+L 267.436252 73.267829 
+L 266.411373 73.590251 
+L 265.386494 73.910762 
+L 264.361614 74.229387 
+L 263.336735 74.546147 
+L 262.311856 74.861063 
+L 261.286977 75.174158 
+L 260.262098 75.485451 
+L 259.237219 75.794964 
+L 258.21234 76.102718 
+L 257.187461 76.408731 
+L 256.162581 76.713023 
+L 255.137702 77.015614 
+L 254.112823 77.316522 
+L 253.087944 77.615767 
+L 252.063065 77.913366 
+L 251.038186 78.209338 
+L 250.013307 78.503699 
+L 248.988428 78.796468 
+L 247.963549 79.087662 
+L 246.938669 79.377298 
+L 245.91379 79.665392 
+L 244.888911 79.95196 
+L 243.864032 80.237018 
+L 242.839153 80.520583 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_87">
+    <path d="M 242.839153 80.520583 
+L 242.326904 80.641977 
+L 241.814655 80.763099 
+L 241.302406 80.883951 
+L 240.790156 81.004533 
+L 240.277907 81.124847 
+L 239.765658 81.244895 
+L 239.253409 81.364676 
+L 238.74116 81.484193 
+L 238.228911 81.603447 
+L 237.716661 81.722439 
+L 237.204412 81.841169 
+L 236.692163 81.95964 
+L 236.179914 82.077851 
+L 235.667665 82.195806 
+L 235.155416 82.313503 
+L 234.643167 82.430945 
+L 234.130917 82.548133 
+L 233.618668 82.665068 
+L 233.106419 82.78175 
+L 232.59417 82.898182 
+L 232.081921 83.014364 
+L 231.569672 83.130296 
+L 231.057423 83.245981 
+L 230.545173 83.361419 
+L 230.032924 83.476612 
+L 229.520675 83.591559 
+L 229.008426 83.706263 
+L 228.496177 83.820725 
+L 227.983928 83.934945 
+L 227.471678 84.048924 
+L 226.959429 84.162664 
+L 226.44718 84.276165 
+L 225.934931 84.389429 
+L 225.422682 84.502456 
+L 224.910433 84.615248 
+L 224.398184 84.727805 
+L 223.885934 84.840128 
+L 223.373685 84.952219 
+L 222.861436 85.064078 
+L 222.349187 85.175706 
+L 221.836938 85.287105 
+L 221.324689 85.398274 
+L 220.81244 85.509216 
+L 220.30019 85.619931 
+L 219.787941 85.73042 
+L 219.275692 85.840684 
+L 218.763443 85.950723 
+L 218.251194 86.060539 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_88">
+    <path d="M 218.251194 86.060539 
+L 217.825439 86.148773 
+L 217.399685 86.236864 
+L 216.973931 86.324811 
+L 216.548176 86.412616 
+L 216.122422 86.500278 
+L 215.696668 86.587798 
+L 215.270913 86.675178 
+L 214.845159 86.762416 
+L 214.419404 86.849514 
+L 213.99365 86.936472 
+L 213.567896 87.023291 
+L 213.142141 87.10997 
+L 212.716387 87.196511 
+L 212.290632 87.282914 
+L 211.864878 87.369179 
+L 211.439124 87.455306 
+L 211.013369 87.541297 
+L 210.587615 87.627152 
+L 210.161861 87.71287 
+L 209.736106 87.798453 
+L 209.310352 87.883901 
+L 208.884597 87.969214 
+L 208.458843 88.054392 
+L 208.033089 88.139437 
+L 207.607334 88.224349 
+L 207.18158 88.309127 
+L 206.755826 88.393773 
+L 206.330071 88.478287 
+L 205.904317 88.562669 
+L 205.478562 88.646919 
+L 205.052808 88.731039 
+L 204.627054 88.815028 
+L 204.201299 88.898887 
+L 203.775545 88.982616 
+L 203.349791 89.066216 
+L 202.924036 89.149687 
+L 202.498282 89.233029 
+L 202.072527 89.316243 
+L 201.646773 89.39933 
+L 201.221019 89.482289 
+L 200.795264 89.565121 
+L 200.36951 89.647826 
+L 199.943755 89.730405 
+L 199.518001 89.812859 
+L 199.092247 89.895187 
+L 198.666492 89.97739 
+L 198.240738 90.059468 
+L 197.814984 90.141422 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_89">
+    <path d="M 197.814984 90.141422 
+L 197.160054 90.335896 
+L 196.505124 90.529674 
+L 195.850195 90.72276 
+L 195.195265 90.91516 
+L 194.540335 91.106878 
+L 193.885406 91.29792 
+L 193.230476 91.488289 
+L 192.575546 91.677991 
+L 191.920617 91.867031 
+L 191.265687 92.055412 
+L 190.610757 92.24314 
+L 189.955828 92.430219 
+L 189.300898 92.616654 
+L 188.645968 92.802448 
+L 187.991039 92.987607 
+L 187.336109 93.172135 
+L 186.681179 93.356035 
+L 186.02625 93.539313 
+L 185.37132 93.721972 
+L 184.71639 93.904016 
+L 184.06146 94.085451 
+L 183.406531 94.266279 
+L 182.751601 94.446505 
+L 182.096671 94.626132 
+L 181.441742 94.805166 
+L 180.786812 94.983609 
+L 180.131882 95.161466 
+L 179.476953 95.33874 
+L 178.822023 95.515435 
+L 178.167093 95.691555 
+L 177.512164 95.867104 
+L 176.857234 96.042086 
+L 176.202304 96.216503 
+L 175.547375 96.39036 
+L 174.892445 96.563661 
+L 174.237515 96.736408 
+L 173.582586 96.908605 
+L 172.927656 97.080257 
+L 172.272726 97.251365 
+L 171.617797 97.421935 
+L 170.962867 97.591968 
+L 170.307937 97.761469 
+L 169.653008 97.930441 
+L 168.998078 98.098887 
+L 168.343148 98.26681 
+L 167.688219 98.434213 
+L 167.033289 98.601101 
+L 166.378359 98.767475 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_90">
+    <path d="M 166.378359 98.767475 
+L 165.950277 99.032053 
+L 165.522194 99.295344 
+L 165.094111 99.55736 
+L 164.666029 99.818114 
+L 164.237946 100.077617 
+L 163.809864 100.335882 
+L 163.381781 100.59292 
+L 162.953698 100.848744 
+L 162.525616 101.103363 
+L 162.097533 101.35679 
+L 161.66945 101.609037 
+L 161.241368 101.860112 
+L 160.813285 102.110029 
+L 160.385202 102.358796 
+L 159.95712 102.606425 
+L 159.529037 102.852927 
+L 159.100954 103.09831 
+L 158.672872 103.342587 
+L 158.244789 103.585765 
+L 157.816706 103.827856 
+L 157.388624 104.068868 
+L 156.960541 104.308812 
+L 156.532458 104.547697 
+L 156.104376 104.785532 
+L 155.676293 105.022326 
+L 155.24821 105.258089 
+L 154.820128 105.492829 
+L 154.392045 105.726555 
+L 153.963962 105.959276 
+L 153.53588 106.191001 
+L 153.107797 106.421738 
+L 152.679715 106.651495 
+L 152.251632 106.880281 
+L 151.823549 107.108104 
+L 151.395467 107.334971 
+L 150.967384 107.560892 
+L 150.539301 107.785873 
+L 150.111219 108.009923 
+L 149.683136 108.23305 
+L 149.255053 108.45526 
+L 148.826971 108.676561 
+L 148.398888 108.896962 
+L 147.970805 109.116468 
+L 147.542723 109.335087 
+L 147.11464 109.552827 
+L 146.686557 109.769695 
+L 146.258475 109.985696 
+L 145.830392 110.20084 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_91">
+    <path d="M 145.830392 110.20084 
+L 145.596394 110.575284 
+L 145.362396 110.947155 
+L 145.128397 111.316488 
+L 144.894399 111.683318 
+L 144.660401 112.047678 
+L 144.426403 112.409602 
+L 144.192405 112.769121 
+L 143.958406 113.126268 
+L 143.724408 113.481073 
+L 143.49041 113.833567 
+L 143.256412 114.18378 
+L 143.022413 114.531741 
+L 142.788415 114.877479 
+L 142.554417 115.221023 
+L 142.320419 115.562399 
+L 142.086421 115.901636 
+L 141.852422 116.238759 
+L 141.618424 116.573795 
+L 141.384426 116.90677 
+L 141.150428 117.237709 
+L 140.916429 117.566636 
+L 140.682431 117.893576 
+L 140.448433 118.218553 
+L 140.214435 118.54159 
+L 139.980437 118.862711 
+L 139.746438 119.181937 
+L 139.51244 119.499291 
+L 139.278442 119.814795 
+L 139.044444 120.128471 
+L 138.810445 120.440338 
+L 138.576447 120.750419 
+L 138.342449 121.058733 
+L 138.108451 121.365301 
+L 137.874453 121.670142 
+L 137.640454 121.973275 
+L 137.406456 122.27472 
+L 137.172458 122.574495 
+L 136.93846 122.872619 
+L 136.704461 123.16911 
+L 136.470463 123.463985 
+L 136.236465 123.757262 
+L 136.002467 124.048958 
+L 135.768468 124.33909 
+L 135.53447 124.627676 
+L 135.300472 124.91473 
+L 135.066474 125.20027 
+L 134.832476 125.484312 
+L 134.598477 125.76687 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_92">
+    <path d="M 134.598477 125.76687 
+L 134.379286 126.372141 
+L 134.160094 126.970718 
+L 133.940902 127.562746 
+L 133.72171 128.148368 
+L 133.502518 128.727721 
+L 133.283326 129.300937 
+L 133.064134 129.868146 
+L 132.844942 130.429471 
+L 132.625751 130.985033 
+L 132.406559 131.534951 
+L 132.187367 132.079336 
+L 131.968175 132.6183 
+L 131.748983 133.15195 
+L 131.529791 133.680388 
+L 131.310599 134.203717 
+L 131.091408 134.722033 
+L 130.872216 135.235433 
+L 130.653024 135.744007 
+L 130.433832 136.247847 
+L 130.21464 136.747039 
+L 129.995448 137.241669 
+L 129.776256 137.731819 
+L 129.557064 138.217569 
+L 129.337873 138.698999 
+L 129.118681 139.176183 
+L 128.899489 139.649196 
+L 128.680297 140.118111 
+L 128.461105 140.582998 
+L 128.241913 141.043926 
+L 128.022721 141.500961 
+L 127.80353 141.954168 
+L 127.584338 142.403612 
+L 127.365146 142.849354 
+L 127.145954 143.291454 
+L 126.926762 143.729972 
+L 126.70757 144.164966 
+L 126.488378 144.596491 
+L 126.269186 145.024602 
+L 126.049995 145.449353 
+L 125.830803 145.870797 
+L 125.611611 146.288983 
+L 125.392419 146.703964 
+L 125.173227 147.115786 
+L 124.954035 147.524498 
+L 124.734843 147.930147 
+L 124.515652 148.332777 
+L 124.29646 148.732435 
+L 124.077268 149.129162 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_93">
+    <path d="M 124.077268 149.129162 
+L 124.043637 149.310276 
+L 124.010006 149.490786 
+L 123.976375 149.670696 
+L 123.942743 149.85001 
+L 123.909112 150.028731 
+L 123.875481 150.206865 
+L 123.84185 150.384414 
+L 123.808219 150.561382 
+L 123.774588 150.737773 
+L 123.740957 150.913592 
+L 123.707326 151.088841 
+L 123.673695 151.263524 
+L 123.640064 151.437646 
+L 123.606433 151.611209 
+L 123.572802 151.784217 
+L 123.539171 151.956674 
+L 123.50554 152.128583 
+L 123.471909 152.299947 
+L 123.438277 152.470771 
+L 123.404646 152.641058 
+L 123.371015 152.81081 
+L 123.337384 152.980031 
+L 123.303753 153.148725 
+L 123.270122 153.316894 
+L 123.236491 153.484543 
+L 123.20286 153.651674 
+L 123.169229 153.81829 
+L 123.135598 153.984395 
+L 123.101967 154.149992 
+L 123.068336 154.315084 
+L 123.034705 154.479673 
+L 123.001074 154.643764 
+L 122.967442 154.807358 
+L 122.933811 154.970459 
+L 122.90018 155.133071 
+L 122.866549 155.295195 
+L 122.832918 155.456835 
+L 122.799287 155.617993 
+L 122.765656 155.778673 
+L 122.732025 155.938878 
+L 122.698394 156.09861 
+L 122.664763 156.257871 
+L 122.631132 156.416665 
+L 122.597501 156.574995 
+L 122.56387 156.732863 
+L 122.530239 156.890271 
+L 122.496607 157.047223 
+L 122.462976 157.203722 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_94">
+    <path d="M 122.462976 157.203722 
+L 121.599416 159.580035 
+L 120.735856 161.85638 
+L 119.872295 164.040829 
+L 119.008735 166.140514 
+L 118.145174 168.16177 
+L 117.281614 170.110245 
+L 116.418054 171.990998 
+L 115.554493 173.80858 
+L 114.690933 175.567096 
+L 113.827372 177.270266 
+L 112.963812 178.921465 
+L 112.100252 180.523774 
+L 111.236691 182.080003 
+L 110.373131 183.59273 
+L 109.50957 185.06432 
+L 108.64601 186.496951 
+L 107.78245 187.892634 
+L 106.918889 189.253226 
+L 106.055329 190.580448 
+L 105.191768 191.875899 
+L 104.328208 193.141064 
+L 103.464648 194.377327 
+L 102.601087 195.585979 
+L 101.737527 196.768226 
+L 100.873966 197.925197 
+L 100.010406 199.057951 
+L 99.146846 200.16748 
+L 98.283285 201.254718 
+L 97.419725 202.320544 
+L 96.556164 203.365783 
+L 95.692604 204.391217 
+L 94.829044 205.397581 
+L 93.965483 206.385573 
+L 93.101923 207.355851 
+L 92.238362 208.309039 
+L 91.374802 209.245728 
+L 90.511242 210.166481 
+L 89.647681 211.07183 
+L 88.784121 211.962282 
+L 87.92056 212.83832 
+L 87.057 213.700403 
+L 86.193439 214.548968 
+L 85.329879 215.384433 
+L 84.466319 216.207197 
+L 83.602758 217.017639 
+L 82.739198 217.816123 
+L 81.875637 218.602997 
+L 81.012077 219.378594 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_95">
+    <path d="M 81.012077 219.378594 
+L 80.937716 219.863605 
+L 80.863356 220.344308 
+L 80.788995 220.820779 
+L 80.714634 221.293091 
+L 80.640273 221.761318 
+L 80.565912 222.225527 
+L 80.491552 222.685789 
+L 80.417191 223.14217 
+L 80.34283 223.594734 
+L 80.268469 224.043544 
+L 80.194109 224.488664 
+L 80.119748 224.930152 
+L 80.045387 225.368067 
+L 79.971026 225.802468 
+L 79.896665 226.233409 
+L 79.822305 226.660946 
+L 79.747944 227.085132 
+L 79.673583 227.506019 
+L 79.599222 227.923658 
+L 79.524862 228.338099 
+L 79.450501 228.749389 
+L 79.37614 229.157578 
+L 79.301779 229.562711 
+L 79.227418 229.964834 
+L 79.153058 230.363991 
+L 79.078697 230.760225 
+L 79.004336 231.153579 
+L 78.929975 231.544095 
+L 78.855615 231.931813 
+L 78.781254 232.316773 
+L 78.706893 232.699014 
+L 78.632532 233.078575 
+L 78.558171 233.455491 
+L 78.483811 233.829801 
+L 78.40945 234.20154 
+L 78.335089 234.570742 
+L 78.260728 234.937443 
+L 78.186368 235.301676 
+L 78.112007 235.663474 
+L 78.037646 236.02287 
+L 77.963285 236.379894 
+L 77.888924 236.734578 
+L 77.814564 237.086953 
+L 77.740203 237.437049 
+L 77.665842 237.784894 
+L 77.591481 238.130517 
+L 77.517121 238.473948 
+L 77.44276 238.815213 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_96">
+    <path d="M 77.44276 238.815213 
+L 77.432565 239.122051 
+L 77.422371 239.427159 
+L 77.412176 239.730557 
+L 77.401982 240.032264 
+L 77.391787 240.332298 
+L 77.381593 240.630677 
+L 77.371398 240.927421 
+L 77.361204 241.222546 
+L 77.35101 241.516071 
+L 77.340815 241.808012 
+L 77.330621 242.098387 
+L 77.320426 242.387212 
+L 77.310232 242.674504 
+L 77.300037 242.960279 
+L 77.289843 243.244552 
+L 77.279648 243.52734 
+L 77.269454 243.808659 
+L 77.259259 244.088522 
+L 77.249065 244.366946 
+L 77.23887 244.643944 
+L 77.228676 244.919532 
+L 77.218481 245.193724 
+L 77.208287 245.466534 
+L 77.198092 245.737975 
+L 77.187898 246.008061 
+L 77.177703 246.276807 
+L 77.167509 246.544224 
+L 77.157315 246.810326 
+L 77.14712 247.075127 
+L 77.136926 247.338638 
+L 77.126731 247.600872 
+L 77.116537 247.861842 
+L 77.106342 248.121559 
+L 77.096148 248.380036 
+L 77.085953 248.637284 
+L 77.075759 248.893315 
+L 77.065564 249.148141 
+L 77.05537 249.401772 
+L 77.045175 249.65422 
+L 77.034981 249.905496 
+L 77.024786 250.155611 
+L 77.014592 250.404575 
+L 77.004397 250.652399 
+L 76.994203 250.899093 
+L 76.984008 251.144668 
+L 76.973814 251.389134 
+L 76.96362 251.6325 
+L 76.953425 251.874777 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_97">
     <defs>
-     <path id="mee3cfe3861" d="M -0 2.5 
+     <path id="md732a8e3a7" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#mee3cfe3861" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#md732a8e3a7" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_71">
-    <path d="M 432.495268 103.672741 
-L 300.62247 118.022676 
-L 266.967623 125.683 
-L 226.040946 126.152114 
-L 180.985721 144.080759 
-L 164.441833 158.457887 
-L 157.761315 167.001817 
-L 151.269082 181.244808 
-L 150.327087 186.982195 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_98">
     <defs>
-     <path id="mec891f9a24" d="M -0.833333 2.5 
+     <path id="m4254c73284" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1831,31 +3190,437 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#mec891f9a24" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec891f9a24" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#m4254c73284" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4254c73284" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_72">
-    <path d="M 345.030867 135.087035 
-L 273.364924 141.893443 
-L 240.719951 147.934009 
-L 221.353978 153.24805 
-L 207.129625 155.190071 
-L 181.064802 166.690306 
-L 179.282169 170.285179 
-L 177.719335 175.659634 
-L 177.643939 181.03308 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_99">
+    <path d="M 432.495268 103.672741 
+L 429.747918 104.014004 
+L 427.000568 104.353127 
+L 424.253218 104.69014 
+L 421.505868 105.025066 
+L 418.758518 105.357932 
+L 416.011168 105.688764 
+L 413.263818 106.017585 
+L 410.516468 106.344421 
+L 407.769118 106.669294 
+L 405.021768 106.992229 
+L 402.274418 107.313249 
+L 399.527068 107.632375 
+L 396.779718 107.949631 
+L 394.032368 108.265037 
+L 391.285019 108.578616 
+L 388.537669 108.890389 
+L 385.790319 109.200376 
+L 383.042969 109.508597 
+L 380.295619 109.815073 
+L 377.548269 110.119823 
+L 374.800919 110.422866 
+L 372.053569 110.724222 
+L 369.306219 111.023909 
+L 366.558869 111.321946 
+L 363.811519 111.618351 
+L 361.064169 111.91314 
+L 358.316819 112.206333 
+L 355.569469 112.497946 
+L 352.822119 112.787996 
+L 350.074769 113.0765 
+L 347.327419 113.363474 
+L 344.580069 113.648934 
+L 341.832719 113.932897 
+L 339.085369 114.215377 
+L 336.338019 114.49639 
+L 333.590669 114.775952 
+L 330.843319 115.054077 
+L 328.09597 115.33078 
+L 325.34862 115.606076 
+L 322.60127 115.879978 
+L 319.85392 116.152501 
+L 317.10657 116.423658 
+L 314.35922 116.693464 
+L 311.61187 116.961931 
+L 308.86452 117.229073 
+L 306.11717 117.494902 
+L 303.36982 117.759433 
+L 300.62247 118.022676 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_100">
+    <path d="M 300.62247 118.022676 
+L 299.921327 118.193843 
+L 299.220185 118.364469 
+L 298.519042 118.534559 
+L 297.817899 118.704117 
+L 297.116757 118.873145 
+L 296.415614 119.041646 
+L 295.714471 119.209625 
+L 295.013329 119.377083 
+L 294.312186 119.544025 
+L 293.611044 119.710454 
+L 292.909901 119.876373 
+L 292.208758 120.041784 
+L 291.507616 120.206691 
+L 290.806473 120.371098 
+L 290.10533 120.535006 
+L 289.404188 120.69842 
+L 288.703045 120.861341 
+L 288.001902 121.023774 
+L 287.30076 121.18572 
+L 286.599617 121.347184 
+L 285.898474 121.508167 
+L 285.197332 121.668672 
+L 284.496189 121.828703 
+L 283.795047 121.988262 
+L 283.093904 122.147352 
+L 282.392761 122.305976 
+L 281.691619 122.464136 
+L 280.990476 122.621836 
+L 280.289333 122.779077 
+L 279.588191 122.935863 
+L 278.887048 123.092195 
+L 278.185905 123.248078 
+L 277.484763 123.403512 
+L 276.78362 123.558502 
+L 276.082478 123.713049 
+L 275.381335 123.867156 
+L 274.680192 124.020825 
+L 273.97905 124.174059 
+L 273.277907 124.326861 
+L 272.576764 124.479232 
+L 271.875622 124.631175 
+L 271.174479 124.782693 
+L 270.473336 124.933788 
+L 269.772194 125.084463 
+L 269.071051 125.234719 
+L 268.369908 125.384559 
+L 267.668766 125.533985 
+L 266.967623 125.683 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_101">
+    <path d="M 266.967623 125.683 
+L 266.114984 125.692815 
+L 265.262345 125.702628 
+L 264.409706 125.712439 
+L 263.557067 125.722249 
+L 262.704428 125.732056 
+L 261.851789 125.741862 
+L 260.999149 125.751666 
+L 260.14651 125.761469 
+L 259.293871 125.771269 
+L 258.441232 125.781068 
+L 257.588593 125.790865 
+L 256.735954 125.80066 
+L 255.883315 125.810454 
+L 255.030676 125.820245 
+L 254.178037 125.830035 
+L 253.325397 125.839823 
+L 252.472758 125.84961 
+L 251.620119 125.859394 
+L 250.76748 125.869177 
+L 249.914841 125.878958 
+L 249.062202 125.888738 
+L 248.209563 125.898515 
+L 247.356924 125.908291 
+L 246.504285 125.918065 
+L 245.651645 125.927837 
+L 244.799006 125.937608 
+L 243.946367 125.947377 
+L 243.093728 125.957144 
+L 242.241089 125.966909 
+L 241.38845 125.976672 
+L 240.535811 125.986434 
+L 239.683172 125.996194 
+L 238.830533 126.005952 
+L 237.977893 126.015708 
+L 237.125254 126.025463 
+L 236.272615 126.035216 
+L 235.419976 126.044967 
+L 234.567337 126.054716 
+L 233.714698 126.064464 
+L 232.862059 126.07421 
+L 232.00942 126.083954 
+L 231.156781 126.093696 
+L 230.304141 126.103437 
+L 229.451502 126.113176 
+L 228.598863 126.122913 
+L 227.746224 126.132648 
+L 226.893585 126.142382 
+L 226.040946 126.152114 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_102">
+    <path d="M 226.040946 126.152114 
+L 225.102295 126.593132 
+L 224.163645 127.030587 
+L 223.224994 127.464533 
+L 222.286344 127.895027 
+L 221.347693 128.322124 
+L 220.409043 128.745877 
+L 219.470392 129.166337 
+L 218.531742 129.583556 
+L 217.593091 129.997584 
+L 216.654441 130.408467 
+L 215.71579 130.816255 
+L 214.77714 131.220993 
+L 213.838489 131.622726 
+L 212.899839 132.021499 
+L 211.961188 132.417356 
+L 211.022538 132.810337 
+L 210.083887 133.200486 
+L 209.145237 133.587842 
+L 208.206586 133.972446 
+L 207.267936 134.354335 
+L 206.329285 134.733549 
+L 205.390635 135.110123 
+L 204.451984 135.484096 
+L 203.513334 135.855502 
+L 202.574683 136.224376 
+L 201.636033 136.590753 
+L 200.697382 136.954667 
+L 199.758732 137.31615 
+L 198.820081 137.675234 
+L 197.881431 138.031951 
+L 196.94278 138.386333 
+L 196.00413 138.738409 
+L 195.065479 139.088209 
+L 194.126829 139.435763 
+L 193.188178 139.781099 
+L 192.249528 140.124246 
+L 191.310877 140.46523 
+L 190.372227 140.804079 
+L 189.433576 141.14082 
+L 188.494926 141.475479 
+L 187.556275 141.808081 
+L 186.617625 142.138651 
+L 185.678974 142.467214 
+L 184.740324 142.793795 
+L 183.801673 143.118416 
+L 182.863022 143.441102 
+L 181.924372 143.761876 
+L 180.985721 144.080759 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_103">
+    <path d="M 180.985721 144.080759 
+L 180.641057 144.422756 
+L 180.296393 144.762604 
+L 179.951728 145.100332 
+L 179.607064 145.435966 
+L 179.2624 145.769531 
+L 178.917735 146.101052 
+L 178.573071 146.430555 
+L 178.228407 146.758064 
+L 177.883742 147.083602 
+L 177.539078 147.407195 
+L 177.194414 147.728863 
+L 176.849749 148.048632 
+L 176.505085 148.366522 
+L 176.160421 148.682555 
+L 175.815756 148.996754 
+L 175.471092 149.309139 
+L 175.126428 149.619731 
+L 174.781763 149.928551 
+L 174.437099 150.235619 
+L 174.092434 150.540954 
+L 173.74777 150.844576 
+L 173.403106 151.146505 
+L 173.058441 151.446758 
+L 172.713777 151.745354 
+L 172.369113 152.042312 
+L 172.024448 152.33765 
+L 171.679784 152.631384 
+L 171.33512 152.923533 
+L 170.990455 153.214113 
+L 170.645791 153.503142 
+L 170.301127 153.790634 
+L 169.956462 154.076608 
+L 169.611798 154.361079 
+L 169.267134 154.644062 
+L 168.922469 154.925573 
+L 168.577805 155.205627 
+L 168.23314 155.484239 
+L 167.888476 155.761425 
+L 167.543812 156.037198 
+L 167.199147 156.311573 
+L 166.854483 156.584563 
+L 166.509819 156.856184 
+L 166.165154 157.126448 
+L 165.82049 157.395369 
+L 165.475826 157.662961 
+L 165.131161 157.929236 
+L 164.786497 158.194207 
+L 164.441833 158.457887 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_104">
+    <path d="M 164.441833 158.457887 
+L 164.302655 158.650363 
+L 164.163478 158.842157 
+L 164.0243 159.033274 
+L 163.885123 159.223718 
+L 163.745945 159.413494 
+L 163.606768 159.602608 
+L 163.467591 159.791062 
+L 163.328413 159.978863 
+L 163.189236 160.166014 
+L 163.050058 160.35252 
+L 162.910881 160.538386 
+L 162.771703 160.723615 
+L 162.632526 160.908213 
+L 162.493348 161.092183 
+L 162.354171 161.27553 
+L 162.214994 161.458258 
+L 162.075816 161.640371 
+L 161.936639 161.821873 
+L 161.797461 162.002769 
+L 161.658284 162.183061 
+L 161.519106 162.362756 
+L 161.379929 162.541855 
+L 161.240751 162.720364 
+L 161.101574 162.898286 
+L 160.962397 163.075625 
+L 160.823219 163.252384 
+L 160.684042 163.428569 
+L 160.544864 163.604181 
+L 160.405687 163.779226 
+L 160.266509 163.953706 
+L 160.127332 164.127625 
+L 159.988155 164.300987 
+L 159.848977 164.473796 
+L 159.7098 164.646055 
+L 159.570622 164.817767 
+L 159.431445 164.988936 
+L 159.292267 165.159565 
+L 159.15309 165.329658 
+L 159.013912 165.499218 
+L 158.874735 165.668249 
+L 158.735558 165.836753 
+L 158.59638 166.004734 
+L 158.457203 166.172196 
+L 158.318025 166.339141 
+L 158.178848 166.505572 
+L 158.03967 166.671493 
+L 157.900493 166.836907 
+L 157.761315 167.001817 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_105">
+    <path d="M 157.761315 167.001817 
+L 157.626061 167.340196 
+L 157.490806 167.676472 
+L 157.355551 168.010672 
+L 157.220296 168.342821 
+L 157.085041 168.672943 
+L 156.949786 169.001064 
+L 156.814531 169.327208 
+L 156.679277 169.651397 
+L 156.544022 169.973657 
+L 156.408767 170.294009 
+L 156.273512 170.612475 
+L 156.138257 170.929079 
+L 156.003002 171.243841 
+L 155.867747 171.556783 
+L 155.732493 171.867925 
+L 155.597238 172.177289 
+L 155.461983 172.484895 
+L 155.326728 172.790762 
+L 155.191473 173.094911 
+L 155.056218 173.397359 
+L 154.920963 173.698126 
+L 154.785709 173.997232 
+L 154.650454 174.294693 
+L 154.515199 174.590528 
+L 154.379944 174.884755 
+L 154.244689 175.177391 
+L 154.109434 175.468453 
+L 153.974179 175.757957 
+L 153.838924 176.045922 
+L 153.70367 176.332362 
+L 153.568415 176.617294 
+L 153.43316 176.900734 
+L 153.297905 177.182697 
+L 153.16265 177.463199 
+L 153.027395 177.742254 
+L 152.89214 178.019878 
+L 152.756886 178.296085 
+L 152.621631 178.570889 
+L 152.486376 178.844305 
+L 152.351121 179.116347 
+L 152.215866 179.387028 
+L 152.080611 179.656361 
+L 151.945356 179.924361 
+L 151.810102 180.191041 
+L 151.674847 180.456413 
+L 151.539592 180.720489 
+L 151.404337 180.983284 
+L 151.269082 181.244808 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_106">
+    <path d="M 151.269082 181.244808 
+L 151.249457 181.370756 
+L 151.229832 181.496412 
+L 151.210207 181.621777 
+L 151.190583 181.746852 
+L 151.170958 181.871638 
+L 151.151333 181.996138 
+L 151.131708 182.120351 
+L 151.112083 182.24428 
+L 151.092458 182.367926 
+L 151.072833 182.491291 
+L 151.053208 182.614374 
+L 151.033583 182.737179 
+L 151.013958 182.859705 
+L 150.994334 182.981954 
+L 150.974709 183.103928 
+L 150.955084 183.225628 
+L 150.935459 183.347055 
+L 150.915834 183.46821 
+L 150.896209 183.589094 
+L 150.876584 183.709709 
+L 150.856959 183.830055 
+L 150.837334 183.950135 
+L 150.817709 184.069948 
+L 150.798085 184.189497 
+L 150.77846 184.308783 
+L 150.758835 184.427806 
+L 150.73921 184.546568 
+L 150.719585 184.66507 
+L 150.69996 184.783313 
+L 150.680335 184.901298 
+L 150.66071 185.019027 
+L 150.641085 185.1365 
+L 150.62146 185.253718 
+L 150.601836 185.370683 
+L 150.582211 185.487396 
+L 150.562586 185.603858 
+L 150.542961 185.72007 
+L 150.523336 185.836033 
+L 150.503711 185.951747 
+L 150.484086 186.067215 
+L 150.464461 186.182437 
+L 150.444836 186.297415 
+L 150.425212 186.412148 
+L 150.405587 186.526639 
+L 150.385962 186.640888 
+L 150.366337 186.754896 
+L 150.346712 186.868665 
+L 150.327087 186.982195 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_107">
     <defs>
-     <path id="m5336607f75" d="M -1.25 2.5 
+     <path id="mee42a8d87a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1870,31 +3635,437 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#m5336607f75" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5336607f75" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#mee42a8d87a" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee42a8d87a" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_73">
-    <path d="M 226.871027 113.078527 
-L 226.871027 113.102618 
-L 226.871027 113.251157 
-L 226.871027 113.159816 
-L 177.768423 132.098656 
-L 160.37503 145.292152 
-L 153.995779 152.427338 
-L 147.106887 167.637027 
-L 145.871703 174.910889 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_108">
+    <path d="M 345.030867 135.087035 
+L 343.537827 135.237927 
+L 342.044786 135.3884 
+L 340.551746 135.538456 
+L 339.058705 135.688097 
+L 337.565665 135.837325 
+L 336.072624 135.986143 
+L 334.579584 136.134552 
+L 333.086543 136.282556 
+L 331.593503 136.430156 
+L 330.100462 136.577355 
+L 328.607422 136.724155 
+L 327.114381 136.870557 
+L 325.621341 137.016564 
+L 324.1283 137.162179 
+L 322.63526 137.307403 
+L 321.142219 137.452238 
+L 319.649179 137.596686 
+L 318.156138 137.74075 
+L 316.663098 137.884432 
+L 315.170057 138.027733 
+L 313.677017 138.170655 
+L 312.183977 138.313201 
+L 310.690936 138.455373 
+L 309.197896 138.597172 
+L 307.704855 138.738601 
+L 306.211815 138.879661 
+L 304.718774 139.020354 
+L 303.225734 139.160682 
+L 301.732693 139.300648 
+L 300.239653 139.440252 
+L 298.746612 139.579498 
+L 297.253572 139.718385 
+L 295.760531 139.856918 
+L 294.267491 139.995096 
+L 292.77445 140.132923 
+L 291.28141 140.2704 
+L 289.788369 140.407528 
+L 288.295329 140.54431 
+L 286.802288 140.680747 
+L 285.309248 140.81684 
+L 283.816207 140.952593 
+L 282.323167 141.088005 
+L 280.830126 141.22308 
+L 279.337086 141.357819 
+L 277.844045 141.492222 
+L 276.351005 141.626293 
+L 274.857964 141.760033 
+L 273.364924 141.893443 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_109">
+    <path d="M 273.364924 141.893443 
+L 272.68482 142.026416 
+L 272.004717 142.159064 
+L 271.324613 142.291387 
+L 270.644509 142.423388 
+L 269.964406 142.555067 
+L 269.284302 142.686427 
+L 268.604199 142.817469 
+L 267.924095 142.948194 
+L 267.243991 143.078604 
+L 266.563888 143.208701 
+L 265.883784 143.338486 
+L 265.203681 143.46796 
+L 264.523577 143.597125 
+L 263.843473 143.725983 
+L 263.16337 143.854535 
+L 262.483266 143.982782 
+L 261.803163 144.110725 
+L 261.123059 144.238367 
+L 260.442955 144.365709 
+L 259.762852 144.492752 
+L 259.082748 144.619497 
+L 258.402645 144.745946 
+L 257.722541 144.8721 
+L 257.042437 144.997961 
+L 256.362334 145.12353 
+L 255.68223 145.248808 
+L 255.002127 145.373797 
+L 254.322023 145.498498 
+L 253.641919 145.622912 
+L 252.961816 145.747041 
+L 252.281712 145.870885 
+L 251.601609 145.994447 
+L 250.921505 146.117728 
+L 250.241401 146.240728 
+L 249.561298 146.36345 
+L 248.881194 146.485893 
+L 248.201091 146.608061 
+L 247.520987 146.729953 
+L 246.840883 146.851571 
+L 246.16078 146.972917 
+L 245.480676 147.093991 
+L 244.800573 147.214795 
+L 244.120469 147.335329 
+L 243.440365 147.455596 
+L 242.760262 147.575596 
+L 242.080158 147.695331 
+L 241.400055 147.814802 
+L 240.719951 147.934009 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_110">
+    <path d="M 240.719951 147.934009 
+L 240.316493 148.050211 
+L 239.913035 148.166164 
+L 239.509578 148.281869 
+L 239.10612 148.397328 
+L 238.702662 148.51254 
+L 238.299204 148.627508 
+L 237.895746 148.742232 
+L 237.492289 148.856714 
+L 237.088831 148.970953 
+L 236.685373 149.084953 
+L 236.281915 149.198712 
+L 235.878458 149.312233 
+L 235.475 149.425516 
+L 235.071542 149.538563 
+L 234.668084 149.651374 
+L 234.264626 149.76395 
+L 233.861169 149.876293 
+L 233.457711 149.988402 
+L 233.054253 150.100281 
+L 232.650795 150.211928 
+L 232.247338 150.323345 
+L 231.84388 150.434534 
+L 231.440422 150.545494 
+L 231.036964 150.656228 
+L 230.633506 150.766735 
+L 230.230049 150.877018 
+L 229.826591 150.987076 
+L 229.423133 151.09691 
+L 229.019675 151.206522 
+L 228.616218 151.315913 
+L 228.21276 151.425083 
+L 227.809302 151.534033 
+L 227.405844 151.642764 
+L 227.002386 151.751277 
+L 226.598929 151.859573 
+L 226.195471 151.967653 
+L 225.792013 152.075517 
+L 225.388555 152.183167 
+L 224.985098 152.290603 
+L 224.58164 152.397827 
+L 224.178182 152.504838 
+L 223.774724 152.611638 
+L 223.371266 152.718228 
+L 222.967809 152.824608 
+L 222.564351 152.930779 
+L 222.160893 153.036743 
+L 221.757435 153.142499 
+L 221.353978 153.24805 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_111">
+    <path d="M 221.353978 153.24805 
+L 221.057637 153.289227 
+L 220.761296 153.330374 
+L 220.464956 153.371489 
+L 220.168615 153.412573 
+L 219.872274 153.453626 
+L 219.575933 153.494648 
+L 219.279593 153.535638 
+L 218.983252 153.576598 
+L 218.686911 153.617527 
+L 218.390571 153.658424 
+L 218.09423 153.699291 
+L 217.797889 153.740127 
+L 217.501549 153.780932 
+L 217.205208 153.821707 
+L 216.908867 153.862451 
+L 216.612527 153.903164 
+L 216.316186 153.943846 
+L 216.019845 153.984498 
+L 215.723505 154.02512 
+L 215.427164 154.065711 
+L 215.130823 154.106271 
+L 214.834483 154.146801 
+L 214.538142 154.187301 
+L 214.241801 154.227771 
+L 213.945461 154.26821 
+L 213.64912 154.308619 
+L 213.352779 154.348998 
+L 213.056438 154.389347 
+L 212.760098 154.429666 
+L 212.463757 154.469955 
+L 212.167416 154.510213 
+L 211.871076 154.550442 
+L 211.574735 154.590641 
+L 211.278394 154.630811 
+L 210.982054 154.67095 
+L 210.685713 154.71106 
+L 210.389372 154.75114 
+L 210.093032 154.79119 
+L 209.796691 154.83121 
+L 209.50035 154.871202 
+L 209.20401 154.911163 
+L 208.907669 154.951095 
+L 208.611328 154.990998 
+L 208.314988 155.030871 
+L 208.018647 155.070715 
+L 207.722306 155.110529 
+L 207.425965 155.150315 
+L 207.129625 155.190071 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_112">
+    <path d="M 207.129625 155.190071 
+L 206.586608 155.456362 
+L 206.043591 155.72135 
+L 205.500573 155.985046 
+L 204.957556 156.247464 
+L 204.414539 156.508616 
+L 203.871522 156.768513 
+L 203.328505 157.027168 
+L 202.785488 157.284593 
+L 202.242471 157.5408 
+L 201.699453 157.795798 
+L 201.156436 158.049602 
+L 200.613419 158.30222 
+L 200.070402 158.553665 
+L 199.527385 158.803946 
+L 198.984368 159.053076 
+L 198.441351 159.301064 
+L 197.898333 159.547921 
+L 197.355316 159.793657 
+L 196.812299 160.038282 
+L 196.269282 160.281807 
+L 195.726265 160.52424 
+L 195.183248 160.765592 
+L 194.640231 161.005873 
+L 194.097213 161.245092 
+L 193.554196 161.483258 
+L 193.011179 161.72038 
+L 192.468162 161.956468 
+L 191.925145 162.19153 
+L 191.382128 162.425576 
+L 190.839111 162.658614 
+L 190.296093 162.890653 
+L 189.753076 163.121702 
+L 189.210059 163.351768 
+L 188.667042 163.58086 
+L 188.124025 163.808986 
+L 187.581008 164.036155 
+L 187.037991 164.262374 
+L 186.494973 164.487652 
+L 185.951956 164.711995 
+L 185.408939 164.935413 
+L 184.865922 165.157912 
+L 184.322905 165.3795 
+L 183.779888 165.600184 
+L 183.236871 165.819973 
+L 182.693853 166.038872 
+L 182.150836 166.256889 
+L 181.607819 166.474032 
+L 181.064802 166.690306 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_113">
+    <path d="M 181.064802 166.690306 
+L 181.027664 166.767688 
+L 180.990526 166.844958 
+L 180.953387 166.922119 
+L 180.916249 166.99917 
+L 180.879111 167.076111 
+L 180.841973 167.152943 
+L 180.804835 167.229666 
+L 180.767696 167.30628 
+L 180.730558 167.382786 
+L 180.69342 167.459185 
+L 180.656282 167.535475 
+L 180.619144 167.611658 
+L 180.582006 167.687734 
+L 180.544867 167.763703 
+L 180.507729 167.839566 
+L 180.470591 167.915322 
+L 180.433453 167.990973 
+L 180.396315 168.066518 
+L 180.359176 168.141957 
+L 180.322038 168.217292 
+L 180.2849 168.292522 
+L 180.247762 168.367647 
+L 180.210624 168.442669 
+L 180.173485 168.517586 
+L 180.136347 168.5924 
+L 180.099209 168.667111 
+L 180.062071 168.741718 
+L 180.024933 168.816223 
+L 179.987795 168.890626 
+L 179.950656 168.964926 
+L 179.913518 169.039125 
+L 179.87638 169.113221 
+L 179.839242 169.187217 
+L 179.802104 169.261112 
+L 179.764965 169.334905 
+L 179.727827 169.408599 
+L 179.690689 169.482192 
+L 179.653551 169.555685 
+L 179.616413 169.629078 
+L 179.579275 169.702372 
+L 179.542136 169.775567 
+L 179.504998 169.848664 
+L 179.46786 169.921661 
+L 179.430722 169.99456 
+L 179.393584 170.067361 
+L 179.356445 170.140065 
+L 179.319307 170.21267 
+L 179.282169 170.285179 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_114">
+    <path d="M 179.282169 170.285179 
+L 179.24961 170.402767 
+L 179.217051 170.520101 
+L 179.184492 170.63718 
+L 179.151933 170.754007 
+L 179.119374 170.870582 
+L 179.086815 170.986907 
+L 179.054256 171.102982 
+L 179.021697 171.218809 
+L 178.989138 171.334388 
+L 178.956579 171.449721 
+L 178.924019 171.564809 
+L 178.89146 171.679652 
+L 178.858901 171.794253 
+L 178.826342 171.908611 
+L 178.793783 172.022728 
+L 178.761224 172.136605 
+L 178.728665 172.250243 
+L 178.696106 172.363642 
+L 178.663547 172.476805 
+L 178.630988 172.589731 
+L 178.598429 172.702423 
+L 178.56587 172.81488 
+L 178.533311 172.927104 
+L 178.500752 173.039095 
+L 178.468193 173.150856 
+L 178.435634 173.262386 
+L 178.403075 173.373686 
+L 178.370516 173.484759 
+L 178.337957 173.595604 
+L 178.305398 173.706222 
+L 178.272838 173.816614 
+L 178.240279 173.926782 
+L 178.20772 174.036726 
+L 178.175161 174.146447 
+L 178.142602 174.255946 
+L 178.110043 174.365224 
+L 178.077484 174.474282 
+L 178.044925 174.583121 
+L 178.012366 174.691741 
+L 177.979807 174.800143 
+L 177.947248 174.908329 
+L 177.914689 175.016299 
+L 177.88213 175.124054 
+L 177.849571 175.231595 
+L 177.817012 175.338922 
+L 177.784453 175.446037 
+L 177.751894 175.552941 
+L 177.719335 175.659634 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_115">
+    <path d="M 177.719335 175.659634 
+L 177.717764 175.777199 
+L 177.716193 175.894509 
+L 177.714622 176.011566 
+L 177.713052 176.12837 
+L 177.711481 176.244922 
+L 177.70991 176.361224 
+L 177.708339 176.477277 
+L 177.706769 176.593081 
+L 177.705198 176.708638 
+L 177.703627 176.823949 
+L 177.702056 176.939015 
+L 177.700486 177.053836 
+L 177.698915 177.168414 
+L 177.697344 177.282751 
+L 177.695773 177.396846 
+L 177.694203 177.510701 
+L 177.692632 177.624317 
+L 177.691061 177.737695 
+L 177.68949 177.850836 
+L 177.68792 177.963742 
+L 177.686349 178.076412 
+L 177.684778 178.188848 
+L 177.683207 178.30105 
+L 177.681637 178.413021 
+L 177.680066 178.524761 
+L 177.678495 178.63627 
+L 177.676924 178.74755 
+L 177.675354 178.858601 
+L 177.673783 178.969426 
+L 177.672212 179.080023 
+L 177.670641 179.190395 
+L 177.669071 179.300543 
+L 177.6675 179.410467 
+L 177.665929 179.520168 
+L 177.664358 179.629647 
+L 177.662788 179.738905 
+L 177.661217 179.847943 
+L 177.659646 179.956761 
+L 177.658075 180.065362 
+L 177.656505 180.173745 
+L 177.654934 180.281911 
+L 177.653363 180.389861 
+L 177.651792 180.497597 
+L 177.650222 180.605118 
+L 177.648651 180.712426 
+L 177.64708 180.819522 
+L 177.645509 180.926407 
+L 177.643939 181.03308 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_116">
     <defs>
-     <path id="m477f4e2bc6" d="M 0 -2.5 
+     <path id="maf747545ca" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1907,31 +4078,437 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m477f4e2bc6" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#maf747545ca" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#maf747545ca" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_74">
-    <path d="M 585.66883 174.374171 
-L 527.144592 176.439455 
-L 457.339427 184.525165 
-L 292.124837 179.218412 
-L 243.129344 190.901895 
-L 213.541392 204.840226 
-L 204.551957 212.456838 
-L 195.860087 228.889995 
-L 194.019853 234.405357 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_117">
+    <path d="M 226.871027 113.078527 
+L 226.871027 113.079029 
+L 226.871027 113.079531 
+L 226.871027 113.080033 
+L 226.871027 113.080535 
+L 226.871027 113.081037 
+L 226.871027 113.081539 
+L 226.871027 113.082041 
+L 226.871027 113.082543 
+L 226.871027 113.083045 
+L 226.871027 113.083547 
+L 226.871027 113.084049 
+L 226.871027 113.084551 
+L 226.871027 113.085053 
+L 226.871027 113.085555 
+L 226.871027 113.086057 
+L 226.871027 113.086559 
+L 226.871027 113.087061 
+L 226.871027 113.087563 
+L 226.871027 113.088065 
+L 226.871027 113.088566 
+L 226.871027 113.089068 
+L 226.871027 113.08957 
+L 226.871027 113.090072 
+L 226.871027 113.090574 
+L 226.871027 113.091076 
+L 226.871027 113.091578 
+L 226.871027 113.09208 
+L 226.871027 113.092581 
+L 226.871027 113.093083 
+L 226.871027 113.093585 
+L 226.871027 113.094087 
+L 226.871027 113.094589 
+L 226.871027 113.095091 
+L 226.871027 113.095593 
+L 226.871027 113.096094 
+L 226.871027 113.096596 
+L 226.871027 113.097098 
+L 226.871027 113.0976 
+L 226.871027 113.098102 
+L 226.871027 113.098604 
+L 226.871027 113.099105 
+L 226.871027 113.099607 
+L 226.871027 113.100109 
+L 226.871027 113.100611 
+L 226.871027 113.101113 
+L 226.871027 113.101614 
+L 226.871027 113.102116 
+L 226.871027 113.102618 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_118">
+    <path d="M 226.871027 113.102618 
+L 226.871027 113.105717 
+L 226.871027 113.108815 
+L 226.871027 113.111914 
+L 226.871027 113.115012 
+L 226.871027 113.11811 
+L 226.871027 113.121208 
+L 226.871027 113.124305 
+L 226.871027 113.127403 
+L 226.871027 113.1305 
+L 226.871027 113.133597 
+L 226.871027 113.136694 
+L 226.871027 113.139791 
+L 226.871027 113.142888 
+L 226.871027 113.145984 
+L 226.871027 113.14908 
+L 226.871027 113.152176 
+L 226.871027 113.155272 
+L 226.871027 113.158368 
+L 226.871027 113.161464 
+L 226.871027 113.164559 
+L 226.871027 113.167654 
+L 226.871027 113.170749 
+L 226.871027 113.173844 
+L 226.871027 113.176939 
+L 226.871027 113.180033 
+L 226.871027 113.183127 
+L 226.871027 113.186222 
+L 226.871027 113.189316 
+L 226.871027 113.192409 
+L 226.871027 113.195503 
+L 226.871027 113.198596 
+L 226.871027 113.20169 
+L 226.871027 113.204783 
+L 226.871027 113.207876 
+L 226.871027 113.210968 
+L 226.871027 113.214061 
+L 226.871027 113.217153 
+L 226.871027 113.220245 
+L 226.871027 113.223337 
+L 226.871027 113.226429 
+L 226.871027 113.229521 
+L 226.871027 113.232612 
+L 226.871027 113.235704 
+L 226.871027 113.238795 
+L 226.871027 113.241886 
+L 226.871027 113.244976 
+L 226.871027 113.248067 
+L 226.871027 113.251157 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_119">
+    <path d="M 226.871027 113.251157 
+L 226.871027 113.249256 
+L 226.871027 113.247355 
+L 226.871027 113.245453 
+L 226.871027 113.243552 
+L 226.871027 113.24165 
+L 226.871027 113.239748 
+L 226.871027 113.237846 
+L 226.871027 113.235945 
+L 226.871027 113.234043 
+L 226.871027 113.232141 
+L 226.871027 113.230239 
+L 226.871027 113.228336 
+L 226.871027 113.226434 
+L 226.871027 113.224532 
+L 226.871027 113.22263 
+L 226.871027 113.220727 
+L 226.871027 113.218825 
+L 226.871027 113.216922 
+L 226.871027 113.21502 
+L 226.871027 113.213117 
+L 226.871027 113.211214 
+L 226.871027 113.209312 
+L 226.871027 113.207409 
+L 226.871027 113.205506 
+L 226.871027 113.203603 
+L 226.871027 113.2017 
+L 226.871027 113.199797 
+L 226.871027 113.197894 
+L 226.871027 113.19599 
+L 226.871027 113.194087 
+L 226.871027 113.192184 
+L 226.871027 113.19028 
+L 226.871027 113.188377 
+L 226.871027 113.186473 
+L 226.871027 113.184569 
+L 226.871027 113.182666 
+L 226.871027 113.180762 
+L 226.871027 113.178858 
+L 226.871027 113.176954 
+L 226.871027 113.17505 
+L 226.871027 113.173146 
+L 226.871027 113.171242 
+L 226.871027 113.169338 
+L 226.871027 113.167434 
+L 226.871027 113.165529 
+L 226.871027 113.163625 
+L 226.871027 113.16172 
+L 226.871027 113.159816 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_120">
+    <path d="M 226.871027 113.159816 
+L 225.848056 113.630174 
+L 224.825086 114.096478 
+L 223.802115 114.5588 
+L 222.779144 115.017205 
+L 221.756173 115.47176 
+L 220.733202 115.922529 
+L 219.710231 116.369574 
+L 218.68726 116.812957 
+L 217.664289 117.252736 
+L 216.641318 117.688971 
+L 215.618347 118.121717 
+L 214.595376 118.551031 
+L 213.572405 118.976966 
+L 212.549434 119.399574 
+L 211.526464 119.818908 
+L 210.503493 120.235018 
+L 209.480522 120.647952 
+L 208.457551 121.05776 
+L 207.43458 121.464488 
+L 206.411609 121.868182 
+L 205.388638 122.268886 
+L 204.365667 122.666646 
+L 203.342696 123.061504 
+L 202.319725 123.453501 
+L 201.296754 123.84268 
+L 200.273783 124.229079 
+L 199.250812 124.61274 
+L 198.227842 124.9937 
+L 197.204871 125.371997 
+L 196.1819 125.747667 
+L 195.158929 126.120748 
+L 194.135958 126.491275 
+L 193.112987 126.859282 
+L 192.090016 127.224804 
+L 191.067045 127.587873 
+L 190.044074 127.948523 
+L 189.021103 128.306785 
+L 187.998132 128.662691 
+L 186.975161 129.016272 
+L 185.952191 129.367558 
+L 184.92922 129.716578 
+L 183.906249 130.063362 
+L 182.883278 130.407937 
+L 181.860307 130.750333 
+L 180.837336 131.090576 
+L 179.814365 131.428693 
+L 178.791394 131.764711 
+L 177.768423 132.098656 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_121">
+    <path d="M 177.768423 132.098656 
+L 177.406061 132.40903 
+L 177.043698 132.717635 
+L 176.681336 133.024489 
+L 176.318974 133.329614 
+L 175.956611 133.633028 
+L 175.594249 133.93475 
+L 175.231887 134.234799 
+L 174.869524 134.533194 
+L 174.507162 134.829953 
+L 174.1448 135.125093 
+L 173.782437 135.418633 
+L 173.420075 135.710589 
+L 173.057713 136.000978 
+L 172.69535 136.289818 
+L 172.332988 136.577124 
+L 171.970626 136.862913 
+L 171.608263 137.1472 
+L 171.245901 137.430002 
+L 170.883538 137.711334 
+L 170.521176 137.991211 
+L 170.158814 138.269648 
+L 169.796451 138.54666 
+L 169.434089 138.822261 
+L 169.071727 139.096466 
+L 168.709364 139.369288 
+L 168.347002 139.640742 
+L 167.98464 139.910841 
+L 167.622277 140.179599 
+L 167.259915 140.447029 
+L 166.897553 140.713144 
+L 166.53519 140.977956 
+L 166.172828 141.241479 
+L 165.810466 141.503725 
+L 165.448103 141.764707 
+L 165.085741 142.024435 
+L 164.723378 142.282924 
+L 164.361016 142.540183 
+L 163.998654 142.796226 
+L 163.636291 143.051063 
+L 163.273929 143.304705 
+L 162.911567 143.557164 
+L 162.549204 143.808451 
+L 162.186842 144.058577 
+L 161.82448 144.307552 
+L 161.462117 144.555386 
+L 161.099755 144.802091 
+L 160.737393 145.047676 
+L 160.37503 145.292152 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_122">
+    <path d="M 160.37503 145.292152 
+L 160.242129 145.450814 
+L 160.109228 145.609011 
+L 159.976327 145.766748 
+L 159.843426 145.924026 
+L 159.710525 146.080848 
+L 159.577624 146.237217 
+L 159.444723 146.393136 
+L 159.311822 146.548607 
+L 159.178921 146.703632 
+L 159.04602 146.858215 
+L 158.913119 147.012357 
+L 158.780218 147.166062 
+L 158.647316 147.319331 
+L 158.514415 147.472168 
+L 158.381514 147.624574 
+L 158.248613 147.776552 
+L 158.115712 147.928104 
+L 157.982811 148.079233 
+L 157.84991 148.229941 
+L 157.717009 148.380231 
+L 157.584108 148.530105 
+L 157.451207 148.679564 
+L 157.318306 148.828612 
+L 157.185405 148.977251 
+L 157.052504 149.125483 
+L 156.919603 149.273309 
+L 156.786702 149.420733 
+L 156.653801 149.567757 
+L 156.5209 149.714382 
+L 156.387998 149.860611 
+L 156.255097 150.006446 
+L 156.122196 150.151889 
+L 155.989295 150.296942 
+L 155.856394 150.441607 
+L 155.723493 150.585887 
+L 155.590592 150.729783 
+L 155.457691 150.873297 
+L 155.32479 151.016432 
+L 155.191889 151.15919 
+L 155.058988 151.301571 
+L 154.926087 151.44358 
+L 154.793186 151.585216 
+L 154.660285 151.726483 
+L 154.527384 151.867382 
+L 154.394483 152.007915 
+L 154.261581 152.148084 
+L 154.12868 152.287891 
+L 153.995779 152.427338 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_123">
+    <path d="M 153.995779 152.427338 
+L 153.852261 152.791984 
+L 153.708742 153.154189 
+L 153.565224 153.513987 
+L 153.421705 153.871408 
+L 153.278186 154.226484 
+L 153.134668 154.579245 
+L 152.991149 154.929722 
+L 152.847631 155.277944 
+L 152.704112 155.62394 
+L 152.560593 155.967738 
+L 152.417075 156.309365 
+L 152.273556 156.648849 
+L 152.130038 156.986217 
+L 151.986519 157.321495 
+L 151.843 157.654709 
+L 151.699482 157.985883 
+L 151.555963 158.315044 
+L 151.412445 158.642214 
+L 151.268926 158.967418 
+L 151.125407 159.29068 
+L 150.981889 159.612022 
+L 150.83837 159.931468 
+L 150.694852 160.249039 
+L 150.551333 160.564757 
+L 150.407814 160.878644 
+L 150.264296 161.190721 
+L 150.120777 161.501009 
+L 149.977259 161.809528 
+L 149.83374 162.116298 
+L 149.690221 162.421339 
+L 149.546703 162.72467 
+L 149.403184 163.026311 
+L 149.259666 163.326279 
+L 149.116147 163.624594 
+L 148.972628 163.921274 
+L 148.82911 164.216336 
+L 148.685591 164.509798 
+L 148.542073 164.801678 
+L 148.398554 165.091992 
+L 148.255035 165.380756 
+L 148.111517 165.667988 
+L 147.967998 165.953704 
+L 147.82448 166.237919 
+L 147.680961 166.520649 
+L 147.537442 166.80191 
+L 147.393924 167.081716 
+L 147.250405 167.360084 
+L 147.106887 167.637027 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_124">
+    <path d="M 147.106887 167.637027 
+L 147.081154 167.798979 
+L 147.055421 167.960448 
+L 147.029688 168.121436 
+L 147.003955 168.281947 
+L 146.978222 168.441984 
+L 146.952489 168.601549 
+L 146.926756 168.760644 
+L 146.901023 168.919273 
+L 146.87529 169.077439 
+L 146.849557 169.235143 
+L 146.823824 169.39239 
+L 146.798091 169.549181 
+L 146.772358 169.705519 
+L 146.746625 169.861406 
+L 146.720892 170.016846 
+L 146.695159 170.171841 
+L 146.669426 170.326393 
+L 146.643693 170.480505 
+L 146.61796 170.634179 
+L 146.592227 170.787418 
+L 146.566494 170.940225 
+L 146.540761 171.092601 
+L 146.515028 171.244549 
+L 146.489295 171.396072 
+L 146.463562 171.547172 
+L 146.437829 171.697852 
+L 146.412096 171.848112 
+L 146.386363 171.997957 
+L 146.36063 172.147388 
+L 146.334897 172.296408 
+L 146.309164 172.445018 
+L 146.283431 172.593222 
+L 146.257698 172.74102 
+L 146.231965 172.888417 
+L 146.206232 173.035412 
+L 146.180499 173.18201 
+L 146.154766 173.328212 
+L 146.129033 173.474019 
+L 146.1033 173.619435 
+L 146.077567 173.764461 
+L 146.051834 173.9091 
+L 146.026101 174.053353 
+L 146.000368 174.197223 
+L 145.974635 174.340711 
+L 145.948902 174.483819 
+L 145.923169 174.626551 
+L 145.897436 174.768906 
+L 145.871703 174.910889 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_125">
     <defs>
-     <path id="mb68c7a53d1" d="M 0 -2.5 
+     <path id="m4d5955b153" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1940,17 +4517,433 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#mb68c7a53d1" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb68c7a53d1" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#m4d5955b153" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5955b153" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
+   </g>
+   <g id="line2d_126">
+    <path d="M 585.66883 174.374171 
+L 584.449575 174.418012 
+L 583.23032 174.461817 
+L 582.011065 174.505586 
+L 580.79181 174.549321 
+L 579.572555 174.59302 
+L 578.3533 174.636683 
+L 577.134045 174.680312 
+L 575.91479 174.723905 
+L 574.695535 174.767463 
+L 573.47628 174.810986 
+L 572.257025 174.854475 
+L 571.037771 174.897928 
+L 569.818516 174.941346 
+L 568.599261 174.98473 
+L 567.380006 175.028079 
+L 566.160751 175.071393 
+L 564.941496 175.114673 
+L 563.722241 175.157918 
+L 562.502986 175.201128 
+L 561.283731 175.244304 
+L 560.064476 175.287446 
+L 558.845221 175.330553 
+L 557.625966 175.373626 
+L 556.406711 175.416664 
+L 555.187456 175.459669 
+L 553.968201 175.502639 
+L 552.748946 175.545575 
+L 551.529691 175.588477 
+L 550.310436 175.631346 
+L 549.091181 175.67418 
+L 547.871926 175.71698 
+L 546.652672 175.759747 
+L 545.433417 175.80248 
+L 544.214162 175.845179 
+L 542.994907 175.887844 
+L 541.775652 175.930476 
+L 540.556397 175.973074 
+L 539.337142 176.015639 
+L 538.117887 176.05817 
+L 536.898632 176.100668 
+L 535.679377 176.143132 
+L 534.460122 176.185564 
+L 533.240867 176.227962 
+L 532.021612 176.270326 
+L 530.802357 176.312658 
+L 529.583102 176.354957 
+L 528.363847 176.397222 
+L 527.144592 176.439455 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_127">
+    <path d="M 527.144592 176.439455 
+L 525.690318 176.620838 
+L 524.236044 176.801615 
+L 522.781769 176.98179 
+L 521.327495 177.161367 
+L 519.873221 177.34035 
+L 518.418947 177.518744 
+L 516.964672 177.696551 
+L 515.510398 177.873776 
+L 514.056124 178.050422 
+L 512.60185 178.226494 
+L 511.147575 178.401995 
+L 509.693301 178.576928 
+L 508.239027 178.751298 
+L 506.784752 178.925108 
+L 505.330478 179.098361 
+L 503.876204 179.271062 
+L 502.42193 179.443213 
+L 500.967655 179.614818 
+L 499.513381 179.785881 
+L 498.059107 179.956405 
+L 496.604833 180.126393 
+L 495.150558 180.295849 
+L 493.696284 180.464776 
+L 492.24201 180.633178 
+L 490.787735 180.801057 
+L 489.333461 180.968416 
+L 487.879187 181.13526 
+L 486.424913 181.301591 
+L 484.970638 181.467413 
+L 483.516364 181.632728 
+L 482.06209 181.797539 
+L 480.607816 181.96185 
+L 479.153541 182.125664 
+L 477.699267 182.288983 
+L 476.244993 182.451811 
+L 474.790718 182.614151 
+L 473.336444 182.776005 
+L 471.88217 182.937376 
+L 470.427896 183.098268 
+L 468.973621 183.258682 
+L 467.519347 183.418623 
+L 466.065073 183.578092 
+L 464.610799 183.737093 
+L 463.156524 183.895628 
+L 461.70225 184.0537 
+L 460.247976 184.211312 
+L 458.793701 184.368466 
+L 457.339427 184.525165 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_128">
+    <path d="M 457.339427 184.525165 
+L 453.897457 184.419752 
+L 450.455486 184.314134 
+L 447.013515 184.20831 
+L 443.571545 184.102278 
+L 440.129574 183.996038 
+L 436.687603 183.889589 
+L 433.245633 183.78293 
+L 429.803662 183.67606 
+L 426.361692 183.568979 
+L 422.919721 183.461686 
+L 419.47775 183.35418 
+L 416.03578 183.246459 
+L 412.593809 183.138524 
+L 409.151838 183.030373 
+L 405.709868 182.922006 
+L 402.267897 182.813421 
+L 398.825927 182.704618 
+L 395.383956 182.595595 
+L 391.941985 182.486353 
+L 388.500015 182.37689 
+L 385.058044 182.267204 
+L 381.616074 182.157296 
+L 378.174103 182.047165 
+L 374.732132 181.936808 
+L 371.290162 181.826227 
+L 367.848191 181.715418 
+L 364.40622 181.604383 
+L 360.96425 181.493119 
+L 357.522279 181.381626 
+L 354.080309 181.269903 
+L 350.638338 181.157949 
+L 347.196367 181.045762 
+L 343.754397 180.933343 
+L 340.312426 180.820689 
+L 336.870455 180.707801 
+L 333.428485 180.594677 
+L 329.986514 180.481315 
+L 326.544544 180.367716 
+L 323.102573 180.253878 
+L 319.660602 180.139799 
+L 316.218632 180.02548 
+L 312.776661 179.910919 
+L 309.33469 179.796115 
+L 305.89272 179.681066 
+L 302.450749 179.565773 
+L 299.008779 179.450234 
+L 295.566808 179.334447 
+L 292.124837 179.218412 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_129">
+    <path d="M 292.124837 179.218412 
+L 291.104098 179.48941 
+L 290.083359 179.759057 
+L 289.062619 180.027368 
+L 288.04188 180.294354 
+L 287.02114 180.560031 
+L 286.000401 180.824409 
+L 284.979661 181.087502 
+L 283.958922 181.349322 
+L 282.938182 181.609882 
+L 281.917443 181.869193 
+L 280.896704 182.127268 
+L 279.875964 182.384118 
+L 278.855225 182.639754 
+L 277.834485 182.894189 
+L 276.813746 183.147433 
+L 275.793006 183.399497 
+L 274.772267 183.650393 
+L 273.751528 183.900132 
+L 272.730788 184.148723 
+L 271.710049 184.396177 
+L 270.689309 184.642505 
+L 269.66857 184.887717 
+L 268.64783 185.131823 
+L 267.627091 185.374832 
+L 266.606351 185.616756 
+L 265.585612 185.857602 
+L 264.564873 186.097382 
+L 263.544133 186.336104 
+L 262.523394 186.573777 
+L 261.502654 186.810412 
+L 260.481915 187.046016 
+L 259.461175 187.280599 
+L 258.440436 187.514169 
+L 257.419697 187.746736 
+L 256.398957 187.978307 
+L 255.378218 188.208892 
+L 254.357478 188.438499 
+L 253.336739 188.667135 
+L 252.315999 188.89481 
+L 251.29526 189.121531 
+L 250.274521 189.347306 
+L 249.253781 189.572143 
+L 248.233042 189.79605 
+L 247.212302 190.019034 
+L 246.191563 190.241103 
+L 245.170823 190.462265 
+L 244.150084 190.682527 
+L 243.129344 190.901895 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_130">
+    <path d="M 243.129344 190.901895 
+L 242.512929 191.23209 
+L 241.896513 191.560283 
+L 241.280097 191.886497 
+L 240.663682 192.210757 
+L 240.047266 192.533085 
+L 239.43085 192.853505 
+L 238.814435 193.172039 
+L 238.198019 193.488709 
+L 237.581603 193.803537 
+L 236.965188 194.116544 
+L 236.348772 194.427751 
+L 235.732356 194.737178 
+L 235.115941 195.044847 
+L 234.499525 195.350776 
+L 233.883109 195.654986 
+L 233.266694 195.957495 
+L 232.650278 196.258323 
+L 232.033862 196.557487 
+L 231.417447 196.855007 
+L 230.801031 197.1509 
+L 230.184615 197.445185 
+L 229.5682 197.737877 
+L 228.951784 198.028996 
+L 228.335368 198.318556 
+L 227.718953 198.606576 
+L 227.102537 198.89307 
+L 226.486121 199.178057 
+L 225.869706 199.46155 
+L 225.25329 199.743566 
+L 224.636874 200.02412 
+L 224.020459 200.303227 
+L 223.404043 200.580902 
+L 222.787627 200.857159 
+L 222.171212 201.132014 
+L 221.554796 201.405479 
+L 220.93838 201.67757 
+L 220.321965 201.948299 
+L 219.705549 202.217681 
+L 219.089133 202.485729 
+L 218.472718 202.752456 
+L 217.856302 203.017874 
+L 217.239886 203.281997 
+L 216.623471 203.544838 
+L 216.007055 203.806408 
+L 215.390639 204.06672 
+L 214.774224 204.325785 
+L 214.157808 204.583617 
+L 213.541392 204.840226 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_131">
+    <path d="M 213.541392 204.840226 
+L 213.354112 205.010346 
+L 213.166833 205.179934 
+L 212.979553 205.348992 
+L 212.792273 205.517523 
+L 212.604993 205.685532 
+L 212.417713 205.85302 
+L 212.230433 206.019992 
+L 212.043153 206.18645 
+L 211.855873 206.352397 
+L 211.668593 206.517837 
+L 211.481314 206.682773 
+L 211.294034 206.847208 
+L 211.106754 207.011145 
+L 210.919474 207.174587 
+L 210.732194 207.337536 
+L 210.544914 207.499997 
+L 210.357634 207.661971 
+L 210.170354 207.823462 
+L 209.983074 207.984472 
+L 209.795794 208.145005 
+L 209.608515 208.305063 
+L 209.421235 208.464649 
+L 209.233955 208.623766 
+L 209.046675 208.782416 
+L 208.859395 208.940603 
+L 208.672115 209.098328 
+L 208.484835 209.255596 
+L 208.297555 209.412407 
+L 208.110275 209.568766 
+L 207.922996 209.724674 
+L 207.735716 209.880134 
+L 207.548436 210.035149 
+L 207.361156 210.189721 
+L 207.173876 210.343853 
+L 206.986596 210.497547 
+L 206.799316 210.650806 
+L 206.612036 210.803632 
+L 206.424756 210.956028 
+L 206.237476 211.107996 
+L 206.050197 211.259538 
+L 205.862917 211.410657 
+L 205.675637 211.561356 
+L 205.488357 211.711635 
+L 205.301077 211.861499 
+L 205.113797 212.010949 
+L 204.926517 212.159987 
+L 204.739237 212.308616 
+L 204.551957 212.456838 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_132">
+    <path d="M 204.551957 212.456838 
+L 204.370877 212.855389 
+L 204.189796 213.251026 
+L 204.008716 213.643792 
+L 203.827635 214.033728 
+L 203.646554 214.420875 
+L 203.465474 214.805271 
+L 203.284393 215.186957 
+L 203.103312 215.565969 
+L 202.922232 215.942346 
+L 202.741151 216.316123 
+L 202.56007 216.687336 
+L 202.37899 217.056021 
+L 202.197909 217.42221 
+L 202.016829 217.785939 
+L 201.835748 218.147239 
+L 201.654667 218.506143 
+L 201.473587 218.862682 
+L 201.292506 219.216888 
+L 201.111425 219.568791 
+L 200.930345 219.91842 
+L 200.749264 220.265805 
+L 200.568183 220.610975 
+L 200.387103 220.953957 
+L 200.206022 221.294778 
+L 200.024942 221.633467 
+L 199.843861 221.97005 
+L 199.66278 222.304552 
+L 199.4817 222.636999 
+L 199.300619 222.967417 
+L 199.119538 223.295829 
+L 198.938458 223.62226 
+L 198.757377 223.946735 
+L 198.576296 224.269275 
+L 198.395216 224.589905 
+L 198.214135 224.908646 
+L 198.033055 225.225521 
+L 197.851974 225.540551 
+L 197.670893 225.853758 
+L 197.489813 226.165163 
+L 197.308732 226.474786 
+L 197.127651 226.782648 
+L 196.946571 227.088768 
+L 196.76549 227.393167 
+L 196.58441 227.695863 
+L 196.403329 227.996875 
+L 196.222248 228.296222 
+L 196.041168 228.593923 
+L 195.860087 228.889995 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_133">
+    <path d="M 195.860087 228.889995 
+L 195.821749 229.010823 
+L 195.783411 229.131381 
+L 195.745072 229.251671 
+L 195.706734 229.371695 
+L 195.668396 229.491453 
+L 195.630058 229.610947 
+L 195.59172 229.730177 
+L 195.553381 229.849145 
+L 195.515043 229.967852 
+L 195.476705 230.0863 
+L 195.438367 230.204489 
+L 195.400028 230.32242 
+L 195.36169 230.440095 
+L 195.323352 230.557514 
+L 195.285014 230.674679 
+L 195.246676 230.791592 
+L 195.208337 230.908252 
+L 195.169999 231.024661 
+L 195.131661 231.14082 
+L 195.093323 231.256731 
+L 195.054985 231.372394 
+L 195.016646 231.48781 
+L 194.978308 231.60298 
+L 194.93997 231.717906 
+L 194.901632 231.832589 
+L 194.863293 231.947029 
+L 194.824955 232.061227 
+L 194.786617 232.175185 
+L 194.748279 232.288904 
+L 194.709941 232.402384 
+L 194.671602 232.515626 
+L 194.633264 232.628632 
+L 194.594926 232.741403 
+L 194.556588 232.853939 
+L 194.51825 232.966242 
+L 194.479911 233.078312 
+L 194.441573 233.19015 
+L 194.403235 233.301758 
+L 194.364897 233.413136 
+L 194.326559 233.524286 
+L 194.28822 233.635207 
+L 194.249882 233.745902 
+L 194.211544 233.856371 
+L 194.173206 233.966614 
+L 194.134867 234.076634 
+L 194.096529 234.18643 
+L 194.058191 234.296004 
+L 194.019853 234.405357 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -1966,13 +4959,9 @@ Q 422.84625 408.80375 424.44625 408.80375
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_75">
-     <path d="M 426.04625 353.9475 
-L 434.04625 353.9475 
-L 442.04625 353.9475 
-" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g id="line2d_134">
      <defs>
-      <path id="m8c99534ff6" d="M 0 3.5 
+      <path id="mae930104a8" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1985,7 +4974,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8c99534ff6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mae930104a8" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,13 +5031,9 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_76">
-     <path d="M 426.04625 365.69 
-L 434.04625 365.69 
-L 442.04625 365.69 
-" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_135">
      <g>
-      <use xlink:href="#m8e4da0fa55" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m632e8cdad7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,13 +5045,9 @@ L 442.04625 365.69
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_77">
-     <path d="M 426.04625 377.4325 
-L 434.04625 377.4325 
-L 442.04625 377.4325 
-" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_136">
      <g>
-      <use xlink:href="#m7afd972a80" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m445c51c97c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,13 +5090,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_78">
-     <path d="M 426.04625 389.3975 
-L 434.04625 389.3975 
-L 442.04625 389.3975 
-" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_137">
      <g>
-      <use xlink:href="#md5c3e9c0bc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m99692eaeda" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,13 +5133,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_79">
-     <path d="M 426.04625 401.14 
-L 434.04625 401.14 
-L 442.04625 401.14 
-" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_138">
      <g>
-      <use xlink:href="#mee3cfe3861" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md732a8e3a7" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,13 +5149,9 @@ L 442.04625 401.14
       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
      </g>
     </g>
-    <g id="line2d_80">
-     <path d="M 529.72375 353.9475 
-L 537.72375 353.9475 
-L 545.72375 353.9475 
-" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_139">
      <g>
-      <use xlink:href="#mec891f9a24" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4254c73284" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,13 +5203,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_81">
-     <path d="M 529.72375 365.69 
-L 537.72375 365.69 
-L 545.72375 365.69 
-" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_140">
      <g>
-      <use xlink:href="#m5336607f75" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee42a8d87a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,13 +5268,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_82">
-     <path d="M 529.72375 377.4325 
-L 537.72375 377.4325 
-L 545.72375 377.4325 
-" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_141">
      <g>
-      <use xlink:href="#m477f4e2bc6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#maf747545ca" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,13 +5306,9 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_83">
-     <path d="M 529.72375 389.175 
-L 537.72375 389.175 
-L 545.72375 389.175 
-" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <g id="line2d_142">
      <g>
-      <use xlink:href="#mb68c7a53d1" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4d5955b153" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2420,33 +5377,439 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_84">
-    <path d="M 257.531237 149.107129 
-L 236.23654 153.82467 
-L 222.073314 158.324086 
-L 202.315941 169.281009 
-L 199.905291 170.980798 
-L 195.893147 175.179401 
-L 187.210062 188.875151 
-L 157.246106 245.372702 
-L 95.319203 339.014613 
-" clip-path="url(#pbf47cf6877)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pbf47cf6877)">
-     <use xlink:href="#m8c99534ff6" x="257.531237" y="149.107129" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="236.23654" y="153.82467" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="222.073314" y="158.324086" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="202.315941" y="169.281009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="199.905291" y="170.980798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="195.893147" y="175.179401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="187.210062" y="188.875151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="157.246106" y="245.372702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8c99534ff6" x="95.319203" y="339.014613" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_143">
+    <g clip-path="url(#p66bcfd2819)">
+     <use xlink:href="#mae930104a8" x="257.531237" y="149.107129" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="236.23654" y="153.82467" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="222.073314" y="158.324086" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="202.315941" y="169.281009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="199.905291" y="170.980798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="195.893147" y="175.179401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="187.210062" y="188.875151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="157.246106" y="245.372702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae930104a8" x="95.319203" y="339.014613" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
+   </g>
+   <g id="line2d_144">
+    <path d="M 257.531237 149.107129 
+L 257.087598 149.209724 
+L 256.643958 149.312126 
+L 256.200319 149.414334 
+L 255.756679 149.51635 
+L 255.31304 149.618173 
+L 254.8694 149.719805 
+L 254.425761 149.821247 
+L 253.982121 149.922499 
+L 253.538482 150.023562 
+L 253.094842 150.124437 
+L 252.651203 150.225124 
+L 252.207563 150.325624 
+L 251.763924 150.425937 
+L 251.320284 150.526065 
+L 250.876645 150.626008 
+L 250.433005 150.725767 
+L 249.989365 150.825343 
+L 249.545726 150.924735 
+L 249.102086 151.023945 
+L 248.658447 151.122974 
+L 248.214807 151.221822 
+L 247.771168 151.32049 
+L 247.327528 151.418978 
+L 246.883889 151.517287 
+L 246.440249 151.615418 
+L 245.99661 151.713371 
+L 245.55297 151.811147 
+L 245.109331 151.908747 
+L 244.665691 152.006172 
+L 244.222052 152.103421 
+L 243.778412 152.200496 
+L 243.334773 152.297397 
+L 242.891133 152.394124 
+L 242.447494 152.49068 
+L 242.003854 152.587063 
+L 241.560215 152.683275 
+L 241.116575 152.779316 
+L 240.672936 152.875187 
+L 240.229296 152.970888 
+L 239.785656 153.066421 
+L 239.342017 153.161785 
+L 238.898377 153.256981 
+L 238.454738 153.352011 
+L 238.011098 153.446873 
+L 237.567459 153.54157 
+L 237.123819 153.636101 
+L 236.68018 153.730468 
+L 236.23654 153.82467 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_145">
+    <path d="M 236.23654 153.82467 
+L 235.941473 153.922327 
+L 235.646406 154.019807 
+L 235.351339 154.117113 
+L 235.056271 154.214244 
+L 234.761204 154.3112 
+L 234.466137 154.407984 
+L 234.17107 154.504594 
+L 233.876003 154.601033 
+L 233.580935 154.6973 
+L 233.285868 154.793396 
+L 232.990801 154.889321 
+L 232.695734 154.985077 
+L 232.400667 155.080664 
+L 232.105599 155.176082 
+L 231.810532 155.271333 
+L 231.515465 155.366416 
+L 231.220398 155.461332 
+L 230.92533 155.556082 
+L 230.630263 155.650666 
+L 230.335196 155.745086 
+L 230.040129 155.839341 
+L 229.745062 155.933432 
+L 229.449994 156.02736 
+L 229.154927 156.121125 
+L 228.85986 156.214728 
+L 228.564793 156.308169 
+L 228.269726 156.401449 
+L 227.974658 156.494569 
+L 227.679591 156.587529 
+L 227.384524 156.680329 
+L 227.089457 156.77297 
+L 226.794389 156.865454 
+L 226.499322 156.957779 
+L 226.204255 157.049947 
+L 225.909188 157.141959 
+L 225.614121 157.233814 
+L 225.319053 157.325514 
+L 225.023986 157.417058 
+L 224.728919 157.508448 
+L 224.433852 157.599684 
+L 224.138785 157.690766 
+L 223.843717 157.781695 
+L 223.54865 157.872472 
+L 223.253583 157.963097 
+L 222.958516 158.05357 
+L 222.663449 158.143892 
+L 222.368381 158.234064 
+L 222.073314 158.324086 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_146">
+    <path d="M 222.073314 158.324086 
+L 221.661702 158.576515 
+L 221.25009 158.827772 
+L 220.838478 159.077869 
+L 220.426866 159.326814 
+L 220.015254 159.57462 
+L 219.603642 159.821296 
+L 219.19203 160.066853 
+L 218.780418 160.311301 
+L 218.368807 160.55465 
+L 217.957195 160.796909 
+L 217.545583 161.038089 
+L 217.133971 161.278198 
+L 216.722359 161.517247 
+L 216.310747 161.755245 
+L 215.899135 161.992201 
+L 215.487523 162.228123 
+L 215.075911 162.463022 
+L 214.664299 162.696906 
+L 214.252687 162.929783 
+L 213.841075 163.161662 
+L 213.429463 163.392552 
+L 213.017851 163.622461 
+L 212.606239 163.851398 
+L 212.194627 164.07937 
+L 211.783015 164.306386 
+L 211.371403 164.532453 
+L 210.959791 164.75758 
+L 210.54818 164.981775 
+L 210.136568 165.205044 
+L 209.724956 165.427397 
+L 209.313344 165.648839 
+L 208.901732 165.869379 
+L 208.49012 166.089024 
+L 208.078508 166.307781 
+L 207.666896 166.525658 
+L 207.255284 166.74266 
+L 206.843672 166.958796 
+L 206.43206 167.174073 
+L 206.020448 167.388496 
+L 205.608836 167.602073 
+L 205.197224 167.814811 
+L 204.785612 168.026716 
+L 204.374 168.237794 
+L 203.962388 168.448052 
+L 203.550776 168.657496 
+L 203.139164 168.866133 
+L 202.727553 169.073969 
+L 202.315941 169.281009 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_147">
+    <path d="M 202.315941 169.281009 
+L 202.265719 169.316971 
+L 202.215497 169.35291 
+L 202.165275 169.388824 
+L 202.115053 169.424715 
+L 202.064831 169.460582 
+L 202.014609 169.496425 
+L 201.964388 169.532245 
+L 201.914166 169.568041 
+L 201.863944 169.603813 
+L 201.813722 169.639561 
+L 201.7635 169.675286 
+L 201.713278 169.710988 
+L 201.663056 169.746665 
+L 201.612834 169.78232 
+L 201.562613 169.817951 
+L 201.512391 169.853558 
+L 201.462169 169.889142 
+L 201.411947 169.924702 
+L 201.361725 169.96024 
+L 201.311503 169.995754 
+L 201.261281 170.031244 
+L 201.21106 170.066712 
+L 201.160838 170.102156 
+L 201.110616 170.137577 
+L 201.060394 170.172974 
+L 201.010172 170.208349 
+L 200.95995 170.243701 
+L 200.909728 170.279029 
+L 200.859507 170.314334 
+L 200.809285 170.349617 
+L 200.759063 170.384876 
+L 200.708841 170.420113 
+L 200.658619 170.455326 
+L 200.608397 170.490517 
+L 200.558175 170.525685 
+L 200.507953 170.560829 
+L 200.457732 170.595952 
+L 200.40751 170.631051 
+L 200.357288 170.666127 
+L 200.307066 170.701181 
+L 200.256844 170.736212 
+L 200.206622 170.771221 
+L 200.1564 170.806207 
+L 200.106179 170.84117 
+L 200.055957 170.876111 
+L 200.005735 170.911029 
+L 199.955513 170.945925 
+L 199.905291 170.980798 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_148">
+    <path d="M 199.905291 170.980798 
+L 199.821705 171.071675 
+L 199.738118 171.1624 
+L 199.654532 171.252972 
+L 199.570946 171.343394 
+L 199.487359 171.433665 
+L 199.403773 171.523785 
+L 199.320187 171.613756 
+L 199.2366 171.703577 
+L 199.153014 171.79325 
+L 199.069428 171.882774 
+L 198.985841 171.97215 
+L 198.902255 172.061379 
+L 198.818669 172.150461 
+L 198.735082 172.239396 
+L 198.651496 172.328186 
+L 198.56791 172.41683 
+L 198.484323 172.50533 
+L 198.400737 172.593685 
+L 198.317151 172.681895 
+L 198.233564 172.769963 
+L 198.149978 172.857887 
+L 198.066392 172.945669 
+L 197.982805 173.033308 
+L 197.899219 173.120806 
+L 197.815633 173.208162 
+L 197.732046 173.295378 
+L 197.64846 173.382453 
+L 197.564874 173.469389 
+L 197.481287 173.556185 
+L 197.397701 173.642842 
+L 197.314115 173.729361 
+L 197.230528 173.815741 
+L 197.146942 173.901984 
+L 197.063356 173.98809 
+L 196.979769 174.074058 
+L 196.896183 174.159891 
+L 196.812597 174.245587 
+L 196.72901 174.331148 
+L 196.645424 174.416574 
+L 196.561838 174.501866 
+L 196.478251 174.587023 
+L 196.394665 174.672046 
+L 196.311079 174.756936 
+L 196.227492 174.841693 
+L 196.143906 174.926318 
+L 196.06032 175.01081 
+L 195.976733 175.095171 
+L 195.893147 175.179401 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_149">
+    <path d="M 195.893147 175.179401 
+L 195.712249 175.503111 
+L 195.531352 175.824897 
+L 195.350454 176.14478 
+L 195.169557 176.462784 
+L 194.988659 176.778931 
+L 194.807761 177.093241 
+L 194.626864 177.405736 
+L 194.445966 177.716437 
+L 194.265069 178.025365 
+L 194.084171 178.332539 
+L 193.903273 178.637979 
+L 193.722376 178.941706 
+L 193.541478 179.243737 
+L 193.360581 179.544092 
+L 193.179683 179.842789 
+L 192.998785 180.139847 
+L 192.817888 180.435282 
+L 192.63699 180.729114 
+L 192.456093 181.021359 
+L 192.275195 181.312035 
+L 192.094297 181.601158 
+L 191.9134 181.888744 
+L 191.732502 182.17481 
+L 191.551605 182.459372 
+L 191.370707 182.742445 
+L 191.189809 183.024045 
+L 191.008912 183.304188 
+L 190.828014 183.582888 
+L 190.647117 183.86016 
+L 190.466219 184.136019 
+L 190.285321 184.410479 
+L 190.104424 184.683554 
+L 189.923526 184.955258 
+L 189.742629 185.225605 
+L 189.561731 185.494607 
+L 189.380833 185.76228 
+L 189.199936 186.028635 
+L 189.019038 186.293685 
+L 188.838141 186.557444 
+L 188.657243 186.819923 
+L 188.476345 187.081136 
+L 188.295448 187.341094 
+L 188.11455 187.599809 
+L 187.933653 187.857293 
+L 187.752755 188.113558 
+L 187.571857 188.368615 
+L 187.39096 188.622475 
+L 187.210062 188.875151 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_150">
+    <path d="M 187.210062 188.875151 
+L 186.585813 190.911399 
+L 185.961564 192.873803 
+L 185.337315 194.76753 
+L 184.713066 196.597226 
+L 184.088817 198.367079 
+L 183.464568 200.080881 
+L 182.840319 201.742072 
+L 182.21607 203.353788 
+L 181.591821 204.918889 
+L 180.967571 206.439997 
+L 180.343322 207.919518 
+L 179.719073 209.359664 
+L 179.094824 210.762479 
+L 178.470575 212.129848 
+L 177.846326 213.463518 
+L 177.222077 214.76511 
+L 176.597828 216.036133 
+L 175.973579 217.277988 
+L 175.34933 218.491984 
+L 174.725081 219.679344 
+L 174.100832 220.841211 
+L 173.476582 221.978658 
+L 172.852333 223.09269 
+L 172.228084 224.184251 
+L 171.603835 225.25423 
+L 170.979586 226.303464 
+L 170.355337 227.332742 
+L 169.731088 228.342809 
+L 169.106839 229.334369 
+L 168.48259 230.308089 
+L 167.858341 231.264597 
+L 167.234092 232.204494 
+L 166.609843 233.128345 
+L 165.985594 234.036689 
+L 165.361344 234.930039 
+L 164.737095 235.808881 
+L 164.112846 236.67368 
+L 163.488597 237.524876 
+L 162.864348 238.362891 
+L 162.240099 239.188127 
+L 161.61585 240.000969 
+L 160.991601 240.801782 
+L 160.367352 241.590918 
+L 159.743103 242.368712 
+L 159.118854 243.135486 
+L 158.494605 243.891547 
+L 157.870355 244.637191 
+L 157.246106 245.372702 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_151">
+    <path d="M 157.246106 245.372702 
+L 155.955963 250.368983 
+L 154.665819 254.942735 
+L 153.375675 259.159885 
+L 152.085531 263.07204 
+L 150.795387 266.720357 
+L 149.505243 270.138183 
+L 148.2151 273.352922 
+L 146.924956 276.387359 
+L 145.634812 279.26065 
+L 144.344668 281.989051 
+L 143.054524 284.586476 
+L 141.76438 287.064926 
+L 140.474237 289.434824 
+L 139.184093 291.705281 
+L 137.893949 293.884308 
+L 136.603805 295.978984 
+L 135.313661 297.995597 
+L 134.023517 299.939756 
+L 132.733374 301.816489 
+L 131.44323 303.630316 
+L 130.153086 305.385317 
+L 128.862942 307.085188 
+L 127.572798 308.733288 
+L 126.282654 310.332678 
+L 124.992511 311.886153 
+L 123.702367 313.396278 
+L 122.412223 314.865405 
+L 121.122079 316.295703 
+L 119.831935 317.68917 
+L 118.541791 319.047657 
+L 117.251648 320.372876 
+L 115.961504 321.666419 
+L 114.67136 322.929763 
+L 113.381216 324.164287 
+L 112.091072 325.371277 
+L 110.800929 326.551934 
+L 109.510785 327.707383 
+L 108.220641 328.838677 
+L 106.930497 329.946806 
+L 105.640353 331.0327 
+L 104.350209 332.097233 
+L 103.060066 333.141229 
+L 101.769922 334.165467 
+L 100.479778 335.170679 
+L 99.189634 336.15756 
+L 97.89949 337.126767 
+L 96.609346 338.078921 
+L 95.319203 339.014613 
+" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
-   <!-- Compression speed vs ratio  (silesia — geomean over 12 files; line = level sweep) -->
-   <g transform="translate(24.797891 19.237969) scale(0.13 -0.13)">
+   <!-- Compression speed vs ratio  (silesia — geomean over 12 files) -->
+   <g transform="translate(96.243047 19.237969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-43" d="M 4288 256 
 Q 3956 84 3597 -3 
@@ -2680,37 +6043,6 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-3b" d="M 716 1209 
-L 1844 1209 
-L 1844 256 
-L 1069 -909 
-L 403 -909 
-L 716 256 
-L 716 1209 
-z
-M 716 3500 
-L 1844 3500 
-L 1844 2291 
-L 716 2291 
-L 716 3500 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-77" d="M 225 3500 
-L 1313 3500 
-L 1900 1088 
-L 2491 3500 
-L 3425 3500 
-L 4013 1113 
-L 4603 3500 
-L 5691 3500 
-L 4769 0 
-L 3547 0 
-L 2956 2406 
-L 2369 0 
-L 1147 0 
-L 225 3500 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-29" d="M 513 -844 
 Q 913 -100 1113 609 
 Q 1313 1319 1313 2009 
@@ -2785,27 +6117,7 @@ z
     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3296.630859 0)"/>
     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3330.908203 0)"/>
     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3398.730469 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-3b" transform="translate(3458.251953 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3498.242188 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3533.056641 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3567.333984 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3601.611328 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3672.802734 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3740.625 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(3775.439453 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3894.042969 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3928.320312 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3996.142578 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4061.328125 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(4129.150391 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(4163.427734 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(4198.242188 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(4257.763672 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4350.146484 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4417.96875 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(4485.791016 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(4557.373047 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3458.251953 0)"/>
    </g>
   </g>
   <g id="text_26">
@@ -3116,7 +6428,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pbf47cf6877">
+  <clipPath id="p66bcfd2819">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/plot.py
+++ b/bench/plot.py
@@ -132,12 +132,44 @@ def _level_points(results, corpus, key, speed_metric):
     return pts
 
 
+def _mix_curve(x0, y0, x1, y1, n=48):
+    """Operating points reachable by compressing a byte-fraction `f` of the input
+    at the higher-effort level and `1-f` at the lower one — the *achievable*
+    frontier between two adjacent levels, and the honest connector between them.
+
+    Ratio is additive in bytes, so it is linear in `f`; wall-clock time is
+    additive, so **1/throughput** is linear in `f` (throughput itself is not).
+    The frontier is therefore a straight line only in (ratio, time-per-byte)
+    space — NOT a straight segment on the (ratio, MB/s) axis, and emphatically
+    not on the log-MB/s axis, where a straight segment sags *above* the real
+    frontier and overstates the speed reachable at an intermediate ratio. A new
+    operating point is genuinely outside the frontier only if it sits above this
+    curve (faster at equal ratio), never merely above the straight segment.
+
+    Exact for a single workload; the dashboard points are per-file geomeans, so
+    between two geomean points this is the mixing curve of the aggregate (a close
+    proxy for, not literally, the corpus-geomean achievable set). See
+    bench/README.md ("Reading the Pareto")."""
+    if not (y0 > 0 and y1 > 0):          # 1/speed undefined — fall back to a segment
+        return [x0, x1], [y0, y1]
+    xs, ys = [], []
+    for i in range(n + 1):
+        f = i / n
+        xs.append((1.0 - f) * x0 + f * x1)
+        ys.append(1.0 / ((1.0 - f) / y0 + f / y1))
+    return xs, ys
+
+
 def pareto_scatter(results, meta, corpus, speed_metric, speed_label, title, outfile):
     """Headline view: speed vs ratio. x = compression ratio (smaller = better,
-    left), y = speed (MB/s, log). Each compressor is one line tracing its levels,
-    so the whole speed/ratio tradeoff and the Pareto frontier read at a glance —
-    top-left is ideal, a dominated codec sits to the lower-right. Collapses the
-    per-level chart set into a single figure."""
+    left), y = speed (MB/s, log). Each compressor is markers at its measured
+    levels joined by the *mixing frontier* — the operating points reachable by
+    blending two adjacent levels (`_mix_curve`), which is the physically
+    achievable connector, unlike a straight segment on the log axis. So the whole
+    speed/ratio tradeoff and the achievable frontier read at a glance — top-left
+    is ideal; a point is outside a codec's frontier only if it sits above that
+    codec's mixing curve, not merely above the straight level-to-level segment.
+    Collapses the per-level chart set into a single figure."""
     pats = corpus_patterns(results, corpus)
     if not pats:
         return
@@ -147,9 +179,19 @@ def pareto_scatter(results, meta, corpus, speed_metric, speed_label, title, outf
         pts = _level_points(results, corpus, key, speed_metric)
         if not pts:
             continue
+        style = series_style(key, colour)
         xs = [p[1] for p in pts]
         ys = [p[2] for p in pts]
-        ax.plot(xs, ys, marker=marker, label=label, **series_style(key, colour))
+        # Markers at the real (measured) level points carry the legend entry.
+        ax.plot(xs, ys, linestyle="none", marker=marker, label=label,
+                **{k: v for k, v in style.items() if k != "linewidth"})
+        # Connectors are the achievable mixing frontier between consecutive
+        # levels, not straight segments (see `_mix_curve`). A single-point series
+        # (e.g. the frozen zopfli ceiling) has no connector — just its marker.
+        for a in range(len(pts) - 1):
+            cx, cy = _mix_curve(xs[a], ys[a], xs[a + 1], ys[a + 1])
+            ax.plot(cx, cy, color=colour, linewidth=style["linewidth"],
+                    alpha=style["alpha"], zorder=style["zorder"])
         # Mark the level sweep direction on the subject's curve only (avoid clutter).
         if key == "native" and len(pts) > 1:
             for idx in (0, -1):
@@ -167,7 +209,7 @@ def pareto_scatter(results, meta, corpus, speed_metric, speed_label, title, outf
     ax.legend(fontsize=8, ncol=2, loc="best")
     ax.text(0.015, 0.985, "↖ fast & small = best", transform=ax.transAxes,
             fontsize=10, va="top", color="#2a8a3a", fontweight="bold")
-    fig.suptitle(f"{title}  ({corpus} — geomean over {len(pats)} files; line = level sweep)",
+    fig.suptitle(f"{title}  ({corpus} — geomean over {len(pats)} files)",
                  fontsize=13, fontweight="bold")
     fig.text(0.5, 0.005, _provenance(meta), ha="center", fontsize=7, color="#555")
     fig.tight_layout(rect=(0, 0.03, 1, 0.97))


### PR DESCRIPTION
This PR changes the benchmark dashboard's compress Pareto to connect a codec's adjacent levels with the *achievable mixing frontier* instead of straight segments, and updates the tooling, skills, and docs so "is this a real Pareto gain?" is judged correctly.

Between two adjacent levels the reachable operating points are the mixing curve: compress a byte-fraction `f` of the input at the higher level and `1-f` at the lower. Ratio is additive in bytes, so it is linear in `f`; wall-clock time is additive, so `1/throughput` is linear in `f` — throughput itself is a rate and is not. The frontier is therefore straight only in *(ratio, seconds-per-MiB)*; on the log-MB/s axis we plot, a straight level-to-level segment sags *above* the true curve and overstates the speed reachable at an intermediate ratio. Judging a new operating point "inside our frontier" against that straight segment rejects genuine wins — a point that is faster at equal ratio than any blend of the two bracketing levels is a real gain even though it sits below the straight line on the log plot. This is the mistake we made assessing the #2638 L9-fast probe.

`bench/plot.py` draws the mixing curve (`_mix_curve`) between consecutive levels and the committed `silesia`/`canterbury` compress-Pareto SVGs are regenerated; a single-point series (the frozen zopfli ceiling) keeps just its marker, no connector, and non-positive throughputs fall back to a plain segment. The `perf-pr-graphs` skill and its before/after plotter get the same connector plus the numerical seconds-per-MiB "outside the frontier" test, and a note that this within-native test — not catching the libdeflate/zopfli C+SIMD ceiling — is the bar for incremental progress (cross-codec standing still matters as context and for a new tier's external justification). `bench/README.md` and the top-level README caption document the reading.

🤖 Prepared with Claude Code