### PR TITLE
feat: ship the L9-fast approximate-optimal parser at level 9; exact crown moves to level 10 (#2638)

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -50,9 +50,12 @@ optional nicety.
 
 The graphs show **native before vs after** on the real corpora (Canterbury +
 Silesia), overlaid on the existing other-language curves (zlib, miniz_oxide,
-libdeflate, Go, JS, Zig, OCaml) for context. Native sweeps levels 1–9;
-`libdeflate` is swept 1–12 (its full range, the others cap at 9), so its
-curve carries the extra dense points 10–12. The before/after **overlay** PNGs
+libdeflate, Go, JS, Zig, OCaml) for context. Native sweeps levels **1–10** —
+since #2638 level 9 is the L9-fast tier and **level 10 is the exact-DP crown**;
+always include level 10 so the crown stays on the Pareto (drop it and the graph
+looks like an L9 ratio regression with no crown shown). `libdeflate` is swept
+1–12 (its full range; the zlib/miniz FFI cap at 9), so its curve carries the
+extra dense points 10–12. The before/after **overlay** PNGs
 (`$W/perf_before_after_*`) are a report artifact — NOT committed; they live
 only in the PR comment. The **dashboard** (`bench/results/latest.json` and the
 routine `bench/graphs/*.svg`), by contrast, **is** refreshed and committed inside
@@ -168,12 +171,14 @@ artifacts move into `$W`.
    lake env .lake/build/bin/bench-report --native-only $W/perf_after.json
    ```
    `--native-only` records native `ratio`, `compress_mbps` and
-   `decompress_mbps` and reuses nothing else. For a **decode-only** PR, append a
-   level list that skips the slow L9 optimal-parse compress, e.g.
+   `decompress_mbps` and reuses nothing else. Its default native sweep is **1–10**
+   (level 10 = the exact-DP crown). For a **decode-only** PR, append a level list
+   that skips the slow optimal-parse compress at 9 and 10, e.g.
    `… --native-only $W/perf_after.json 1,2,3,4,5,6,7,8` (decode is measured at
-   every listed level; native L9 *compress* on 203 MB is minutes of pure waste
-   when you only care about decode). For a **compress** PR, keep all 9 levels —
-   L9 is usually the point.
+   every listed level; native L9/L10 *compress* on 203 MB is minutes of pure
+   waste when you only care about decode). For a **compress** PR, keep all 10
+   native levels — **always include level 10, the crown** (L9/L10 are usually the
+   point).
 
 4. **BEFORE is the base branch's committed `bench/results/latest.json` — do NOT
    rebuild it.** Master already carries up-to-date native numbers:
@@ -314,10 +319,11 @@ artifacts move into `$W`.
    git commit -m "bench: refresh dashboard for <this PR's change>"
    ```
    `bench/results/latest.json` is the committed source of truth, so its native
-   rows must be **consistent across all 9 levels**. If step 3 measured only a
-   level subset (e.g. `1,2,3,4,5,6,7,8` for a decode PR), the spliced dashboard
-   would keep stale rows on the skipped levels — so for the dashboard refresh,
-   either measure all 9 levels, or run the full native-only path that does the
+   rows must be **consistent across all 10 native levels (1–10, crown included)**.
+   If step 3 measured only a level subset (e.g. `1,2,3,4,5,6,7,8` for a decode
+   PR), the spliced dashboard would keep stale rows on the skipped levels — so for
+   the dashboard refresh, either measure all 10 native levels, or run the full
+   native-only path that does the
    measure+merge+plot in one shot and records every level:
    ```
    nix-shell --run "taskset -c <free-core> bash bench/run.sh --native-only"

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1107,9 +1107,11 @@ theorem deflateDynamicBlocksSharedAt_def (data : ByteArray)
     peak at 16 MiB input, 1.73 GB at 52 MiB — ≈27 B of transient state per
     input byte marginal (global choice arrays + per-region cache + token
     stream) over the process baseline. 64 MiB covers every Silesia file at a
-    projected ~2.1 GB peak, acceptable for the max-effort tier; truly huge
-    inputs still fall back to the plain level-9 path. A pure dispatch knob —
-    `pickSmaller` composes either way. -/
+    projected ~2.1 GB peak, acceptable for the max-effort tiers (levels 9–10);
+    truly huge inputs still fall back to the split path. A pure dispatch knob —
+    `pickSmaller` composes either way. (The L9-fast candidate at level 9 has a
+    lower peak — shallower cache, single round — so the gate is conservative
+    there, but a single gate for both optimal tiers keeps the dispatch simple.) -/
 def optimalMaxSize : Nat := 67108864
 
 /-- Cross-block (shared-window) block-split dynamic compression over the
@@ -1123,6 +1125,20 @@ def deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) : ByteArray 
       (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
   else
     (emitSharedBlocks data (lz77OptimalIter data) tokChunk 0 BitWriter.empty).flush
+
+/-- Cross-block split over the **L9-fast** approximate-optimal token stream
+    (`lz77OptimalFastIter`, #2638): identical to `deflateDynamicBlocksOptimal`
+    but the cheaper single-round, bounds-free, shallow-cache parser. The tokens
+    satisfy the same encoder contracts, so the roundtrip proof is the exact
+    twin (`decode_deflateDynamicBlocksOptimalFast` etc.). Deployed at level 9;
+    the exact crown moves to level 10. -/
+def deflateDynamicBlocksOptimalFast (data : ByteArray) (tokChunk : Nat) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitSharedBlocks data (lz77OptimalFastIter data) tokChunk 0 BitWriter.empty).flush
 
 /-! ## Incompressible pre-scan
 
@@ -1259,10 +1275,20 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
   -- Every region looked incompressible.
   return true
 
-/-- Unified raw DEFLATE compression dispatch. Level 0 = stored; levels 1–7 run the
-    single-block cost-model dispatch (`deflateRawBase`). At the max-compression
-    tiers (level ≥ 8) two block-split streams are also tried, and the smallest of
-    all candidates is emitted:
+/-- Unified raw DEFLATE compression dispatch. The native level range is **0–10**
+    (wider than zlib's 0–9). Since #2638 the top of the ladder is:
+
+      * **level 9** — the **L9-fast** approximate-optimal parse (near-crown ratio,
+        ~2× faster); this is a change from the old level-9 = exact crown;
+      * **level ≥ 10** — the exact backward-DP **crown** (the max-ratio ceiling,
+        the former level-9 output); 11+ alias level 10.
+
+    So callers pinning `level = 9` for absolute best ratio should now pass 10.
+    (The zlib/FFI bindings are a separate 0–9 path and are unchanged.)
+
+    Level 0 = stored; levels 1–7 run the single-block cost-model dispatch
+    (`deflateRawBase`). At the max-compression tiers (level ≥ 8) two block-split
+    streams are also tried, and the smallest of all candidates is emitted:
       * self-contained split — per-chunk Huffman trees, fresh window per chunk
         (wins on locally-varying statistics, e.g. structured binary);
       * cross-block (shared-window) split — one whole-file match pass, token stream
@@ -1275,11 +1301,17 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
         the winner's per-block trees from the sizing pass
         (`deflateDynamicBlocksSharedSized`, = the reference candidate by
         `deflateDynamicBlocksSharedSized_eq`).
-    At level 9 (and within the `optimalMaxSize` memory gate) the dispatch switches
-    to the **near-optimal** cost-model DP parse (`deflateDynamicBlocksOptimal`),
-    which chooses the globally cheapest token sequence under an estimated bit cost
-    instead of the locally longest match, grouped into blocks on the fixed
-    `sharedTokChunk` cadence. It is emitted as `pickSmaller(base, optimal)`. On the
+    At levels 9 and 10 (and within the `optimalMaxSize` memory gate) the dispatch
+    switches to a cost-model DP parse (grouped into blocks on the fixed
+    `sharedTokChunk` cadence, emitted as `pickSmaller(base, optimal)`), choosing
+    the globally cheapest token sequence under an estimated bit cost instead of
+    the locally longest match. **Level 10** runs the exact backward-DP crown
+    (`deflateDynamicBlocksOptimal`) — the max-ratio ceiling. **Level 9** runs the
+    cheaper **L9-fast** approximate-optimal parse (`deflateDynamicBlocksOptimalFast`,
+    #2638): single round, no length-code boundary scan, shallower cache — near the
+    crown's ratio at ~2× its speed, measured ~20% outside the L8↔L9 mixing frontier
+    on Silesia (a genuine new Pareto point; L10 ≤ L9 < L8 in output size, L9 > L8 in
+    speed). On the
     Canterbury (11) and Silesia (12) corpora this fixed-cadence optimal candidate is
     measured strictly smaller than base, the self-contained split, *and* the
     arbitrated shared-window split on every file — including the binary
@@ -1337,24 +1369,30 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     -- emit, stage C); the shared-split candidate still unpacks once (stage D
     -- moves it onto packed words).
     let ptokens := lzMatchP data level
-    if 9 ≤ level ∧ data.size ≤ optimalMaxSize then
+    if level == 9 ∧ data.size ≤ optimalMaxSize then
+      -- Level 9 (#2638): the cheaper **L9-fast** approximate-optimal parse — near
+      -- the crown's ratio at ~2× its speed, measured ~20% outside the L8↔L9
+      -- mixing frontier on Silesia (a genuine new Pareto point). As with the
+      -- exact candidate below, the split candidates are dropped on measured
+      -- evidence; keep `base` (reuses `ptokens`, ~free) as the safety floor and
+      -- emit `pickSmaller(base, fast-optimal)`.
+      pickSmaller (deflateRawBaseP data ptokens)
+        (deflateDynamicBlocksOptimalFast data sharedTokChunk)
+    else if 10 ≤ level ∧ data.size ≤ optimalMaxSize then
+      -- Level ≥ 10: the exact backward-DP crown (the former level-9 behaviour,
+      -- #2640) — the max-ratio ceiling, kept reachable per the #2638 directive.
       -- The fixed-cadence optimal candidate measured strictly smallest on every
-      -- Canterbury and Silesia file (#2640), so the self-contained and
-      -- shared-window split candidates — a full independent match/split pass each,
-      -- for output `pickSmaller` always discarded — are dropped here on that
-      -- measured evidence (see the dispatch docstring; this is a corpus-gated
-      -- speed/ratio tradeoff, not a proven dominance invariant). Keep `base` (it
-      -- reuses the already-computed `ptokens`, ~free) as a safety floor and emit
-      -- `pickSmaller(base, optimal)`: never worse than the lazy single-block
-      -- baseline on any input.
+      -- Canterbury and Silesia file, so the split candidates are dropped here;
+      -- `pickSmaller(base, optimal)` is never worse than the lazy baseline.
       pickSmaller (deflateRawBaseP data ptokens)
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
-      -- Level 8: base vs cross-block shared-window split. The self-contained split
-      -- is not a candidate here (nor at L9 since #2640): it pays a full per-chunk
-      -- match pass and never sized smallest on the measured corpora. Level 7 no
-      -- longer enters here — it is the top single-block point (see the dispatch
-      -- docstring), so the split tier starts at level 8.
+      -- Level 8 (and level 9/10 above the memory gate): base vs cross-block
+      -- shared-window split. The self-contained split is not a candidate here
+      -- (nor at L9/L10 since #2640): it pays a full per-chunk match pass and
+      -- never sized smallest on the measured corpora. Level 7 no longer enters
+      -- here — it is the top single-block point (see the dispatch docstring), so
+      -- the split tier starts at level 8.
       pickSmaller (deflateRawBaseP data ptokens)
         (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))
   else deflateRawBase data level

--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -787,4 +787,143 @@ def lz77OptimalIter (data : ByteArray) : Array LZ77Token :=
   let (chLen, chDist) := computeChoices data
   optimalEmitIter data chLen chDist 0 #[]
 
+/-! ## L9-fast parser (#2638): a cheaper approximate-optimal parse
+
+The exact backward DP above stays the max-ratio crown (level 10). This is the
+*cheaper* tier deployed at level 9: three cost cuts, each a per-position saving,
+measured to land ~20% outside the L8↔L9 mixing frontier at near-crown ratio
+(Silesia, `lake exe l9-fast` sweep):
+
+* **single round** — no round-2 refit (one `fillRegion` pass, no region-token
+  collection / histogram / Huffman fit);
+* **no length-code boundary scan** — `scanCandsFast` prices each candidate only
+  at its full cached length, dropping the inner `scanBounds` truncation scan
+  (the largest single DP cost, #2622; the sweep confirmed keeping it costs more
+  speed than it buys ratio at every depth);
+* **shallower candidate cache** — `fastChainDepth < optChainDepth`, so the
+  `buildCache` chain walk (the dominant remaining cost) does ~4× less work.
+
+The choice-array format is byte-identical to the exact DP's, so the same
+re-verifying emitter (`optimalEmit`/`optimalEmitIter`) and the same
+arbitrary-choice-array validity proofs (`LZ77OptimalCorrect`) apply verbatim.
+Everything here is heuristic — opaque to correctness. -/
+
+/-- Candidate-cache chain-walk depth for the L9-fast tier. Lower than
+    `optChainDepth = 256`: the sweep's outside-the-frontier gain peaks at 64
+    (48 and 96 within a point), trading a little ratio for the ~4× cheaper cache
+    build. Pure ratio/speed knob. -/
+def fastChainDepth : Nat := 64
+
+/-- `scanCands` without the `scanBounds` length-code boundary scan: price each
+    candidate slot only at its full cached length. Slots hold strictly
+    increasing lengths; a zero length terminates the block. Cache reads stay
+    panic-checked (`[..]!`) exactly like the value reads in `scanBounds` — the
+    cache is heuristic and opaque to correctness. -/
+def scanCandsFast (cacheLens cacheDists lenCost distCost cost : Array Nat)
+    (slotBase i slots k : Nat) (bestC bestL bestD : Nat) : Nat × Nat × Nat :=
+  if _h : k < slots then
+    let len := cacheLens[slotBase + k]!
+    if len = 0 then (bestC, bestL, bestD)
+    else
+      let dist := cacheDists[slotBase + k]!
+      let cFull := lenCost[len]! + distCost[dist]! + cost[i + len]!
+      let (bestC, bestL, bestD) :=
+        if cFull < bestC then (cFull, len, dist) else (bestC, bestL, bestD)
+      scanCandsFast cacheLens cacheDists lenCost distCost cost slotBase i slots
+        (k + 1) bestC bestL bestD
+  else (bestC, bestL, bestD)
+termination_by slots - k
+decreasing_by omega
+
+/-- Backward DP fill using the bounds-free `scanCandsFast`. Same structure as
+    `fillRegion` (literal vs best cached candidate, choice recorded at the
+    absolute position), minus the cache-size hypotheses (the cache reads are
+    panic-checked in `scanCandsFast`). Heuristic only. -/
+def fillRegionFast (data : ByteArray) (base r slots : Nat)
+    (cacheLens cacheDists litCost lenCost distCost : Array Nat)
+    (i : Nat) (cost chLen chDist : Array Nat)
+    (hr : base + r ≤ data.size) (hlit : 256 ≤ litCost.size)
+    (hcost : r + 259 ≤ cost.size) (hir : i ≤ r) : Array Nat × Array Nat :=
+  if h0 : i = 0 then (chLen, chDist)
+  else
+    let idx := i - 1
+    let pos := base + idx
+    let byte := data[pos]'(by omega)
+    let lit := litCost[byte.toNat]'(by have := UInt8.toNat_lt byte; omega) + cost[idx + 1]'(by omega)
+    let (bc, bl, bd) := scanCandsFast cacheLens cacheDists lenCost distCost cost
+      (slots * idx) idx slots 0 lit 1 0
+    let chLen := chLen.set! pos bl
+    let chDist := chDist.set! pos bd
+    fillRegionFast data base r slots cacheLens cacheDists litCost lenCost distCost
+      idx (cost.set! idx bc) chLen chDist hr hlit
+      (by simp only [Array.set!_eq_setIfInBounds, Array.size_setIfInBounds]; exact hcost) (by omega)
+termination_by i
+decreasing_by omega
+
+/-- One region of the L9-fast parse: build the candidate cache (at `depth`) and
+    run a single static-cost backward DP over it. No round-2 refit. Returns the
+    threaded chain state and choice arrays. -/
+def fillRegionFastRound (data : ByteArray) (depth slots base r : Nat)
+    (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat)
+    (chLen chDist : Array Nat)
+    (hr : base + r ≤ data.size) (hslit : 256 ≤ slit.size) :
+    Array Nat × Array Nat × Array Nat × Array Nat :=
+  let cache := buildCache data hashTable prev depth slots base r 0
+    (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
+  let cacheLens := cache.1
+  let cacheDists := cache.2.1
+  let hashTable := cache.2.2.1
+  let prev := cache.2.2.2
+  let cost := seedTailCosts (Array.replicate (r + 259) 0) r (avgLitBits slit) 0
+  have hcost : r + 259 ≤ cost.size := by
+    show r + 259 ≤ (seedTailCosts (Array.replicate (r + 259) 0) r (avgLitBits slit) 0).size
+    rw [seedTailCosts_size, Array.size_replicate]; omega
+  let res := fillRegionFast data base r slots cacheLens cacheDists
+    slit slen sdist r cost chLen chDist hr hslit hcost (Nat.le_refl r)
+  (hashTable, prev, res.1, res.2)
+
+/-- Region driver for `computeChoicesFast` (fast twin of `computeChoicesLoop`).
+    No `chLen`/`chDist` size hypotheses are threaded: the single-round fill
+    never reads them back (no region-token collection), so only their `set!`s
+    matter. Fuel = `data.size` bounds the region count as in the exact loop. -/
+private def computeChoicesFastLoop (data : ByteArray) (depth slots regionSize : Nat)
+    (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat) (base : Nat)
+    (chLen chDist : Array Nat) (hslit : 256 ≤ slit.size) (fuel : Nat) :
+    Array Nat × Array Nat :=
+  match fuel with
+  | 0 => (chLen, chDist)
+  | fuel + 1 =>
+    if hb : base < data.size ∧ 0 < regionSize then
+      let r := min regionSize (data.size - base)
+      have hr : base + r ≤ data.size := by omega
+      let result := fillRegionFastRound data depth slots base r
+        slit slen sdist hashTable prev chLen chDist hr hslit
+      computeChoicesFastLoop data depth slots regionSize slit slen sdist result.1 result.2.1
+        (base + r) result.2.2.1 result.2.2.2 hslit fuel
+    else (chLen, chDist)
+
+/-- L9-fast choice arrays: like `computeChoices` but the cheaper single-round,
+    bounds-free, shallow-cache DP. Defaults `(1, 0)` = literal everywhere.
+    Heuristic only — consumed by the re-verifying emitter. -/
+def computeChoicesFast (data : ByteArray) : Array Nat × Array Nat :=
+  let st := staticCostTables
+  computeChoicesFastLoop data fastChainDepth optCacheSlots optRegionSize st.1 st.2.1 st.2.2
+    (Array.replicate 65536 data.size) (Array.replicate (min chainWinSize data.size) data.size)
+    0 (Array.replicate data.size 1) (Array.replicate data.size 0)
+    (by have h : st.1.size = 256 := staticCostTables_fst_size; omega)
+    data.size
+
+/-- L9-fast parse (list-backed reference version, the proofs' subject); same
+    re-verifying emission as `lz77Optimal`. `lz77OptimalFastIter` is the runtime
+    entry point. -/
+def lz77OptimalFast (data : ByteArray) : Array LZ77Token :=
+  let (chLen, chDist) := computeChoicesFast data
+  (optimalEmit data chLen chDist 0).toArray
+
+/-- L9-fast runtime entry point: cheaper approximate-optimal parse, then the
+    same re-verifying tail-recursive emission as `lz77OptimalIter`. -/
+def lz77OptimalFastIter (data : ByteArray) : Array LZ77Token :=
+  let (chLen, chDist) := computeChoicesFast data
+  optimalEmitIter data chLen chDist 0 #[]
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1393,6 +1393,169 @@ theorem deflateDynamicBlocksOptimal_pad (data : ByteArray) (tokChunk : Nat) :
         data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
     exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
+/-! ## Cross-block split over the L9-fast parse (`deflateDynamicBlocksOptimalFast`, #2638)
+
+Byte-for-byte twin of the `deflateDynamicBlocksOptimal` quadruple above with the
+exact parser's contracts (`lz77OptimalIter_*`) replaced by the L9-fast parser's
+(`lz77OptimalFastIter_*`); the shared-window fold is already generic over the
+token array, so the proofs are identical modulo that substitution. -/
+
+private theorem deflateDynamicBlocksOptimalFast_facts (data : ByteArray)
+    (hpos : 0 < data.size) :
+    (∀ t ∈ (lz77OptimalFastIter data).toList,
+        match t with
+        | .literal _ => True
+        | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) ∧
+      0 < (lz77OptimalFastIter data).size ∧
+      Deflate.Spec.resolveLZ77
+        (((lz77OptimalFastIter data).toList.map
+          LZ77Token.toLZ77Symbol).drop 0) [] = some data.data.toList := by
+  have henc := lz77OptimalFastIter_encodable data
+  have hwhole := lz77OptimalFastIter_resolves data
+  have hMfree := mem_map_toLZ77Symbol_ne_endOfBlock
+    (lz77OptimalFastIter data).toList
+  have hM : Deflate.Spec.resolveLZ77
+      ((lz77OptimalFastIter data).toList.map
+        LZ77Token.toLZ77Symbol) [] = some data.data.toList := by
+    simp only [tokensToSymbols] at hwhole
+    rwa [Deflate.Spec.resolveLZ77_eobFree_eob _ [] hMfree] at hwhole
+  refine ⟨henc, ?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos (lz77OptimalFastIter data).size with h0 | h0
+    · exfalso
+      have hnil : (lz77OptimalFastIter data).toList = [] :=
+        List.eq_nil_of_length_eq_zero (by rw [Array.length_toList]; omega)
+      rw [hnil, List.map_nil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hM
+      have hl := congrArg List.length hM
+      simp only [List.length_nil, Array.length_toList, ByteArray.size_data] at hl
+      omega
+    · exact h0
+  · rw [List.drop_zero]; exact hM
+
+/-- L9-fast cross-block roundtrip: decoding the block stream over the L9-fast
+    parse reproduces the input. -/
+theorem decode_deflateDynamicBlocksOptimalFast (data : ByteArray) (tokChunk : Nat) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalFast data tokChunk)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksOptimalFast
+  split
+  · rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalFast_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    exact hdec (List.replicate ((8 - B.length % 8) % 8) false)
+
+/-- L9-fast cross-block roundtrip: inflating `deflateDynamicBlocksOptimalFast`
+    recovers the input, for any `maxOutputSize` large enough to hold it. -/
+theorem inflate_deflateDynamicBlocksOptimalFast (data : ByteArray) (tokChunk : Nat)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksOptimalFast data tokChunk) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksOptimalFast data tokChunk) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksOptimalFast data tokChunk)
+
+/-- The `decode.goR` of `deflateDynamicBlocksOptimalFast` returns the input and
+    short (< 8-bit) trailing padding. -/
+theorem deflateDynamicBlocksOptimalFast_goR_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalFast data tokChunk)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksOptimalFast
+  split
+  · rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalFast_facts data hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decodeR data (lz77OptimalFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, hdec _, ?_⟩
+    simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksOptimalFast` decomposes into content bits
+    plus short (< 8-bit) padding. -/
+theorem deflateDynamicBlocksOptimalFast_pad (data : ByteArray) (tokChunk : Nat) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksOptimalFast data tokChunk) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksOptimalFast
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksOptimalFast_facts data hpos
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitSharedBlocks_decode data (lz77OptimalFastIter data)
+        tokChunk (by omega) henc
+        (lz77OptimalFastIter data).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+
 /-! ## Sized-tree emitter equality (Wave 5, #2552)
 
 `deflateDynamicBlocksSharedSized` reuses the per-block Huffman trees the

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -123,12 +123,18 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     · exact inflate_deflateStoredPure data _ (by omega)
     · split
       · split
-        · exact inflate_pickSmaller _ _ data maxOutputSize
+        · -- level 9: L9-fast (#2638)
+          exact inflate_pickSmaller _ _ data maxOutputSize
             (inflate_deflateRawBase data level _ hsize)
-            (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
-        · exact inflate_pickSmaller _ _ data maxOutputSize
-            (inflate_deflateRawBase data level _ hsize)
-            (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize)
+            (inflate_deflateDynamicBlocksOptimalFast data sharedTokChunk _ hsize)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            exact inflate_pickSmaller _ _ data maxOutputSize
+              (inflate_deflateRawBase data level _ hsize)
+              (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
+          · exact inflate_pickSmaller _ _ data maxOutputSize
+              (inflate_deflateRawBase data level _ hsize)
+              (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize)
       · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -215,16 +221,24 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · split
       · split
-        · exact pickSmaller_bytesToBits
+        · -- level 9: L9-fast (#2638)
+          exact pickSmaller_bytesToBits
             (P := fun bits => ∃ (contentBits padding : List Bool),
               bits = contentBits ++ padding ∧ padding.length < 8)
             _ _ (deflateRawBase_pad data level)
-            (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
-        · exact pickSmaller_bytesToBits
-            (P := fun bits => ∃ (contentBits padding : List Bool),
-              bits = contentBits ++ padding ∧ padding.length < 8)
-            _ _ (deflateRawBase_pad data level)
-            (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level)
+            (deflateDynamicBlocksOptimalFast_pad data sharedTokChunk)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ (contentBits padding : List Bool),
+                bits = contentBits ++ padding ∧ padding.length < 8)
+              _ _ (deflateRawBase_pad data level)
+              (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
+          · exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ (contentBits padding : List Bool),
+                bits = contentBits ++ padding ∧ padding.length < 8)
+              _ _ (deflateRawBase_pad data level)
+              (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level)
       · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -383,18 +397,27 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · split
       · split
-        · exact pickSmaller_bytesToBits
+        · -- level 9: L9-fast (#2638)
+          exact pickSmaller_bytesToBits
             (P := fun bits => ∃ remaining,
               Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
                 remaining.length < 8)
             _ _ (deflateRawBase_goR_pad data level)
-            (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
-        · exact pickSmaller_bytesToBits
-            (P := fun bits => ∃ remaining,
-              Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                remaining.length < 8)
-            _ _ (deflateRawBase_goR_pad data level)
-            (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level)
+            (deflateDynamicBlocksOptimalFast_goR_pad data sharedTokChunk)
+        · split
+          · -- level ≥ 10: exact-DP crown
+            exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ remaining,
+                Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                  remaining.length < 8)
+              _ _ (deflateRawBase_goR_pad data level)
+              (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
+          · exact pickSmaller_bytesToBits
+              (P := fun bits => ∃ remaining,
+                Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                  remaining.length < 8)
+              _ _ (deflateRawBase_goR_pad data level)
+              (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level)
       · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77OptimalCorrect.lean
+++ b/Zip/Spec/LZ77OptimalCorrect.lean
@@ -164,4 +164,71 @@ theorem lz77OptimalIter_empty (data : ByteArray) (hzero : data.size = 0) :
     lz77OptimalIter data = #[] := by
   rw [lz77OptimalIter_eq_lz77Optimal]; exact lz77Optimal_empty data hzero
 
+/-! ## L9-fast parser contracts (#2638)
+
+`lz77OptimalFast` shares the *arbitrary*-choice-array emitter `optimalEmit` with
+`lz77Optimal`; only the (heuristic) choice arrays differ (`computeChoicesFast`).
+So every contract transfers verbatim — the proofs are byte-for-byte the exact
+ones with `computeChoicesFast` substituted, exactly as the file's opening note
+promises ("immune to any future tuning of the parser"). -/
+
+theorem lz77OptimalFastIter_eq_lz77OptimalFast (data : ByteArray) :
+    lz77OptimalFastIter data = lz77OptimalFast data := by
+  unfold lz77OptimalFastIter lz77OptimalFast
+  obtain ⟨chLen, chDist⟩ := computeChoicesFast data
+  dsimp only
+  rw [optimalEmitIter_eq_emit]
+  simp only [List.append_toArray, List.nil_append]
+
+theorem lz77OptimalFast_valid (data : ByteArray) :
+    ValidDecomp data 0 (lz77OptimalFast data).toList := by
+  unfold lz77OptimalFast
+  obtain ⟨chLen, chDist⟩ := computeChoicesFast data
+  dsimp only
+  exact optimalEmit_valid data chLen chDist 0
+
+theorem lz77OptimalFast_resolves (data : ByteArray) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77OptimalFast data)) [] =
+      some data.data.toList :=
+  validDecomp_resolves data _ (lz77OptimalFast_valid data)
+
+theorem lz77OptimalFast_encodable (data : ByteArray) :
+    ∀ t ∈ (lz77OptimalFast data).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  unfold lz77OptimalFast
+  obtain ⟨chLen, chDist⟩ := computeChoicesFast data
+  intro t ht
+  dsimp only at ht
+  exact optimalEmit_encodable data chLen chDist 0 t ht
+
+theorem lz77OptimalFast_empty (data : ByteArray) (hzero : data.size = 0) :
+    lz77OptimalFast data = #[] := by
+  unfold lz77OptimalFast
+  obtain ⟨chLen, chDist⟩ := computeChoicesFast data
+  dsimp only
+  unfold optimalEmit
+  simp only [show ¬(0 < data.size) from by omega, ↓reduceDIte, List.toArray]
+
+theorem lz77OptimalFastIter_valid (data : ByteArray) :
+    ValidDecomp data 0 (lz77OptimalFastIter data).toList := by
+  rw [lz77OptimalFastIter_eq_lz77OptimalFast]; exact lz77OptimalFast_valid data
+
+theorem lz77OptimalFastIter_resolves (data : ByteArray) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77OptimalFastIter data)) [] =
+      some data.data.toList := by
+  rw [lz77OptimalFastIter_eq_lz77OptimalFast]; exact lz77OptimalFast_resolves data
+
+theorem lz77OptimalFastIter_encodable (data : ByteArray) :
+    ∀ t ∈ (lz77OptimalFastIter data).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  rw [lz77OptimalFastIter_eq_lz77OptimalFast]; exact lz77OptimalFast_encodable data
+
+theorem lz77OptimalFastIter_empty (data : ByteArray) (hzero : data.size = 0) :
+    lz77OptimalFastIter data = #[] := by
+  rw [lz77OptimalFastIter_eq_lz77OptimalFast]; exact lz77OptimalFast_empty data hzero
+
 end Zip.Native.Deflate

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -134,12 +134,22 @@ def Row.toJson (r : Row) : String :=
 
 /-! ## Matrix -/
 
+/-- Level range for the FFI reference codecs (zlib, miniz_oxide), whose
+    `deflateInit2` accepts only 0–9. -/
 def levels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-/-- libdeflate's full level range. Unlike zlib/miniz/native (capped at 9),
-    libdeflate exposes 1–12, and its densest points (10–12) are exactly the
-    ones the comparison Pareto needs from it — so it is swept to 12 here while
-    every other codec stays on the shared `levels`. -/
+/-- Native lean-zip's level range. Wider than the zlib/miniz FFI cap of 9: since
+    #2638, level 9 is the L9-fast approximate-optimal tier and **level 10 is the
+    exact-DP crown** (the max-ratio ceiling). The dashboard must always sweep
+    native through 10 so the crown stays on the Pareto — otherwise the headline
+    graph loses our best-ratio point. `runWorkloads` already omits the decode
+    timing for `level > 9` (no zlib-FFI raw-deflate reference exists there), so
+    the extra native point is compress-only, exactly like libdeflate 10–12. -/
+def nativeLevels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+/-- libdeflate's full level range. It exposes 1–12, and its densest points
+    (10–12) are exactly the ones the comparison Pareto needs from it — so it is
+    swept to 12 here while the FFI references cap at 9 and native caps at 10. -/
 def libdeflateLevels : List Nat := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 def reps : Nat := 5
 
@@ -258,10 +268,14 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
     -- level/rep it dominated the wall-clock of the whole matrix. Its FFI binding
     -- (`zopfliCompress`) is kept for ad-hoc ratio-ceiling checks.
     let big := corpus == "silesia"
+    -- Native sweeps 1–10 (incl. the level-10 crown, #2638); the FFI references
+    -- (zlib/miniz) cap at 9. An explicit `levelOverride` (a native-only regen at
+    -- a chosen level list) applies to whichever codecs run.
+    let nlvls := levelOverride.getD nativeLevels
     let lvls := levelOverride.getD levels
     let rps  := if big then 1 else reps
-    IO.eprintln s!"Running {corpus} corpus matrix ({files.length} files, levels {lvls}, reps {rps})…"
-    let cn ← runWorkloads "native"      files nativeCompress     (some nativeDecompress)     (theLevels := lvls) (theReps := rps)
+    IO.eprintln s!"Running {corpus} corpus matrix ({files.length} files, native levels {nlvls}, reps {rps})…"
+    let cn ← runWorkloads "native"      files nativeCompress     (some nativeDecompress)     (theLevels := nlvls) (theReps := rps)
     -- `--native-only`: skip the reference compressors. Their ratios are
     -- deterministic and their MB/s drift <~3% run-to-run (measured), so a Lean-only
     -- change reuses the prior dashboard's reference rows (spliced in post-hoc by

--- a/ZipTest/OptimalParse.lean
+++ b/ZipTest/OptimalParse.lean
@@ -64,20 +64,21 @@ private def resolveTokens (label : String) (tokens : Array LZ77Token) :
         out := out.push out[out.size - dist]!
   return out
 
-/-- Full pipeline check for the optimal parser on one input: token stream
-    resolves back to the data, and a dynamic Huffman block built from it
-    inflates back to the data (native verified decoder). -/
+/-- Full pipeline check for **both** near-optimal parsers on one input (the
+    exact crown `lz77OptimalIter` and the L9-fast `lz77OptimalFastIter`, #2638):
+    each token stream resolves back to the data, and a dynamic Huffman block
+    built from it inflates back to the data (native verified decoder). -/
 private def checkParse (label : String) (data : ByteArray) : IO Unit := do
-  let toks := lz77OptimalIter data
-  let back ← resolveTokens label toks
-  unless back == data do
-    throw (IO.userError s!"{label}: token resolution mismatch ({back.size} vs {data.size})")
-  let blk := deflateDynamicBlock data toks
-  match Zip.Native.Inflate.inflate blk with
-  | .ok r =>
-    unless r == data do
-      throw (IO.userError s!"{label}: dynamic block roundtrip mismatch")
-  | .error e => throw (IO.userError s!"{label}: inflate failed: {e}")
+  for (pname, toks) in [("exact", lz77OptimalIter data), ("fast", lz77OptimalFastIter data)] do
+    let back ← resolveTokens s!"{label}-{pname}" toks
+    unless back == data do
+      throw (IO.userError s!"{label}-{pname}: token resolution mismatch ({back.size} vs {data.size})")
+    let blk := deflateDynamicBlock data toks
+    match Zip.Native.Inflate.inflate blk with
+    | .ok r =>
+      unless r == data do
+        throw (IO.userError s!"{label}-{pname}: dynamic block roundtrip mismatch")
+    | .error e => throw (IO.userError s!"{label}-{pname}: inflate failed: {e}")
 
 def tests : IO Unit := do
   IO.println "  OptimalParse tests..."
@@ -170,38 +171,46 @@ def tests : IO Unit := do
   unless sizeOpt < sizeLazy do
     throw (IO.userError s!"ratio canary: optimal {sizeOpt} ≥ lazy-9 {sizeLazy}")
 
-  -- Level-9 dispatch: the optimal candidate joins via pickSmaller. Verify
-  -- the full deflateRaw output through the native (verified) decoder AND the
-  -- zlib FFI (cross-implementation conformance), and that level 9 improves
-  -- on level 8 on real text (the whole point of the feature).
-  for (label, payload) in [("alice", alice), ("text", mkTextData 65536),
-      ("prng", mkPrngData 65536), ("constant", mkConstantData 65536),
-      ("cyclic", mkCyclicData 65536), ("tiny", ByteArray.mk #[1, 2, 3])] do
-    let out := deflateRaw payload 9
-    match Zip.Native.Inflate.inflate out with
-    | .ok r =>
-      unless r == payload do
-        throw (IO.userError s!"deflateRaw-9 {label}: native roundtrip mismatch")
-    | .error e => throw (IO.userError s!"deflateRaw-9 {label}: inflate failed: {e}")
-    let ffi ← RawDeflate.decompress out
-    unless ffi == payload do
-      throw (IO.userError s!"deflateRaw-9 {label}: FFI conformance mismatch")
+  -- Level 9 (L9-fast, #2638) and level 10 (exact-DP crown) dispatch: both
+  -- optimal candidates join via pickSmaller. Verify the full deflateRaw output
+  -- of each through the native (verified) decoder AND the zlib FFI
+  -- (cross-implementation conformance).
+  for lvl in [(9 : UInt8), 10] do
+    for (label, payload) in [("alice", alice), ("text", mkTextData 65536),
+        ("prng", mkPrngData 65536), ("constant", mkConstantData 65536),
+        ("cyclic", mkCyclicData 65536), ("tiny", ByteArray.mk #[1, 2, 3])] do
+      let out := deflateRaw payload lvl
+      match Zip.Native.Inflate.inflate out with
+      | .ok r =>
+        unless r == payload do
+          throw (IO.userError s!"deflateRaw-{lvl} {label}: native roundtrip mismatch")
+      | .error e => throw (IO.userError s!"deflateRaw-{lvl} {label}: inflate failed: {e}")
+      let ffi ← RawDeflate.decompress out
+      unless ffi == payload do
+        throw (IO.userError s!"deflateRaw-{lvl} {label}: FFI conformance mismatch")
+  -- Tier ordering on real text: the exact crown (10) is smallest, L9-fast (9)
+  -- sits between it and level 8 — a genuine intermediate tier (crown ≤ fast < L8).
+  let raw10 := (deflateRaw alice 10).size
   let raw9 := (deflateRaw alice 9).size
   let raw8 := (deflateRaw alice 8).size
-  IO.println s!"    alice29.txt deflateRaw: level 9 {raw9} vs level 8 {raw8}"
+  IO.println s!"    alice29.txt deflateRaw: L10 crown {raw10} ≤ L9-fast {raw9} < L8 {raw8}"
+  unless raw10 ≤ raw9 do
+    throw (IO.userError s!"deflateRaw: L10 crown {raw10} did not match/beat L9-fast {raw9}")
   unless raw9 < raw8 do
-    throw (IO.userError s!"deflateRaw: level 9 {raw9} did not beat level 8 {raw8}")
-  -- Incompressible input must still fall back to the stored block.
+    throw (IO.userError s!"deflateRaw: L9-fast {raw9} did not beat level 8 {raw8}")
+  -- Incompressible input must still fall back to the stored block (both tiers).
   let prng := mkPrngData 65536
   unless (deflateRaw prng 9).size ≤ prng.size + 600 do
     throw (IO.userError "deflateRaw-9: incompressible input expanded past stored bound")
-  -- Inputs above the memory gate skip the optimal candidate but roundtrip.
+  -- Inputs above the memory gate skip the optimal candidate but roundtrip
+  -- (both level 9 and level 10 fall through to the split path there).
   let big := mkConstantData (optimalMaxSize + 1)
-  match Zip.Native.Inflate.inflate (deflateRaw big 9) (big.size + 1) with
-  | .ok r =>
-    unless r == big do
-      throw (IO.userError "deflateRaw-9 above-gate: roundtrip mismatch")
-  | .error e => throw (IO.userError s!"deflateRaw-9 above-gate: inflate failed: {e}")
+  for lvl in [(9 : UInt8), 10] do
+    match Zip.Native.Inflate.inflate (deflateRaw big lvl) (big.size + 1) with
+    | .ok r =>
+      unless r == big do
+        throw (IO.userError s!"deflateRaw-{lvl} above-gate: roundtrip mismatch")
+    | .error e => throw (IO.userError s!"deflateRaw-{lvl} above-gate: inflate failed: {e}")
 
   IO.println "  OptimalParse tests passed"
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -29,10 +29,10 @@ implementations (no SIMD/asm, or GC'd, or JIT'd) — not just the C + SIMD ceili
 
 | Key | Implementation | Role |
 |-----|----------------|------|
-| `native` | lean-zip pure-Lean DEFLATE | the thing we are improving |
+| `native` | lean-zip pure-Lean DEFLATE | the thing we are improving; swept **levels 1–10** — since #2638 level 9 is the L9-fast tier and level 10 is the exact-DP crown (always sweep through 10 so the crown stays on the Pareto) |
 | `zlib` | system zlib (FFI) | the ubiquitous baseline |
 | `miniz_oxide` | Rust miniz_oxide (FFI) | widely-used Rust reimplementation |
-| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar; swept over its full **levels 1–12** (the others cap at 9), so its densest points (10–12) appear on the Pareto |
+| `libdeflate` | libdeflate (FFI) | optimized C + SIMD — the runtime speed bar; swept over its full **levels 1–12** (native caps at 10, the zlib/miniz FFI at 9), so its densest points (10–12) appear on the Pareto |
 | `zopfli` | zopfli (FFI) | maximum-ratio ceiling — **frozen** (see below); never in the routine matrix |
 
 **Language-native peers** (each a self-verifying CLI under
@@ -66,8 +66,9 @@ whose toolchain is unavailable is skipped, so the dashboard degrades gracefully.
 
 ## Workloads
 
-The **real compression corpora** from the literature, swept over levels 1–9
-(`libdeflate` over its full 1–12 — see *Compressors compared*).
+The **real compression corpora** from the literature, swept over native levels
+1–10 (the level-10 exact crown always included; the zlib/miniz FFI references cap
+at 9, `libdeflate` over its full 1–12 — see *Compressors compared*).
 Each corpus is a subdirectory of [`corpora/`](corpora); every file in it is one
 single-size workload tagged `<corpus>/<file>`, and the harness discovers corpora
 by directory (nothing hard-codes Canterbury — a new corpus slots in once its
@@ -161,14 +162,14 @@ improvements on catching a SIMD C codec. (Cross-codec comparison still matters �
 as context, and for justifying a *new tier's* external reason to exist — it just
 is not the pass/fail test for an incremental within-native gain.)
 
-### Canterbury corpus (11 small files, levels 1–9; libdeflate 1–12)
+### Canterbury corpus (11 small files, native levels 1–10; libdeflate 1–12)
 
 ![canterbury compression speed vs ratio](graphs/canterbury_compress_pareto.svg)
 ![canterbury summary table](graphs/canterbury_summary.svg)
 ![canterbury ratio vs zlib per file](graphs/canterbury_ratio_heatmap.svg)
 ![canterbury compress speed vs zlib per file](graphs/canterbury_compress_heatmap.svg)
 
-### Silesia corpus (12 large files, levels 1–9; libdeflate 1–12)
+### Silesia corpus (12 large files, native levels 1–10; libdeflate 1–12)
 
 ![silesia compression speed vs ratio](graphs/silesia_compress_pareto.svg)
 ![silesia decode throughput vs input density](graphs/silesia_decode_density.svg)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd7fc49fe48)">
+   <g clip-path="url(#pfa3be8695e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3Yz4pkZx3H4erumiEMzaBCYhxERFA37rPwGtzkQrwC7yJXIAiu3IagS3degn+CCBlDbGdM05mpdNfUyS77wOflZ4rnuYLv4RRvfc57cfr899uOb5fD3fSCdQ630wuW2B7upycsc/H0nekJazx6a3rBOpeX0wvWeDhML1jn4jzf2fby+fSEZc7zjQEADBJYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/T93N9Mblng4HaYnLPOD7/xkesIy19u70xOWuPjixfSEZf78+q/TE5b44eN3picsczzdT09Y4u7N+Z7796fj9IQl3nv6o+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF7Zd/2KZHrPD6eDc9YZm3T0+mJ6xzvJ9esMbdzfSCdb7/s+kFS9xtr6YnLHOu5+Pb2/X0hGWe715MT1ji2c3/pics4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYvvrlzfTG5a43j+enrDO4dPpBctsd59PT1jjdJpesMzFk8+mJyxxzmfI9f7p9IQ1Hr81vWCZZ6/vpycssb369/SEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9tvNp9Mb+KZOp+kF8LXtk4+nJ6xx6fvzW8fZyP8RJwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9r/+z7+mNyzx8vBmesIyf3l+Oz1hmQ/f/+X0hCXeffLj6QnL/OK3v5uesMSvfvq96QnL/OPlYXoC39BHf/z79IQlXn3wm+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF8fSnbXrECm9Ox+kJy1xenG8XXx1eTU9Y42o/vWCdL15ML1ji9N1n0xOW2bbT9IQlrs74zuBhO8//tEfH83yu3c4NFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2l+faWJf76QXLXH728fSEZbbb/05PWON4nF6wzOnn701PWOLqXM/G3W73sJ3n7/HqzXk+12632z063E5PWGL75G/TE5Y53xMEAGCIwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiH0F426NAdZrLn8AAAAASUVORK5CYII=" id="image31c74c7c0c" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3Yz4pkZx3H4erumiEMzaBCYhxERFA37rPwGtzkQrwC7yJXIAiu3IagS3degn+CCBlDbGdM05mpdNfUyS77wOflZ4rnuYLv4RRvfc57cfr899uOb5fD3fSCdQ630wuW2B7upycsc/H0nekJazx6a3rBOpeX0wvWeDhML1jn4jzf2fby+fSEZc7zjQEADBJYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/T93N9Mblng4HaYnLPOD7/xkesIy19u70xOWuPjixfSEZf78+q/TE5b44eN3picsczzdT09Y4u7N+Z7796fj9IQl3nv6o+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF7Zd/2KZHrPD6eDc9YZm3T0+mJ6xzvJ9esMbdzfSCdb7/s+kFS9xtr6YnLHOu5+Pb2/X0hGWe715MT1ji2c3/pics4wYLACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYvvrlzfTG5a43j+enrDO4dPpBctsd59PT1jjdJpesMzFk8+mJyxxzmfI9f7p9IQ1Hr81vWCZZ6/vpycssb369/SEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9tvNp9Mb+KZOp+kF8LXtk4+nJ6xx6fvzW8fZyP8RJwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9r/+z7+mNyzx8vBmesIyf3l+Oz1hmQ/f/+X0hCXeffLj6QnL/OK3v5uesMSvfvq96QnL/OPlYXoC39BHf/z79IQlXn3wm+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjF8fSnbXrECm9Ox+kJy1xenG8XXx1eTU9Y42o/vWCdL15ML1ji9N1n0xOW2bbT9IQlrs74zuBhO8//tEfH83yu3c4NFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2l+faWJf76QXLXH728fSEZbbb/05PWON4nF6wzOnn701PWOLqXM/G3W73sJ3n7/HqzXk+12632z063E5PWGL75G/TE5Y53xMEAGCIwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiH0F426NAdZrLn8AAAAASUVORK5CYII=" id="imageb4878470a9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb6cd1d1dad" d="M 0 0 
+       <path id="m0f055aee98" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb6cd1d1dad" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0f055aee98" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m57ed81b3d5" d="M 0 0 
+       <path id="m2ae54b860b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m57ed81b3d5" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ae54b860b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1384,7 +1384,7 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- -87 -->
+    <!-- -86 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1429,7 +1429,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1469,8 +1469,31 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- +3 -->
+    <!-- +2 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +10 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -14 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -35 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1505,29 +1528,6 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +10 -->
-    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -14 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -35 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -2179,18 +2179,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image7d3460814c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image57419365e4" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m161dd572f8" d="M 0 0 
+       <path id="m444b027476" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2227,7 +2227,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2241,7 +2241,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2254,7 +2254,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2267,7 +2267,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2280,7 +2280,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m161dd572f8" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m444b027476" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2941,8 +2941,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.611875 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.987891 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3006,19 +3006,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3057,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd7fc49fe48">
+  <clipPath id="pfa3be8695e">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc36641b3aa" d="M 0 0 
+       <path id="mf73a422ca5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc36641b3aa" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc36641b3aa" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc36641b3aa" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc36641b3aa" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc36641b3aa" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc36641b3aa" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc36641b3aa" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf73a422ca5" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m66500a003c" d="M 0 0 
+       <path id="m3271779437" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m66500a003c" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3271779437" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m66500a003c" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3271779437" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m66500a003c" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3271779437" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m15f0745b20" d="M 0 0 
+       <path id="me2cf07bde7" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m15f0745b20" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2cf07bde7" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 174.618486) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 174.80002) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1409,42 +1409,34 @@ z
     </g>
    </g>
    <g id="text_14">
-    <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.908823) scale(0.07 -0.07)">
+    <!-- L10 -->
+    <g style="fill: #d62728" transform="translate(103.348822 313.331425) scale(0.07 -0.07)">
      <defs>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
 z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-4c"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(63.720703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(133.300781 0)"/>
     </g>
    </g>
    <g id="text_15">
@@ -1740,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="ma8b0475a2d" d="M -2.5 2.5 
+     <path id="m0b0d453e00" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#ma8b0475a2d" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8b0475a2d" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#m0b0d453e00" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b0d453e00" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1809,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1861,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1913,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1965,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2017,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2069,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2121,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2173,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="md472f5d34f" d="M 0 -2.5 
+     <path id="m2eb0610780" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#md472f5d34f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md472f5d34f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#m2eb0610780" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2eb0610780" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2245,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2297,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2349,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2401,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2453,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2505,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2557,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2609,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mbc0e668acc" d="M -0 3.535534 
+     <path id="m28e22a9662" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#mbc0e668acc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc0e668acc" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#m28e22a9662" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m28e22a9662" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2685,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2737,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2789,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2841,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2893,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2945,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2997,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3049,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3101,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3153,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3205,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m6a3f3ce72a" d="M -0 2.5 
+     <path id="ma98c14697f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#m6a3f3ce72a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#ma98c14697f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m8172be00a2" d="M -0.833333 2.5 
+     <path id="m9c9ee6ffc1" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3236,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#m8172be00a2" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8172be00a2" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#m9c9ee6ffc1" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9c9ee6ffc1" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3298,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3350,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3402,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3454,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3506,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3558,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3610,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3662,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m1c50d60c68" d="M -1.25 2.5 
+     <path id="ma29ff41eb0" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3681,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#m1c50d60c68" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1c50d60c68" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#ma29ff41eb0" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma29ff41eb0" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3743,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3795,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3847,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3899,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3951,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -4003,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4055,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4107,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="ma0e4067efa" d="M 0 -2.5 
+     <path id="m2576881912" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4124,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma0e4067efa" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#m2576881912" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2576881912" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4186,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4238,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4290,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4342,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4394,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4446,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4498,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4550,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mb9f69ca509" d="M 0 -2.5 
+     <path id="mbb92d8f531" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4563,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#mb9f69ca509" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb9f69ca509" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#mbb92d8f531" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb92d8f531" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4625,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4677,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4729,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4781,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4833,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4885,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4937,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4989,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -5007,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m326bc9c49d" d="M 0 3.5 
+      <path id="mdf93b9fe20" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5020,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m326bc9c49d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mdf93b9fe20" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5079,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#ma8b0475a2d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b0d453e00" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5093,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#md472f5d34f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2eb0610780" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5138,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mbc0e668acc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m28e22a9662" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5181,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m6a3f3ce72a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma98c14697f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5197,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m8172be00a2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9c9ee6ffc1" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5251,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m1c50d60c68" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma29ff41eb0" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5316,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#ma0e4067efa" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m2576881912" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5354,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mb9f69ca509" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbb92d8f531" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5424,433 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p14f9c3d880)">
-     <use xlink:href="#m326bc9c49d" x="226.647908" y="179.618486" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="214.084819" y="182.356552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="206.266533" y="184.821312" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="187.75787" y="192.089877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="186.58897" y="192.797576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="184.505355" y="194.997697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="164.72409" y="206.439744" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="150.950891" y="251.438009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m326bc9c49d" x="98.348822" y="318.908823" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p8e9461a457)">
+     <use xlink:href="#mdf93b9fe20" x="226.647908" y="179.80002" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="214.084819" y="182.483722" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="206.266533" y="185.082298" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="187.75787" y="191.664606" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="186.58897" y="192.717784" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="184.505355" y="195.034276" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="164.72409" y="206.490287" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="150.950891" y="251.550915" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="118.987151" y="289.553423" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mdf93b9fe20" x="98.348822" y="318.331425" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 226.647908 179.618486 
-L 226.386177 179.677173 
-L 226.124446 179.735788 
-L 225.862715 179.794329 
-L 225.600984 179.852799 
-L 225.339253 179.911196 
-L 225.077522 179.969522 
-L 224.815791 180.027776 
-L 224.55406 180.085959 
-L 224.292329 180.14407 
-L 224.030598 180.20211 
-L 223.768867 180.260078 
-L 223.507136 180.317977 
-L 223.245405 180.375804 
-L 222.983674 180.433561 
-L 222.721943 180.491248 
-L 222.460212 180.548864 
-L 222.198481 180.606411 
-L 221.93675 180.663887 
-L 221.675019 180.721295 
-L 221.413288 180.778632 
-L 221.151557 180.835901 
-L 220.889826 180.8931 
-L 220.628095 180.95023 
-L 220.366363 181.007292 
-L 220.104632 181.064285 
-L 219.842901 181.121209 
-L 219.58117 181.178065 
-L 219.319439 181.234853 
-L 219.057708 181.291573 
-L 218.795977 181.348225 
-L 218.534246 181.40481 
-L 218.272515 181.461327 
-L 218.010784 181.517777 
-L 217.749053 181.574159 
-L 217.487322 181.630475 
-L 217.225591 181.686724 
-L 216.96386 181.742906 
-L 216.702129 181.799021 
-L 216.440398 181.85507 
-L 216.178667 181.911053 
-L 215.916936 181.96697 
-L 215.655205 182.022821 
-L 215.393474 182.078606 
-L 215.131743 182.134326 
-L 214.870012 182.18998 
-L 214.608281 182.245569 
-L 214.34655 182.301093 
-L 214.084819 182.356552 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 226.647908 179.80002 
+L 226.386177 179.857509 
+L 226.124446 179.914929 
+L 225.862715 179.972278 
+L 225.600984 180.029559 
+L 225.339253 180.08677 
+L 225.077522 180.143913 
+L 224.815791 180.200986 
+L 224.55406 180.257991 
+L 224.292329 180.314928 
+L 224.030598 180.371796 
+L 223.768867 180.428596 
+L 223.507136 180.485328 
+L 223.245405 180.541992 
+L 222.983674 180.598589 
+L 222.721943 180.655117 
+L 222.460212 180.711579 
+L 222.198481 180.767973 
+L 221.93675 180.824301 
+L 221.675019 180.880561 
+L 221.413288 180.936755 
+L 221.151557 180.992882 
+L 220.889826 181.048943 
+L 220.628095 181.104938 
+L 220.366363 181.160866 
+L 220.104632 181.216729 
+L 219.842901 181.272526 
+L 219.58117 181.328257 
+L 219.319439 181.383923 
+L 219.057708 181.439523 
+L 218.795977 181.495058 
+L 218.534246 181.550528 
+L 218.272515 181.605934 
+L 218.010784 181.661275 
+L 217.749053 181.716551 
+L 217.487322 181.771762 
+L 217.225591 181.82691 
+L 216.96386 181.881993 
+L 216.702129 181.937013 
+L 216.440398 181.991968 
+L 216.178667 182.04686 
+L 215.916936 182.101689 
+L 215.655205 182.156454 
+L 215.393474 182.211156 
+L 215.131743 182.265795 
+L 214.870012 182.32037 
+L 214.608281 182.374884 
+L 214.34655 182.429334 
+L 214.084819 182.483722 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 214.084819 182.356552 
-L 213.921938 182.409231 
-L 213.759057 182.461851 
-L 213.596176 182.514413 
-L 213.433295 182.566916 
-L 213.270414 182.619362 
-L 213.107533 182.671749 
-L 212.944652 182.724079 
-L 212.781771 182.776351 
-L 212.61889 182.828565 
-L 212.456009 182.880722 
-L 212.293128 182.932822 
-L 212.130247 182.984864 
-L 211.967366 183.036849 
-L 211.804485 183.088778 
-L 211.641604 183.140649 
-L 211.478723 183.192464 
-L 211.315843 183.244222 
-L 211.152962 183.295924 
-L 210.990081 183.347569 
-L 210.8272 183.399158 
-L 210.664319 183.450691 
-L 210.501438 183.502168 
-L 210.338557 183.553589 
-L 210.175676 183.604955 
-L 210.012795 183.656265 
-L 209.849914 183.707519 
-L 209.687033 183.758718 
-L 209.524152 183.809862 
-L 209.361271 183.86095 
-L 209.19839 183.911984 
-L 209.035509 183.962962 
-L 208.872628 184.013886 
-L 208.709747 184.064755 
-L 208.546866 184.11557 
-L 208.383985 184.16633 
-L 208.221104 184.217036 
-L 208.058223 184.267688 
-L 207.895342 184.318285 
-L 207.732462 184.368829 
-L 207.569581 184.419319 
-L 207.4067 184.469755 
-L 207.243819 184.520137 
-L 207.080938 184.570466 
-L 206.918057 184.620742 
-L 206.755176 184.670964 
-L 206.592295 184.721133 
-L 206.429414 184.771249 
-L 206.266533 184.821312 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 214.084819 182.483722 
+L 213.921938 182.539338 
+L 213.759057 182.594889 
+L 213.596176 182.650375 
+L 213.433295 182.705796 
+L 213.270414 182.761152 
+L 213.107533 182.816444 
+L 212.944652 182.871671 
+L 212.781771 182.926834 
+L 212.61889 182.981933 
+L 212.456009 183.036968 
+L 212.293128 183.091939 
+L 212.130247 183.146846 
+L 211.967366 183.20169 
+L 211.804485 183.25647 
+L 211.641604 183.311188 
+L 211.478723 183.365842 
+L 211.315843 183.420433 
+L 211.152962 183.474961 
+L 210.990081 183.529427 
+L 210.8272 183.58383 
+L 210.664319 183.63817 
+L 210.501438 183.692449 
+L 210.338557 183.746665 
+L 210.175676 183.800819 
+L 210.012795 183.854912 
+L 209.849914 183.908943 
+L 209.687033 183.962912 
+L 209.524152 184.01682 
+L 209.361271 184.070667 
+L 209.19839 184.124452 
+L 209.035509 184.178177 
+L 208.872628 184.231841 
+L 208.709747 184.285444 
+L 208.546866 184.338986 
+L 208.383985 184.392468 
+L 208.221104 184.44589 
+L 208.058223 184.499252 
+L 207.895342 184.552553 
+L 207.732462 184.605795 
+L 207.569581 184.658977 
+L 207.4067 184.712099 
+L 207.243819 184.765162 
+L 207.080938 184.818166 
+L 206.918057 184.87111 
+L 206.755176 184.923995 
+L 206.592295 184.976822 
+L 206.429414 185.029589 
+L 206.266533 185.082298 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 206.266533 184.821312 
-L 205.880936 184.984689 
-L 205.495339 185.147505 
-L 205.109742 185.309763 
-L 204.724144 185.471467 
-L 204.338547 185.632622 
-L 203.95295 185.79323 
-L 203.567353 185.953296 
-L 203.181756 186.112823 
-L 202.796159 186.271815 
-L 202.410562 186.430275 
-L 202.024964 186.588207 
-L 201.639367 186.745614 
-L 201.25377 186.902501 
-L 200.868173 187.058869 
-L 200.482576 187.214724 
-L 200.096979 187.370067 
-L 199.711382 187.524903 
-L 199.325784 187.679235 
-L 198.940187 187.833065 
-L 198.55459 187.986398 
-L 198.168993 188.139236 
-L 197.783396 188.291584 
-L 197.397799 188.443442 
-L 197.012202 188.594816 
-L 196.626605 188.745708 
-L 196.241007 188.896121 
-L 195.85541 189.046058 
-L 195.469813 189.195522 
-L 195.084216 189.344516 
-L 194.698619 189.493043 
-L 194.313022 189.641106 
-L 193.927425 189.788708 
-L 193.541827 189.935851 
-L 193.15623 190.082539 
-L 192.770633 190.228775 
-L 192.385036 190.37456 
-L 191.999439 190.519899 
-L 191.613842 190.664793 
-L 191.228245 190.809245 
-L 190.842647 190.953259 
-L 190.45705 191.096836 
-L 190.071453 191.239979 
-L 189.685856 191.382692 
-L 189.300259 191.524975 
-L 188.914662 191.666833 
-L 188.529065 191.808268 
-L 188.143468 191.949281 
-L 187.75787 192.089877 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 206.266533 185.082298 
+L 205.880936 185.229182 
+L 205.495339 185.375612 
+L 205.109742 185.521591 
+L 204.724144 185.667122 
+L 204.338547 185.812207 
+L 203.95295 185.956849 
+L 203.567353 186.101052 
+L 203.181756 186.244817 
+L 202.796159 186.388146 
+L 202.410562 186.531044 
+L 202.024964 186.673512 
+L 201.639367 186.815553 
+L 201.25377 186.95717 
+L 200.868173 187.098365 
+L 200.482576 187.23914 
+L 200.096979 187.379498 
+L 199.711382 187.519442 
+L 199.325784 187.658974 
+L 198.940187 187.798096 
+L 198.55459 187.936811 
+L 198.168993 188.075121 
+L 197.783396 188.213029 
+L 197.397799 188.350536 
+L 197.012202 188.487645 
+L 196.626605 188.624359 
+L 196.241007 188.76068 
+L 195.85541 188.89661 
+L 195.469813 189.032151 
+L 195.084216 189.167305 
+L 194.698619 189.302075 
+L 194.313022 189.436463 
+L 193.927425 189.57047 
+L 193.541827 189.7041 
+L 193.15623 189.837354 
+L 192.770633 189.970235 
+L 192.385036 190.102744 
+L 191.999439 190.234883 
+L 191.613842 190.366655 
+L 191.228245 190.498062 
+L 190.842647 190.629105 
+L 190.45705 190.759787 
+L 190.071453 190.890109 
+L 189.685856 191.020074 
+L 189.300259 191.149684 
+L 188.914662 191.27894 
+L 188.529065 191.407844 
+L 188.143468 191.536399 
+L 187.75787 191.664606 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 187.75787 192.089877 
-L 187.733518 192.104729 
-L 187.709166 192.119576 
-L 187.684814 192.134419 
-L 187.660462 192.149257 
-L 187.63611 192.16409 
-L 187.611758 192.178919 
-L 187.587406 192.193743 
-L 187.563054 192.208563 
-L 187.538702 192.223378 
-L 187.514349 192.238188 
-L 187.489997 192.252994 
-L 187.465645 192.267795 
-L 187.441293 192.282591 
-L 187.416941 192.297383 
-L 187.392589 192.31217 
-L 187.368237 192.326953 
-L 187.343885 192.341731 
-L 187.319533 192.356504 
-L 187.295181 192.371273 
-L 187.270829 192.386037 
-L 187.246476 192.400796 
-L 187.222124 192.415551 
-L 187.197772 192.430302 
-L 187.17342 192.445047 
-L 187.149068 192.459788 
-L 187.124716 192.474525 
-L 187.100364 192.489257 
-L 187.076012 192.503984 
-L 187.05166 192.518707 
-L 187.027308 192.533426 
-L 187.002956 192.548139 
-L 186.978603 192.562848 
-L 186.954251 192.577553 
-L 186.929899 192.592253 
-L 186.905547 192.606948 
-L 186.881195 192.621639 
-L 186.856843 192.636326 
-L 186.832491 192.651007 
-L 186.808139 192.665685 
-L 186.783787 192.680357 
-L 186.759435 192.695026 
-L 186.735083 192.709689 
-L 186.71073 192.724348 
-L 186.686378 192.739003 
-L 186.662026 192.753653 
-L 186.637674 192.768298 
-L 186.613322 192.782939 
-L 186.58897 192.797576 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 187.75787 191.664606 
+L 187.733518 191.686787 
+L 187.709166 191.708959 
+L 187.684814 191.73112 
+L 187.660462 191.75327 
+L 187.63611 191.77541 
+L 187.611758 191.79754 
+L 187.587406 191.81966 
+L 187.563054 191.841769 
+L 187.538702 191.863868 
+L 187.514349 191.885956 
+L 187.489997 191.908035 
+L 187.465645 191.930103 
+L 187.441293 191.95216 
+L 187.416941 191.974208 
+L 187.392589 191.996245 
+L 187.368237 192.018272 
+L 187.343885 192.040289 
+L 187.319533 192.062295 
+L 187.295181 192.084292 
+L 187.270829 192.106278 
+L 187.246476 192.128254 
+L 187.222124 192.15022 
+L 187.197772 192.172175 
+L 187.17342 192.194121 
+L 187.149068 192.216056 
+L 187.124716 192.237981 
+L 187.100364 192.259896 
+L 187.076012 192.281801 
+L 187.05166 192.303695 
+L 187.027308 192.32558 
+L 187.002956 192.347454 
+L 186.978603 192.369319 
+L 186.954251 192.391173 
+L 186.929899 192.413017 
+L 186.905547 192.434851 
+L 186.881195 192.456676 
+L 186.856843 192.47849 
+L 186.832491 192.500294 
+L 186.808139 192.522088 
+L 186.783787 192.543872 
+L 186.759435 192.565646 
+L 186.735083 192.58741 
+L 186.71073 192.609164 
+L 186.686378 192.630908 
+L 186.662026 192.652642 
+L 186.637674 192.674366 
+L 186.613322 192.69608 
+L 186.58897 192.717784 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 186.58897 192.797576 
-L 186.545561 192.844469 
-L 186.502153 192.891316 
-L 186.458744 192.938117 
-L 186.415335 192.984871 
-L 186.371927 193.03158 
-L 186.328518 193.078242 
-L 186.285109 193.124859 
-L 186.241701 193.171429 
-L 186.198292 193.217954 
-L 186.154883 193.264434 
-L 186.111475 193.310868 
-L 186.068066 193.357256 
-L 186.024658 193.403599 
-L 185.981249 193.449897 
-L 185.93784 193.496149 
-L 185.894432 193.542357 
-L 185.851023 193.588519 
-L 185.807614 193.634637 
-L 185.764206 193.680709 
-L 185.720797 193.726737 
-L 185.677388 193.77272 
-L 185.63398 193.818659 
-L 185.590571 193.864553 
-L 185.547162 193.910403 
-L 185.503754 193.956209 
-L 185.460345 194.00197 
-L 185.416936 194.047687 
-L 185.373528 194.09336 
-L 185.330119 194.138989 
-L 185.28671 194.184574 
-L 185.243302 194.230116 
-L 185.199893 194.275613 
-L 185.156484 194.321067 
-L 185.113076 194.366478 
-L 185.069667 194.411845 
-L 185.026258 194.457168 
-L 184.98285 194.502448 
-L 184.939441 194.547685 
-L 184.896033 194.592879 
-L 184.852624 194.63803 
-L 184.809215 194.683138 
-L 184.765807 194.728203 
-L 184.722398 194.773225 
-L 184.678989 194.818205 
-L 184.635581 194.863141 
-L 184.592172 194.908036 
-L 184.548763 194.952887 
-L 184.505355 194.997697 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 192.717784 
+L 186.545561 192.767217 
+L 186.502153 192.816599 
+L 186.458744 192.86593 
+L 186.415335 192.915209 
+L 186.371927 192.964437 
+L 186.328518 193.013614 
+L 186.285109 193.06274 
+L 186.241701 193.111815 
+L 186.198292 193.16084 
+L 186.154883 193.209813 
+L 186.111475 193.258737 
+L 186.068066 193.307609 
+L 186.024658 193.356431 
+L 185.981249 193.405204 
+L 185.93784 193.453926 
+L 185.894432 193.502597 
+L 185.851023 193.551219 
+L 185.807614 193.599791 
+L 185.764206 193.648314 
+L 185.720797 193.696787 
+L 185.677388 193.74521 
+L 185.63398 193.793584 
+L 185.590571 193.841908 
+L 185.547162 193.890183 
+L 185.503754 193.938409 
+L 185.460345 193.986586 
+L 185.416936 194.034715 
+L 185.373528 194.082794 
+L 185.330119 194.130825 
+L 185.28671 194.178806 
+L 185.243302 194.22674 
+L 185.199893 194.274625 
+L 185.156484 194.322462 
+L 185.113076 194.37025 
+L 185.069667 194.41799 
+L 185.026258 194.465682 
+L 184.98285 194.513327 
+L 184.939441 194.560923 
+L 184.896033 194.608472 
+L 184.852624 194.655973 
+L 184.809215 194.703426 
+L 184.765807 194.750832 
+L 184.722398 194.798191 
+L 184.678989 194.845502 
+L 184.635581 194.892766 
+L 184.592172 194.939983 
+L 184.548763 194.987153 
+L 184.505355 195.034276 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 184.505355 194.997697 
-L 184.093245 195.26655 
-L 183.681135 195.533886 
-L 183.269026 195.799722 
-L 182.856916 196.064076 
-L 182.444806 196.326963 
-L 182.032697 196.5884 
-L 181.620587 196.848402 
-L 181.208477 197.106986 
-L 180.796368 197.364166 
-L 180.384258 197.619958 
-L 179.972148 197.874377 
-L 179.560039 198.127437 
-L 179.147929 198.379153 
-L 178.735819 198.629539 
-L 178.323709 198.878609 
-L 177.9116 199.126377 
-L 177.49949 199.372856 
-L 177.08738 199.61806 
-L 176.675271 199.862001 
-L 176.263161 200.104693 
-L 175.851051 200.346149 
-L 175.438942 200.58638 
-L 175.026832 200.8254 
-L 174.614722 201.063221 
-L 174.202613 201.299854 
-L 173.790503 201.535311 
-L 173.378393 201.769604 
-L 172.966284 202.002744 
-L 172.554174 202.234743 
-L 172.142064 202.465611 
-L 171.729955 202.695361 
-L 171.317845 202.924002 
-L 170.905735 203.151545 
-L 170.493626 203.378 
-L 170.081516 203.603379 
-L 169.669406 203.827691 
-L 169.257297 204.050946 
-L 168.845187 204.273154 
-L 168.433077 204.494325 
-L 168.020968 204.714469 
-L 167.608858 204.933595 
-L 167.196748 205.151712 
-L 166.784639 205.36883 
-L 166.372529 205.584958 
-L 165.960419 205.800104 
-L 165.54831 206.014278 
-L 165.1362 206.227488 
-L 164.72409 206.439744 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 184.505355 195.034276 
+L 184.093245 195.303498 
+L 183.681135 195.571198 
+L 183.269026 195.837394 
+L 182.856916 196.102104 
+L 182.444806 196.365343 
+L 182.032697 196.627128 
+L 181.620587 196.887475 
+L 181.208477 197.146399 
+L 180.796368 197.403917 
+L 180.384258 197.660042 
+L 179.972148 197.914791 
+L 179.560039 198.168177 
+L 179.147929 198.420216 
+L 178.735819 198.670922 
+L 178.323709 198.920308 
+L 177.9116 199.168388 
+L 177.49949 199.415177 
+L 177.08738 199.660687 
+L 176.675271 199.904931 
+L 176.263161 200.147924 
+L 175.851051 200.389676 
+L 175.438942 200.630202 
+L 175.026832 200.869513 
+L 174.614722 201.107621 
+L 174.202613 201.344539 
+L 173.790503 201.580279 
+L 173.378393 201.814852 
+L 172.966284 202.048269 
+L 172.554174 202.280542 
+L 172.142064 202.511682 
+L 171.729955 202.7417 
+L 171.317845 202.970608 
+L 170.905735 203.198414 
+L 170.493626 203.425131 
+L 170.081516 203.650769 
+L 169.669406 203.875337 
+L 169.257297 204.098846 
+L 168.845187 204.321306 
+L 168.433077 204.542726 
+L 168.020968 204.763117 
+L 167.608858 204.982487 
+L 167.196748 205.200846 
+L 166.784639 205.418204 
+L 166.372529 205.63457 
+L 165.960419 205.849952 
+L 165.54831 206.06436 
+L 165.1362 206.277802 
+L 164.72409 206.490287 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 164.72409 206.439744 
-L 164.437149 207.97886 
-L 164.150207 209.469555 
-L 163.863265 210.914786 
-L 163.576324 212.317241 
-L 163.289382 213.679382 
-L 163.00244 215.003461 
-L 162.715499 216.291548 
-L 162.428557 217.545547 
-L 162.141615 218.767217 
-L 161.854674 219.958182 
-L 161.567732 221.119949 
-L 161.28079 222.253914 
-L 160.993849 223.361377 
-L 160.706907 224.44355 
-L 160.419966 225.50156 
-L 160.133024 226.536464 
-L 159.846082 227.54925 
-L 159.559141 228.540842 
-L 159.272199 229.512111 
-L 158.985257 230.463871 
-L 158.698316 231.396893 
-L 158.411374 232.311898 
-L 158.124432 233.20957 
-L 157.837491 234.090554 
-L 157.550549 234.955458 
-L 157.263608 235.804859 
-L 156.976666 236.639302 
-L 156.689724 237.459307 
-L 156.402783 238.265363 
-L 156.115841 239.057938 
-L 155.828899 239.837475 
-L 155.541958 240.604396 
-L 155.255016 241.359102 
-L 154.968074 242.101978 
-L 154.681133 242.833387 
-L 154.394191 243.553679 
-L 154.10725 244.263187 
-L 153.820308 244.962228 
-L 153.533366 245.651108 
-L 153.246425 246.330117 
-L 152.959483 246.999533 
-L 152.672541 247.659626 
-L 152.3856 248.310649 
-L 152.098658 248.95285 
-L 151.811716 249.586465 
-L 151.524775 250.211719 
-L 151.237833 250.828831 
-L 150.950891 251.438009 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 164.72409 206.490287 
+L 164.437149 208.032655 
+L 164.150207 209.526402 
+L 163.863265 210.9745 
+L 163.576324 212.379656 
+L 163.289382 213.744343 
+L 163.00244 215.070829 
+L 162.715499 216.361193 
+L 162.428557 217.61735 
+L 162.141615 218.841068 
+L 161.854674 220.03398 
+L 161.567732 221.197599 
+L 161.28079 222.333329 
+L 160.993849 223.442475 
+L 160.706907 224.526254 
+L 160.419966 225.585801 
+L 160.133024 226.622174 
+L 159.846082 227.636367 
+L 159.559141 228.629309 
+L 159.272199 229.601871 
+L 158.985257 230.554875 
+L 158.698316 231.48909 
+L 158.411374 232.405244 
+L 158.124432 233.304021 
+L 157.837491 234.18607 
+L 157.550549 235.052 
+L 157.263608 235.90239 
+L 156.976666 236.737789 
+L 156.689724 237.558716 
+L 156.402783 238.365663 
+L 156.115841 239.1591 
+L 155.828899 239.93947 
+L 155.541958 240.707198 
+L 155.255016 241.462685 
+L 154.968074 242.206318 
+L 154.681133 242.938461 
+L 154.394191 243.659465 
+L 154.10725 244.369663 
+L 153.820308 245.069374 
+L 153.533366 245.758904 
+L 153.246425 246.438545 
+L 152.959483 247.108577 
+L 152.672541 247.769266 
+L 152.3856 248.420871 
+L 152.098658 249.063638 
+L 151.811716 249.697803 
+L 151.524775 250.323593 
+L 151.237833 250.941227 
+L 150.950891 251.550915 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 251.438009 
-L 149.855015 254.452662 
-L 148.759139 257.286954 
-L 147.663262 259.961252 
-L 146.567386 262.49266 
-L 145.471509 264.895674 
-L 144.375633 267.182693 
-L 143.279756 269.364402 
-L 142.18388 271.450074 
-L 141.088003 273.447808 
-L 139.992127 275.36472 
-L 138.89625 277.207097 
-L 137.800374 278.980519 
-L 136.704498 280.689962 
-L 135.608621 282.339881 
-L 134.512745 283.934283 
-L 133.416868 285.476782 
-L 132.320992 286.970653 
-L 131.225115 288.418866 
-L 130.129239 289.824131 
-L 129.033362 291.188922 
-L 127.937486 292.515504 
-L 126.84161 293.80596 
-L 125.745733 295.062205 
-L 124.649857 296.286006 
-L 123.55398 297.478996 
-L 122.458104 298.64269 
-L 121.362227 299.778491 
-L 120.266351 300.887705 
-L 119.170474 301.971549 
-L 118.074598 303.031158 
-L 116.978721 304.067591 
-L 115.882845 305.08184 
-L 114.786969 306.074836 
-L 113.691092 307.047451 
-L 112.595216 308.000505 
-L 111.499339 308.934768 
-L 110.403463 309.850969 
-L 109.307586 310.749791 
-L 108.21171 311.631882 
-L 107.115833 312.497853 
-L 106.019957 313.348284 
-L 104.92408 314.183721 
-L 103.828204 315.004685 
-L 102.732328 315.811669 
-L 101.636451 316.60514 
-L 100.540575 317.385544 
-L 99.444698 318.153304 
-L 98.348822 318.908823 
-" clip-path="url(#p14f9c3d880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 251.550915 
+L 150.28498 252.749802 
+L 149.619069 253.919105 
+L 148.953158 255.060249 
+L 148.287246 256.174559 
+L 147.621335 257.263268 
+L 146.955424 258.327526 
+L 146.289513 259.368406 
+L 145.623601 260.386915 
+L 144.95769 261.383992 
+L 144.291779 262.360523 
+L 143.625868 263.317336 
+L 142.959956 264.255212 
+L 142.294045 265.174886 
+L 141.628134 266.077051 
+L 140.962223 266.962361 
+L 140.296311 267.831435 
+L 139.6304 268.684858 
+L 138.964489 269.523183 
+L 138.298578 270.346935 
+L 137.632666 271.156612 
+L 136.966755 271.952687 
+L 136.300844 272.73561 
+L 135.634933 273.505808 
+L 134.969021 274.263688 
+L 134.30311 275.009637 
+L 133.637199 275.744027 
+L 132.971288 276.467209 
+L 132.305376 277.179521 
+L 131.639465 277.881283 
+L 130.973554 278.572806 
+L 130.307643 279.254382 
+L 129.641731 279.926294 
+L 128.97582 280.588812 
+L 128.309909 281.242196 
+L 127.643998 281.886693 
+L 126.978086 282.522543 
+L 126.312175 283.149973 
+L 125.646264 283.769205 
+L 124.980353 284.38045 
+L 124.314441 284.983911 
+L 123.64853 285.579783 
+L 122.982619 286.168256 
+L 122.316708 286.749511 
+L 121.650796 287.323723 
+L 120.984885 287.89106 
+L 120.318974 288.451685 
+L 119.653063 289.005756 
+L 118.987151 289.553423 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_160">
+    <path d="M 118.987151 289.553423 
+L 118.557186 290.371112 
+L 118.127221 291.174931 
+L 117.697256 291.965342 
+L 117.267291 292.742786 
+L 116.837325 293.507681 
+L 116.40736 294.260425 
+L 115.977395 295.0014 
+L 115.54743 295.730966 
+L 115.117465 296.449471 
+L 114.687499 297.157245 
+L 114.257534 297.854603 
+L 113.827569 298.541847 
+L 113.397604 299.219267 
+L 112.967639 299.88714 
+L 112.537673 300.545731 
+L 112.107708 301.195294 
+L 111.677743 301.836074 
+L 111.247778 302.468305 
+L 110.817813 303.092212 
+L 110.387847 303.708012 
+L 109.957882 304.315912 
+L 109.527917 304.916112 
+L 109.097952 305.508806 
+L 108.667987 306.094178 
+L 108.238021 306.672408 
+L 107.808056 307.243667 
+L 107.378091 307.808121 
+L 106.948126 308.365932 
+L 106.518161 308.917253 
+L 106.088195 309.462233 
+L 105.65823 310.001017 
+L 105.228265 310.533745 
+L 104.7983 311.06055 
+L 104.368335 311.581563 
+L 103.938369 312.09691 
+L 103.508404 312.606713 
+L 103.078439 313.11109 
+L 102.648474 313.610155 
+L 102.218509 314.104019 
+L 101.788543 314.59279 
+L 101.358578 315.07657 
+L 100.928613 315.555462 
+L 100.498648 316.029562 
+L 100.068683 316.498967 
+L 99.638717 316.963767 
+L 99.208752 317.424053 
+L 98.778787 317.87991 
+L 98.348822 318.331425 
+" clip-path="url(#p8e9461a457)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6209,9 +6254,19 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.611875 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.987891 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -6221,6 +6276,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6293,41 +6373,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6363,19 +6408,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6414,109 +6459,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p14f9c3d880">
+  <clipPath id="p8e9461a457">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p346f9e4456)">
+   <g clip-path="url(#p636b4500a2)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagee78e607fec" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image6e773911cf" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me9209b34ad" d="M 0 0 
+       <path id="mcee7424c8a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9209b34ad" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me9209b34ad" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me9209b34ad" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me9209b34ad" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me9209b34ad" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me9209b34ad" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me9209b34ad" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me9209b34ad" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me9209b34ad" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me9209b34ad" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me9209b34ad" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcee7424c8a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mbb3720818b" d="M 0 0 
+       <path id="m343c070100" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbb3720818b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m343c070100" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagef52552f2f6" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec2bdf091f1" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="ma9a7d59937" d="M 0 0 
+       <path id="mc9314f814c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma9a7d59937" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc9314f814c" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.987891 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2948,19 +2948,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p346f9e4456">
+  <clipPath id="p636b4500a2">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.17625pt" height="386.202469pt" viewBox="0 0 569.17625 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.424219pt" height="386.202469pt" viewBox="0 0 570.424219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M -0 386.202469 
-L 569.17625 386.202469 
-L 569.17625 0 
+L 570.424219 386.202469 
+L 570.424219 0 
 L -0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.713125 104.1264 
-L 291.338125 104.1264 
-L 291.338125 74.7432 
-L 186.713125 74.7432 
+    <path d="M 187.337109 104.1264 
+L 291.962109 104.1264 
+L 291.962109 74.7432 
+L 187.337109 74.7432 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.338125 104.1264 
-L 395.963125 104.1264 
-L 395.963125 74.7432 
-L 291.338125 74.7432 
+    <path d="M 291.962109 104.1264 
+L 396.587109 104.1264 
+L 396.587109 74.7432 
+L 291.962109 74.7432 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.963125 104.1264 
-L 500.588125 104.1264 
-L 500.588125 74.7432 
-L 395.963125 74.7432 
+    <path d="M 396.587109 104.1264 
+L 501.212109 104.1264 
+L 501.212109 74.7432 
+L 396.587109 74.7432 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.713125 133.5096 
-L 291.338125 133.5096 
-L 291.338125 104.1264 
-L 186.713125 104.1264 
+    <path d="M 187.337109 133.5096 
+L 291.962109 133.5096 
+L 291.962109 104.1264 
+L 187.337109 104.1264 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.338125 133.5096 
-L 395.963125 133.5096 
-L 395.963125 104.1264 
-L 291.338125 104.1264 
+    <path d="M 291.962109 133.5096 
+L 396.587109 133.5096 
+L 396.587109 104.1264 
+L 291.962109 104.1264 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.963125 133.5096 
-L 500.588125 133.5096 
-L 500.588125 104.1264 
-L 395.963125 104.1264 
+    <path d="M 396.587109 133.5096 
+L 501.212109 133.5096 
+L 501.212109 104.1264 
+L 396.587109 104.1264 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.713125 162.8928 
-L 291.338125 162.8928 
-L 291.338125 133.5096 
-L 186.713125 133.5096 
+    <path d="M 187.337109 162.8928 
+L 291.962109 162.8928 
+L 291.962109 133.5096 
+L 187.337109 133.5096 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.338125 162.8928 
-L 395.963125 162.8928 
-L 395.963125 133.5096 
-L 291.338125 133.5096 
+    <path d="M 291.962109 162.8928 
+L 396.587109 162.8928 
+L 396.587109 133.5096 
+L 291.962109 133.5096 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.963125 162.8928 
-L 500.588125 162.8928 
-L 500.588125 133.5096 
-L 395.963125 133.5096 
+    <path d="M 396.587109 162.8928 
+L 501.212109 162.8928 
+L 501.212109 133.5096 
+L 396.587109 133.5096 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.713125 192.276 
-L 291.338125 192.276 
-L 291.338125 162.8928 
-L 186.713125 162.8928 
+    <path d="M 187.337109 192.276 
+L 291.962109 192.276 
+L 291.962109 162.8928 
+L 187.337109 162.8928 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.338125 192.276 
-L 395.963125 192.276 
-L 395.963125 162.8928 
-L 291.338125 162.8928 
+    <path d="M 291.962109 192.276 
+L 396.587109 192.276 
+L 396.587109 162.8928 
+L 291.962109 162.8928 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.963125 192.276 
-L 500.588125 192.276 
-L 500.588125 162.8928 
-L 395.963125 162.8928 
+    <path d="M 396.587109 192.276 
+L 501.212109 192.276 
+L 501.212109 162.8928 
+L 396.587109 162.8928 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.713125 221.6592 
-L 291.338125 221.6592 
-L 291.338125 192.276 
-L 186.713125 192.276 
+    <path d="M 187.337109 221.6592 
+L 291.962109 221.6592 
+L 291.962109 192.276 
+L 187.337109 192.276 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.338125 221.6592 
-L 395.963125 221.6592 
-L 395.963125 192.276 
-L 291.338125 192.276 
+    <path d="M 291.962109 221.6592 
+L 396.587109 221.6592 
+L 396.587109 192.276 
+L 291.962109 192.276 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.963125 221.6592 
-L 500.588125 221.6592 
-L 500.588125 192.276 
-L 395.963125 192.276 
+    <path d="M 396.587109 221.6592 
+L 501.212109 221.6592 
+L 501.212109 192.276 
+L 396.587109 192.276 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.713125 251.0424 
-L 291.338125 251.0424 
-L 291.338125 221.6592 
-L 186.713125 221.6592 
+    <path d="M 187.337109 251.0424 
+L 291.962109 251.0424 
+L 291.962109 221.6592 
+L 187.337109 221.6592 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.338125 251.0424 
-L 395.963125 251.0424 
-L 395.963125 221.6592 
-L 291.338125 221.6592 
+    <path d="M 291.962109 251.0424 
+L 396.587109 251.0424 
+L 396.587109 221.6592 
+L 291.962109 221.6592 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.963125 251.0424 
-L 500.588125 251.0424 
-L 500.588125 221.6592 
-L 395.963125 221.6592 
+    <path d="M 396.587109 251.0424 
+L 501.212109 251.0424 
+L 501.212109 221.6592 
+L 396.587109 221.6592 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.713125 280.4256 
-L 291.338125 280.4256 
-L 291.338125 251.0424 
-L 186.713125 251.0424 
+    <path d="M 187.337109 280.4256 
+L 291.962109 280.4256 
+L 291.962109 251.0424 
+L 187.337109 251.0424 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.338125 280.4256 
-L 395.963125 280.4256 
-L 395.963125 251.0424 
-L 291.338125 251.0424 
+    <path d="M 291.962109 280.4256 
+L 396.587109 280.4256 
+L 396.587109 251.0424 
+L 291.962109 251.0424 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.963125 280.4256 
-L 500.588125 280.4256 
-L 500.588125 251.0424 
-L 395.963125 251.0424 
+    <path d="M 396.587109 280.4256 
+L 501.212109 280.4256 
+L 501.212109 251.0424 
+L 396.587109 251.0424 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.713125 309.8088 
-L 291.338125 309.8088 
-L 291.338125 280.4256 
-L 186.713125 280.4256 
+    <path d="M 187.337109 309.8088 
+L 291.962109 309.8088 
+L 291.962109 280.4256 
+L 187.337109 280.4256 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.338125 309.8088 
-L 395.963125 309.8088 
-L 395.963125 280.4256 
-L 291.338125 280.4256 
+    <path d="M 291.962109 309.8088 
+L 396.587109 309.8088 
+L 396.587109 280.4256 
+L 291.962109 280.4256 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.963125 309.8088 
-L 500.588125 309.8088 
-L 500.588125 280.4256 
-L 395.963125 280.4256 
+    <path d="M 396.587109 309.8088 
+L 501.212109 309.8088 
+L 501.212109 280.4256 
+L 396.587109 280.4256 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.713125 339.192 
-L 291.338125 339.192 
-L 291.338125 309.8088 
-L 186.713125 309.8088 
+    <path d="M 187.337109 339.192 
+L 291.962109 339.192 
+L 291.962109 309.8088 
+L 187.337109 309.8088 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.338125 339.192 
-L 395.963125 339.192 
-L 395.963125 309.8088 
-L 291.338125 309.8088 
+    <path d="M 291.962109 339.192 
+L 396.587109 339.192 
+L 396.587109 309.8088 
+L 291.962109 309.8088 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.963125 339.192 
-L 500.588125 339.192 
-L 500.588125 309.8088 
-L 395.963125 309.8088 
+    <path d="M 396.587109 339.192 
+L 501.212109 339.192 
+L 501.212109 309.8088 
+L 396.587109 309.8088 
 z
-" clip-path="url(#p0ec17fb101)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c9ec3cb87)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.700391 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.324375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.984609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.608594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.556719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.180703 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.908437 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.532422 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.638125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.262109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.574375 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.015625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.639609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.640625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.27625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.900234 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.574375 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.560625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.640625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.539375 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.163359 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.574375 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.560625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.640625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.845625 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.469609 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.574375 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.560625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.640625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.001875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.625859 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.574375 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.560625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.640625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.3475 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.971484 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.37375 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.997734 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(338.084375 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.708359 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,32 +1755,16 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 211 -->
-    <g transform="translate(439.92625 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 205 -->
+    <g transform="translate(440.550234 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.4625 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.086484 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1909,7 +1893,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.574375 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1919,14 +1903,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.560625 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.640625 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1934,7 +1918,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.969375 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.593359 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1990,7 +1974,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.574375 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2000,21 +1984,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.560625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.185625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.809609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.68375 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.307734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2025,7 +2009,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.574375 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2035,13 +2019,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.105625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.729609 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.275625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.899609 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2057,7 +2041,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.096875 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.720859 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2270,7 +2254,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2406,19 +2390,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2457,110 +2441,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0ec17fb101">
-   <rect x="82.088125" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p2c9ec3cb87">
+   <rect x="82.712109" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p658f00267e)">
+   <g clip-path="url(#p68d1dba960)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ50lEQVR4nO3XsY6lYwDH4TkzZ2fX2GWxRpBsNKhIhErjDhQuQ6nVK9VavRtQEZVEhI6OoGA3hN3FzJyZM65AtXl/78yX57mC/8n3fef9vavt7x+f7yzZ5mj2Ah7G9nT2grFWu7MXjHV6MnvBWAc3Zy8Y6/jB7AVj7e3PXsDDWPr7uX8we8FQCz/9AAC4aAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp9debH2dvGGq9uzd7wlDb8/PZE4Y6vHE4e8JQP977efaEsRZ+xX3p2s3ZE4baXN2fPWGob+58N3vCUK/eenH2hKGO97ezJwy1Wv0ze8JQCz8eAAC4aAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp9+8YLszcMdfPq4ewJQ909+mX2hKGe+2fZd6TrT70ye8JQe6v17AlDbXe2sycM9fTOrdkThjq9dTJ7wlDPHNyePWGozXbZz+/Rk2X/vyz7dAcA4MIRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNar1bIb9P7mj9kThnpk7/rsCUOdPfXk7AlD/frXt7MnDPXg5Gj2hKFef+KN2ROGOtmbvWCsvzf3Z0/gIfx5fGf2hLGuHs5eMNSy6xMAgAtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFqdffHe+ewRQ223sxfA/9t1B7zU/L9cbkv//pb+fnp+l9rCnx4AABeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILV+5qvvZ28Yane97Ma+893d2ROG+ujd12ZPGOqDL3+bPWGot24/PnvCUJ98/sPsCUO9/87LsycM9eFnP82eMNTbrz07e8JQP/11PHvCUG8+/+jsCUMtu84AALhwBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAarU5+/R89oiR9k5PZ08Ya3c9e8FYp0ezF4y1fzB7wVirhd9xz7ezF4y18f1damfLPv82q2V/f1cW3i8LPx0AALhoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn12fnp7A1D7V25NnvCUIt/fv/emz1hqKP1su+A13aX/f3tnJ7MXjDWwn/fvdXR7AlDPbZzMHvCUFd217MnjLVZ9vu57NMPAIALR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJD6D73JfrYxDoK3AAAAAElFTkSuQmCC" id="image3c05d5abb7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ5klEQVR4nO3YPW5cVQCGYY89cUJ+RCAhESBFNEAFUgQVDTugYBmUtPSU1LT0bIAKRIWEEHShIwoUkAhEfgiOxx6zAqrovMe5ep4VfNKZc+97Z7X984uTnSXbHMxewNPYHs1eMNZqd/aCsY4OZy8Y6/zl2QvGevJo9oKx9vZnL+BpLP33uX9+9oKhFv72AwDgtBGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk1j9sbs/eMNR6d2/2hKG2JyezJwx17dK12ROGuv3g19kTxlr4J+4b5y7PnjDU5uz+7AlD/Xj31uwJQ7199fXZE4Z6sr+dPWGo1erx7AlDLfz1AADAaSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFLrG5dem71hqMtnr82eMNS9g99mTxjqlcfL/ka6eOWt2ROG2lutZ08YaruznT1hqJd2rs6eMNTR1cPZE4a6fv7G7AlDbbbLPr8Lh8t+viz77Q4AwKkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1Xq2U36MPNX7MnDPXc3sXZE4Y6vvLi7AlD/X7/p9kThnp0eDB7wlDvvPDu7AlDHe7NXjDWP5uHsyfwFP5+cnf2hLHOXpu9YKhl1ycAAKeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU6/vbjk9kjhtpuZy+A/7frG/CZ5vnybFv6/Vv679P5PdMWfnoAAJw2AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT6+vc/z94w1O562Y1999a92ROG+vyjm7MnDPXpd3/MnjDU+zeenz1hqC+/+WX2hKE++fDN2ROG+uzrO7MnDPXBzZdnTxjqzv0nsycM9d6rF2ZPGGrZdQYAwKkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSq83xVyezR4y0d3Q0e8JYu+vZC8Y6Opi9YKz987MXjLVa+DfuyXb2grE27t8z7XjZ77/Natn378zC+2XhbwcAAE4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp9fHI0e8NQe2fOzZ4w1OLP798HsycMdXhmPXvCUPurZd+/naPD2QvG2hzMXjDUo9Wyz+/izrLv35ndZT8/l37//AMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkPoPt3p+taQI3WsAAAAASUVORK5CYII=" id="image741a64997c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m83d6319e56" d="M 0 0 
+       <path id="m5e826c16ba" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m83d6319e56" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m83d6319e56" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m83d6319e56" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m83d6319e56" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m83d6319e56" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m83d6319e56" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m83d6319e56" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m83d6319e56" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m83d6319e56" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m83d6319e56" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m83d6319e56" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m83d6319e56" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e826c16ba" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m3bf9415f65" d="M 0 0 
+       <path id="m11d566cfe4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3bf9415f65" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11d566cfe4" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +12 -->
+    <!-- +11 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1170,84 +1170,78 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -1 -->
+    <!-- -0 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- +6 -->
+    <!-- +5 -->
     <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -31 -->
+    <!-- -32 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1282,135 +1276,120 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +12 -->
+    <!-- +11 -->
     <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
     <!-- -10 -->
     <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -21 -->
+    <!-- -22 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- +24 -->
+    <!-- +21 -->
     <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -11 -->
+    <!-- -12 -->
     <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -5 -->
+    <!-- -6 -->
     <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1833,6 +1812,27 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2193,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image56645b04d8" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image8f62d910a1" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m02d55240a4" d="M 0 0 
+       <path id="m04e6e01482" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m02d55240a4" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m04e6e01482" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.611875 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.987891 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2997,19 +2997,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p658f00267e">
+  <clipPath id="p68d1dba960">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="meea3c14122" d="M 0 0 
+       <path id="m1d0d4cfd13" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#meea3c14122" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#meea3c14122" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#meea3c14122" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#meea3c14122" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#meea3c14122" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#meea3c14122" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#meea3c14122" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d0d4cfd13" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf49654e385" d="M 0 0 
+       <path id="mcb1b94f820" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf49654e385" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb1b94f820" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf49654e385" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb1b94f820" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf49654e385" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb1b94f820" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m849dcf40d0" d="M 0 0 
+       <path id="m0e3d64fc0b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m849dcf40d0" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0e3d64fc0b" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 144.107129) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 144.783068) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1363,42 +1363,34 @@ z
     </g>
    </g>
    <g id="text_14">
-    <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 334.014613) scale(0.07 -0.07)">
+    <!-- L10 -->
+    <g style="fill: #d62728" transform="translate(100.319203 333.295028) scale(0.07 -0.07)">
      <defs>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
 z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-4c"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(63.720703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(133.300781 0)"/>
     </g>
    </g>
    <g id="text_15">
@@ -1694,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m632e8cdad7" d="M -2.5 2.5 
+     <path id="ma2b8ab26d5" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#m632e8cdad7" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m632e8cdad7" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#ma2b8ab26d5" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma2b8ab26d5" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1763,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1815,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1867,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1919,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1971,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2023,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2075,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2127,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m445c51c97c" d="M 0 -2.5 
+     <path id="m0000dc5d53" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#m445c51c97c" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m445c51c97c" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m0000dc5d53" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0000dc5d53" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2199,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2251,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2303,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2355,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2407,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2459,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2511,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2563,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m99692eaeda" d="M -0 3.535534 
+     <path id="m37c882bce9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#m99692eaeda" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m99692eaeda" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m37c882bce9" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m37c882bce9" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2639,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2691,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2743,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2795,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2847,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2899,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2951,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -3003,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3055,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3107,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3159,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="md732a8e3a7" d="M -0 2.5 
+     <path id="m6e14f220c2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#md732a8e3a7" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m6e14f220c2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m4254c73284" d="M -0.833333 2.5 
+     <path id="m65f34b8803" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3190,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#m4254c73284" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4254c73284" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m65f34b8803" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m65f34b8803" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3252,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3304,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3356,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3408,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3460,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3512,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3564,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3616,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mee42a8d87a" d="M -1.25 2.5 
+     <path id="m40dc7baa84" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3635,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#mee42a8d87a" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee42a8d87a" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m40dc7baa84" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40dc7baa84" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3697,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3749,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3801,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3853,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3905,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3957,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4009,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4061,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="maf747545ca" d="M 0 -2.5 
+     <path id="m78b624c6c7" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4078,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#maf747545ca" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#maf747545ca" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#m78b624c6c7" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m78b624c6c7" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4140,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4192,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4244,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4296,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4348,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4400,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4452,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4504,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m4d5955b153" d="M 0 -2.5 
+     <path id="mb89e626028" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4517,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#m4d5955b153" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d5955b153" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#mb89e626028" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb89e626028" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4579,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4631,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4683,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4735,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4787,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4839,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4891,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4943,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4961,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="mae930104a8" d="M 0 3.5 
+      <path id="ma81472b054" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4974,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mae930104a8" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma81472b054" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5033,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m632e8cdad7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma2b8ab26d5" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5047,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m445c51c97c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0000dc5d53" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5092,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m99692eaeda" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m37c882bce9" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5135,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#md732a8e3a7" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6e14f220c2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5151,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m4254c73284" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m65f34b8803" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5205,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mee42a8d87a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m40dc7baa84" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5270,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#maf747545ca" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m78b624c6c7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5308,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m4d5955b153" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb89e626028" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5378,433 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p66bcfd2819)">
-     <use xlink:href="#mae930104a8" x="257.531237" y="149.107129" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="236.23654" y="153.82467" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="222.073314" y="158.324086" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="202.315941" y="169.281009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="199.905291" y="170.980798" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="195.893147" y="175.179401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="187.210062" y="188.875151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="157.246106" y="245.372702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mae930104a8" x="95.319203" y="339.014613" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3dee5a5a57)">
+     <use xlink:href="#ma81472b054" x="257.531237" y="149.783068" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="236.23654" y="154.51841" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="222.073314" y="159.144699" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="202.315941" y="169.586969" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="199.905291" y="171.340479" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="195.893147" y="175.470255" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="187.210062" y="189.250823" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="157.246106" y="245.32268" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="123.427553" y="302.210563" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma81472b054" x="95.319203" y="338.295028" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 257.531237 149.107129 
-L 257.087598 149.209724 
-L 256.643958 149.312126 
-L 256.200319 149.414334 
-L 255.756679 149.51635 
-L 255.31304 149.618173 
-L 254.8694 149.719805 
-L 254.425761 149.821247 
-L 253.982121 149.922499 
-L 253.538482 150.023562 
-L 253.094842 150.124437 
-L 252.651203 150.225124 
-L 252.207563 150.325624 
-L 251.763924 150.425937 
-L 251.320284 150.526065 
-L 250.876645 150.626008 
-L 250.433005 150.725767 
-L 249.989365 150.825343 
-L 249.545726 150.924735 
-L 249.102086 151.023945 
-L 248.658447 151.122974 
-L 248.214807 151.221822 
-L 247.771168 151.32049 
-L 247.327528 151.418978 
-L 246.883889 151.517287 
-L 246.440249 151.615418 
-L 245.99661 151.713371 
-L 245.55297 151.811147 
-L 245.109331 151.908747 
-L 244.665691 152.006172 
-L 244.222052 152.103421 
-L 243.778412 152.200496 
-L 243.334773 152.297397 
-L 242.891133 152.394124 
-L 242.447494 152.49068 
-L 242.003854 152.587063 
-L 241.560215 152.683275 
-L 241.116575 152.779316 
-L 240.672936 152.875187 
-L 240.229296 152.970888 
-L 239.785656 153.066421 
-L 239.342017 153.161785 
-L 238.898377 153.256981 
-L 238.454738 153.352011 
-L 238.011098 153.446873 
-L 237.567459 153.54157 
-L 237.123819 153.636101 
-L 236.68018 153.730468 
-L 236.23654 153.82467 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 257.531237 149.783068 
+L 257.087598 149.886068 
+L 256.643958 149.988872 
+L 256.200319 150.091481 
+L 255.756679 150.193896 
+L 255.31304 150.296117 
+L 254.8694 150.398146 
+L 254.425761 150.499982 
+L 253.982121 150.601628 
+L 253.538482 150.703083 
+L 253.094842 150.804348 
+L 252.651203 150.905424 
+L 252.207563 151.006311 
+L 251.763924 151.107011 
+L 251.320284 151.207524 
+L 250.876645 151.30785 
+L 250.433005 151.407991 
+L 249.989365 151.507947 
+L 249.545726 151.607718 
+L 249.102086 151.707306 
+L 248.658447 151.806711 
+L 248.214807 151.905934 
+L 247.771168 152.004975 
+L 247.327528 152.103835 
+L 246.883889 152.202515 
+L 246.440249 152.301016 
+L 245.99661 152.399337 
+L 245.55297 152.49748 
+L 245.109331 152.595446 
+L 244.665691 152.693234 
+L 244.222052 152.790846 
+L 243.778412 152.888282 
+L 243.334773 152.985544 
+L 242.891133 153.08263 
+L 242.447494 153.179543 
+L 242.003854 153.276283 
+L 241.560215 153.37285 
+L 241.116575 153.469245 
+L 240.672936 153.565469 
+L 240.229296 153.661521 
+L 239.785656 153.757404 
+L 239.342017 153.853117 
+L 238.898377 153.948661 
+L 238.454738 154.044037 
+L 238.011098 154.139245 
+L 237.567459 154.234286 
+L 237.123819 154.32916 
+L 236.68018 154.423868 
+L 236.23654 154.51841 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 236.23654 153.82467 
-L 235.941473 153.922327 
-L 235.646406 154.019807 
-L 235.351339 154.117113 
-L 235.056271 154.214244 
-L 234.761204 154.3112 
-L 234.466137 154.407984 
-L 234.17107 154.504594 
-L 233.876003 154.601033 
-L 233.580935 154.6973 
-L 233.285868 154.793396 
-L 232.990801 154.889321 
-L 232.695734 154.985077 
-L 232.400667 155.080664 
-L 232.105599 155.176082 
-L 231.810532 155.271333 
-L 231.515465 155.366416 
-L 231.220398 155.461332 
-L 230.92533 155.556082 
-L 230.630263 155.650666 
-L 230.335196 155.745086 
-L 230.040129 155.839341 
-L 229.745062 155.933432 
-L 229.449994 156.02736 
-L 229.154927 156.121125 
-L 228.85986 156.214728 
-L 228.564793 156.308169 
-L 228.269726 156.401449 
-L 227.974658 156.494569 
-L 227.679591 156.587529 
-L 227.384524 156.680329 
-L 227.089457 156.77297 
-L 226.794389 156.865454 
-L 226.499322 156.957779 
-L 226.204255 157.049947 
-L 225.909188 157.141959 
-L 225.614121 157.233814 
-L 225.319053 157.325514 
-L 225.023986 157.417058 
-L 224.728919 157.508448 
-L 224.433852 157.599684 
-L 224.138785 157.690766 
-L 223.843717 157.781695 
-L 223.54865 157.872472 
-L 223.253583 157.963097 
-L 222.958516 158.05357 
-L 222.663449 158.143892 
-L 222.368381 158.234064 
-L 222.073314 158.324086 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 236.23654 154.51841 
+L 235.941473 154.618937 
+L 235.646406 154.719278 
+L 235.351339 154.819433 
+L 235.056271 154.919403 
+L 234.761204 155.019189 
+L 234.466137 155.118791 
+L 234.17107 155.21821 
+L 233.876003 155.317446 
+L 233.580935 155.416501 
+L 233.285868 155.515376 
+L 232.990801 155.614069 
+L 232.695734 155.712583 
+L 232.400667 155.810919 
+L 232.105599 155.909075 
+L 231.810532 156.007054 
+L 231.515465 156.104856 
+L 231.220398 156.202482 
+L 230.92533 156.299932 
+L 230.630263 156.397206 
+L 230.335196 156.494306 
+L 230.040129 156.591233 
+L 229.745062 156.687985 
+L 229.449994 156.784566 
+L 229.154927 156.880974 
+L 228.85986 156.977211 
+L 228.564793 157.073277 
+L 228.269726 157.169172 
+L 227.974658 157.264898 
+L 227.679591 157.360455 
+L 227.384524 157.455844 
+L 227.089457 157.551065 
+L 226.794389 157.646118 
+L 226.499322 157.741005 
+L 226.204255 157.835726 
+L 225.909188 157.930281 
+L 225.614121 158.024672 
+L 225.319053 158.118898 
+L 225.023986 158.21296 
+L 224.728919 158.306859 
+L 224.433852 158.400595 
+L 224.138785 158.49417 
+L 223.843717 158.587583 
+L 223.54865 158.680834 
+L 223.253583 158.773926 
+L 222.958516 158.866857 
+L 222.663449 158.95963 
+L 222.368381 159.052243 
+L 222.073314 159.144699 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 222.073314 158.324086 
-L 221.661702 158.576515 
-L 221.25009 158.827772 
-L 220.838478 159.077869 
-L 220.426866 159.326814 
-L 220.015254 159.57462 
-L 219.603642 159.821296 
-L 219.19203 160.066853 
-L 218.780418 160.311301 
-L 218.368807 160.55465 
-L 217.957195 160.796909 
-L 217.545583 161.038089 
-L 217.133971 161.278198 
-L 216.722359 161.517247 
-L 216.310747 161.755245 
-L 215.899135 161.992201 
-L 215.487523 162.228123 
-L 215.075911 162.463022 
-L 214.664299 162.696906 
-L 214.252687 162.929783 
-L 213.841075 163.161662 
-L 213.429463 163.392552 
-L 213.017851 163.622461 
-L 212.606239 163.851398 
-L 212.194627 164.07937 
-L 211.783015 164.306386 
-L 211.371403 164.532453 
-L 210.959791 164.75758 
-L 210.54818 164.981775 
-L 210.136568 165.205044 
-L 209.724956 165.427397 
-L 209.313344 165.648839 
-L 208.901732 165.869379 
-L 208.49012 166.089024 
-L 208.078508 166.307781 
-L 207.666896 166.525658 
-L 207.255284 166.74266 
-L 206.843672 166.958796 
-L 206.43206 167.174073 
-L 206.020448 167.388496 
-L 205.608836 167.602073 
-L 205.197224 167.814811 
-L 204.785612 168.026716 
-L 204.374 168.237794 
-L 203.962388 168.448052 
-L 203.550776 168.657496 
-L 203.139164 168.866133 
-L 202.727553 169.073969 
-L 202.315941 169.281009 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 222.073314 159.144699 
+L 221.661702 159.384121 
+L 221.25009 159.622489 
+L 220.838478 159.859812 
+L 220.426866 160.096099 
+L 220.015254 160.331358 
+L 219.603642 160.565599 
+L 219.19203 160.798831 
+L 218.780418 161.031061 
+L 218.368807 161.2623 
+L 217.957195 161.492555 
+L 217.545583 161.721834 
+L 217.133971 161.950146 
+L 216.722359 162.177498 
+L 216.310747 162.4039 
+L 215.899135 162.629359 
+L 215.487523 162.853882 
+L 215.075911 163.077477 
+L 214.664299 163.300153 
+L 214.252687 163.521915 
+L 213.841075 163.742773 
+L 213.429463 163.962734 
+L 213.017851 164.181804 
+L 212.606239 164.39999 
+L 212.194627 164.617301 
+L 211.783015 164.833742 
+L 211.371403 165.049322 
+L 210.959791 165.264046 
+L 210.54818 165.477921 
+L 210.136568 165.690954 
+L 209.724956 165.903152 
+L 209.313344 166.114522 
+L 208.901732 166.325069 
+L 208.49012 166.5348 
+L 208.078508 166.743721 
+L 207.666896 166.951839 
+L 207.255284 167.15916 
+L 206.843672 167.365689 
+L 206.43206 167.571434 
+L 206.020448 167.776399 
+L 205.608836 167.980591 
+L 205.197224 168.184015 
+L 204.785612 168.386677 
+L 204.374 168.588584 
+L 203.962388 168.78974 
+L 203.550776 168.990151 
+L 203.139164 169.189822 
+L 202.727553 169.38876 
+L 202.315941 169.586969 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 202.315941 169.281009 
-L 202.265719 169.316971 
-L 202.215497 169.35291 
-L 202.165275 169.388824 
-L 202.115053 169.424715 
-L 202.064831 169.460582 
-L 202.014609 169.496425 
-L 201.964388 169.532245 
-L 201.914166 169.568041 
-L 201.863944 169.603813 
-L 201.813722 169.639561 
-L 201.7635 169.675286 
-L 201.713278 169.710988 
-L 201.663056 169.746665 
-L 201.612834 169.78232 
-L 201.562613 169.817951 
-L 201.512391 169.853558 
-L 201.462169 169.889142 
-L 201.411947 169.924702 
-L 201.361725 169.96024 
-L 201.311503 169.995754 
-L 201.261281 170.031244 
-L 201.21106 170.066712 
-L 201.160838 170.102156 
-L 201.110616 170.137577 
-L 201.060394 170.172974 
-L 201.010172 170.208349 
-L 200.95995 170.243701 
-L 200.909728 170.279029 
-L 200.859507 170.314334 
-L 200.809285 170.349617 
-L 200.759063 170.384876 
-L 200.708841 170.420113 
-L 200.658619 170.455326 
-L 200.608397 170.490517 
-L 200.558175 170.525685 
-L 200.507953 170.560829 
-L 200.457732 170.595952 
-L 200.40751 170.631051 
-L 200.357288 170.666127 
-L 200.307066 170.701181 
-L 200.256844 170.736212 
-L 200.206622 170.771221 
-L 200.1564 170.806207 
-L 200.106179 170.84117 
-L 200.055957 170.876111 
-L 200.005735 170.911029 
-L 199.955513 170.945925 
-L 199.905291 170.980798 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 202.315941 169.586969 
+L 202.265719 169.624086 
+L 202.215497 169.661177 
+L 202.165275 169.698244 
+L 202.115053 169.735284 
+L 202.064831 169.7723 
+L 202.014609 169.80929 
+L 201.964388 169.846255 
+L 201.914166 169.883194 
+L 201.863944 169.920109 
+L 201.813722 169.956998 
+L 201.7635 169.993862 
+L 201.713278 170.030701 
+L 201.663056 170.067516 
+L 201.612834 170.104305 
+L 201.562613 170.141069 
+L 201.512391 170.177808 
+L 201.462169 170.214522 
+L 201.411947 170.251211 
+L 201.361725 170.287875 
+L 201.311503 170.324515 
+L 201.261281 170.36113 
+L 201.21106 170.39772 
+L 201.160838 170.434285 
+L 201.110616 170.470826 
+L 201.060394 170.507341 
+L 201.010172 170.543833 
+L 200.95995 170.5803 
+L 200.909728 170.616742 
+L 200.859507 170.653159 
+L 200.809285 170.689552 
+L 200.759063 170.725921 
+L 200.708841 170.762265 
+L 200.658619 170.798585 
+L 200.608397 170.834881 
+L 200.558175 170.871152 
+L 200.507953 170.907399 
+L 200.457732 170.943622 
+L 200.40751 170.97982 
+L 200.357288 171.015994 
+L 200.307066 171.052144 
+L 200.256844 171.08827 
+L 200.206622 171.124372 
+L 200.1564 171.16045 
+L 200.106179 171.196504 
+L 200.055957 171.232533 
+L 200.005735 171.268539 
+L 199.955513 171.304521 
+L 199.905291 171.340479 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 199.905291 170.980798 
-L 199.821705 171.071675 
-L 199.738118 171.1624 
-L 199.654532 171.252972 
-L 199.570946 171.343394 
-L 199.487359 171.433665 
-L 199.403773 171.523785 
-L 199.320187 171.613756 
-L 199.2366 171.703577 
-L 199.153014 171.79325 
-L 199.069428 171.882774 
-L 198.985841 171.97215 
-L 198.902255 172.061379 
-L 198.818669 172.150461 
-L 198.735082 172.239396 
-L 198.651496 172.328186 
-L 198.56791 172.41683 
-L 198.484323 172.50533 
-L 198.400737 172.593685 
-L 198.317151 172.681895 
-L 198.233564 172.769963 
-L 198.149978 172.857887 
-L 198.066392 172.945669 
-L 197.982805 173.033308 
-L 197.899219 173.120806 
-L 197.815633 173.208162 
-L 197.732046 173.295378 
-L 197.64846 173.382453 
-L 197.564874 173.469389 
-L 197.481287 173.556185 
-L 197.397701 173.642842 
-L 197.314115 173.729361 
-L 197.230528 173.815741 
-L 197.146942 173.901984 
-L 197.063356 173.98809 
-L 196.979769 174.074058 
-L 196.896183 174.159891 
-L 196.812597 174.245587 
-L 196.72901 174.331148 
-L 196.645424 174.416574 
-L 196.561838 174.501866 
-L 196.478251 174.587023 
-L 196.394665 174.672046 
-L 196.311079 174.756936 
-L 196.227492 174.841693 
-L 196.143906 174.926318 
-L 196.06032 175.01081 
-L 195.976733 175.095171 
-L 195.893147 175.179401 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 171.340479 
+L 199.821705 171.42981 
+L 199.738118 171.518994 
+L 199.654532 171.608031 
+L 199.570946 171.696922 
+L 199.487359 171.785667 
+L 199.403773 171.874267 
+L 199.320187 171.962722 
+L 199.2366 172.051033 
+L 199.153014 172.1392 
+L 199.069428 172.227223 
+L 198.985841 172.315103 
+L 198.902255 172.402841 
+L 198.818669 172.490437 
+L 198.735082 172.577892 
+L 198.651496 172.665205 
+L 198.56791 172.752378 
+L 198.484323 172.839411 
+L 198.400737 172.926303 
+L 198.317151 173.013057 
+L 198.233564 173.099671 
+L 198.149978 173.186148 
+L 198.066392 173.272486 
+L 197.982805 173.358687 
+L 197.899219 173.44475 
+L 197.815633 173.530677 
+L 197.732046 173.616468 
+L 197.64846 173.702123 
+L 197.564874 173.787643 
+L 197.481287 173.873028 
+L 197.397701 173.958278 
+L 197.314115 174.043394 
+L 197.230528 174.128377 
+L 197.146942 174.213226 
+L 197.063356 174.297942 
+L 196.979769 174.382526 
+L 196.896183 174.466978 
+L 196.812597 174.551299 
+L 196.72901 174.635488 
+L 196.645424 174.719547 
+L 196.561838 174.803475 
+L 196.478251 174.887273 
+L 196.394665 174.970942 
+L 196.311079 175.054481 
+L 196.227492 175.137892 
+L 196.143906 175.221174 
+L 196.06032 175.304329 
+L 195.976733 175.387356 
+L 195.893147 175.470255 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 195.893147 175.179401 
-L 195.712249 175.503111 
-L 195.531352 175.824897 
-L 195.350454 176.14478 
-L 195.169557 176.462784 
-L 194.988659 176.778931 
-L 194.807761 177.093241 
-L 194.626864 177.405736 
-L 194.445966 177.716437 
-L 194.265069 178.025365 
-L 194.084171 178.332539 
-L 193.903273 178.637979 
-L 193.722376 178.941706 
-L 193.541478 179.243737 
-L 193.360581 179.544092 
-L 193.179683 179.842789 
-L 192.998785 180.139847 
-L 192.817888 180.435282 
-L 192.63699 180.729114 
-L 192.456093 181.021359 
-L 192.275195 181.312035 
-L 192.094297 181.601158 
-L 191.9134 181.888744 
-L 191.732502 182.17481 
-L 191.551605 182.459372 
-L 191.370707 182.742445 
-L 191.189809 183.024045 
-L 191.008912 183.304188 
-L 190.828014 183.582888 
-L 190.647117 183.86016 
-L 190.466219 184.136019 
-L 190.285321 184.410479 
-L 190.104424 184.683554 
-L 189.923526 184.955258 
-L 189.742629 185.225605 
-L 189.561731 185.494607 
-L 189.380833 185.76228 
-L 189.199936 186.028635 
-L 189.019038 186.293685 
-L 188.838141 186.557444 
-L 188.657243 186.819923 
-L 188.476345 187.081136 
-L 188.295448 187.341094 
-L 188.11455 187.599809 
-L 187.933653 187.857293 
-L 187.752755 188.113558 
-L 187.571857 188.368615 
-L 187.39096 188.622475 
-L 187.210062 188.875151 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 195.893147 175.470255 
+L 195.712249 175.79623 
+L 195.531352 176.120253 
+L 195.350454 176.442347 
+L 195.169557 176.762536 
+L 194.988659 177.080841 
+L 194.807761 177.397285 
+L 194.626864 177.71189 
+L 194.445966 178.024676 
+L 194.265069 178.335665 
+L 194.084171 178.644877 
+L 193.903273 178.952332 
+L 193.722376 179.258051 
+L 193.541478 179.562052 
+L 193.360581 179.864355 
+L 193.179683 180.164979 
+L 192.998785 180.463942 
+L 192.817888 180.761262 
+L 192.63699 181.056959 
+L 192.456093 181.351048 
+L 192.275195 181.643547 
+L 192.094297 181.934475 
+L 191.9134 182.223846 
+L 191.732502 182.511679 
+L 191.551605 182.797989 
+L 191.370707 183.082792 
+L 191.189809 183.366104 
+L 191.008912 183.647941 
+L 190.828014 183.928318 
+L 190.647117 184.207249 
+L 190.466219 184.48475 
+L 190.285321 184.760836 
+L 190.104424 185.03552 
+L 189.923526 185.308818 
+L 189.742629 185.580741 
+L 189.561731 185.851306 
+L 189.380833 186.120524 
+L 189.199936 186.38841 
+L 189.019038 186.654977 
+L 188.838141 186.920236 
+L 188.657243 187.184202 
+L 188.476345 187.446887 
+L 188.295448 187.708303 
+L 188.11455 187.968462 
+L 187.933653 188.227377 
+L 187.752755 188.485058 
+L 187.571857 188.741519 
+L 187.39096 188.99677 
+L 187.210062 189.250823 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 187.210062 188.875151 
-L 186.585813 190.911399 
-L 185.961564 192.873803 
-L 185.337315 194.76753 
-L 184.713066 196.597226 
-L 184.088817 198.367079 
-L 183.464568 200.080881 
-L 182.840319 201.742072 
-L 182.21607 203.353788 
-L 181.591821 204.918889 
-L 180.967571 206.439997 
-L 180.343322 207.919518 
-L 179.719073 209.359664 
-L 179.094824 210.762479 
-L 178.470575 212.129848 
-L 177.846326 213.463518 
-L 177.222077 214.76511 
-L 176.597828 216.036133 
-L 175.973579 217.277988 
-L 175.34933 218.491984 
-L 174.725081 219.679344 
-L 174.100832 220.841211 
-L 173.476582 221.978658 
-L 172.852333 223.09269 
-L 172.228084 224.184251 
-L 171.603835 225.25423 
-L 170.979586 226.303464 
-L 170.355337 227.332742 
-L 169.731088 228.342809 
-L 169.106839 229.334369 
-L 168.48259 230.308089 
-L 167.858341 231.264597 
-L 167.234092 232.204494 
-L 166.609843 233.128345 
-L 165.985594 234.036689 
-L 165.361344 234.930039 
-L 164.737095 235.808881 
-L 164.112846 236.67368 
-L 163.488597 237.524876 
-L 162.864348 238.362891 
-L 162.240099 239.188127 
-L 161.61585 240.000969 
-L 160.991601 240.801782 
-L 160.367352 241.590918 
-L 159.743103 242.368712 
-L 159.118854 243.135486 
-L 158.494605 243.891547 
-L 157.870355 244.637191 
-L 157.246106 245.372702 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 187.210062 189.250823 
+L 186.585813 191.2629 
+L 185.961564 193.202845 
+L 185.337315 195.075649 
+L 184.713066 196.885806 
+L 184.088817 198.637372 
+L 183.464568 200.33402 
+L 182.840319 201.97909 
+L 182.21607 203.575625 
+L 181.591821 205.126408 
+L 180.967571 206.633989 
+L 180.343322 208.100708 
+L 179.719073 209.528723 
+L 179.094824 210.920023 
+L 178.470575 212.276451 
+L 177.846326 213.59971 
+L 177.222077 214.891385 
+L 176.597828 216.152948 
+L 175.973579 217.385772 
+L 175.34933 218.591136 
+L 174.725081 219.770237 
+L 174.100832 220.924196 
+L 173.476582 222.054061 
+L 172.852333 223.16082 
+L 172.228084 224.245397 
+L 171.603835 225.308665 
+L 170.979586 226.351445 
+L 170.355337 227.374511 
+L 169.731088 228.378596 
+L 169.106839 229.36439 
+L 168.48259 230.332548 
+L 167.858341 231.28369 
+L 167.234092 232.218404 
+L 166.609843 233.137247 
+L 165.985594 234.040751 
+L 165.361344 234.929417 
+L 164.737095 235.803727 
+L 164.112846 236.664136 
+L 163.488597 237.511079 
+L 162.864348 238.344972 
+L 162.240099 239.166211 
+L 161.61585 239.975173 
+L 160.991601 240.772221 
+L 160.367352 241.557701 
+L 159.743103 242.331943 
+L 159.118854 243.095264 
+L 158.494605 243.847968 
+L 157.870355 244.590347 
+L 157.246106 245.32268 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 245.372702 
-L 155.955963 250.368983 
-L 154.665819 254.942735 
-L 153.375675 259.159885 
-L 152.085531 263.07204 
-L 150.795387 266.720357 
-L 149.505243 270.138183 
-L 148.2151 273.352922 
-L 146.924956 276.387359 
-L 145.634812 279.26065 
-L 144.344668 281.989051 
-L 143.054524 284.586476 
-L 141.76438 287.064926 
-L 140.474237 289.434824 
-L 139.184093 291.705281 
-L 137.893949 293.884308 
-L 136.603805 295.978984 
-L 135.313661 297.995597 
-L 134.023517 299.939756 
-L 132.733374 301.816489 
-L 131.44323 303.630316 
-L 130.153086 305.385317 
-L 128.862942 307.085188 
-L 127.572798 308.733288 
-L 126.282654 310.332678 
-L 124.992511 311.886153 
-L 123.702367 313.396278 
-L 122.412223 314.865405 
-L 121.122079 316.295703 
-L 119.831935 317.68917 
-L 118.541791 319.047657 
-L 117.251648 320.372876 
-L 115.961504 321.666419 
-L 114.67136 322.929763 
-L 113.381216 324.164287 
-L 112.091072 325.371277 
-L 110.800929 326.551934 
-L 109.510785 327.707383 
-L 108.220641 328.838677 
-L 106.930497 329.946806 
-L 105.640353 331.0327 
-L 104.350209 332.097233 
-L 103.060066 333.141229 
-L 101.769922 334.165467 
-L 100.479778 335.170679 
-L 99.189634 336.15756 
-L 97.89949 337.126767 
-L 96.609346 338.078921 
-L 95.319203 339.014613 
-" clip-path="url(#p66bcfd2819)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.246106 245.32268 
+L 156.541553 247.38125 
+L 155.837 249.364376 
+L 155.132447 251.277394 
+L 154.427894 253.125092 
+L 153.72334 254.911784 
+L 153.018787 256.641369 
+L 152.314234 258.317385 
+L 151.609681 259.943052 
+L 150.905128 261.521306 
+L 150.200574 263.054835 
+L 149.496021 264.546104 
+L 148.791468 265.99738 
+L 148.086915 267.410751 
+L 147.382362 268.788148 
+L 146.677808 270.131357 
+L 145.973255 271.442033 
+L 145.268702 272.721716 
+L 144.564149 273.971837 
+L 143.859596 275.193732 
+L 143.155042 276.388646 
+L 142.450489 277.557746 
+L 141.745936 278.702124 
+L 141.041383 279.822803 
+L 140.33683 280.920746 
+L 139.632277 281.996856 
+L 138.927723 283.051984 
+L 138.22317 284.086934 
+L 137.518617 285.102463 
+L 136.814064 286.099286 
+L 136.109511 287.07808 
+L 135.404957 288.039485 
+L 134.700404 288.984109 
+L 133.995851 289.912527 
+L 133.291298 290.825286 
+L 132.586745 291.722905 
+L 131.882191 292.605879 
+L 131.177638 293.474678 
+L 130.473085 294.329749 
+L 129.768532 295.17152 
+L 129.063979 296.000399 
+L 128.359425 296.816773 
+L 127.654872 297.621016 
+L 126.950319 298.413481 
+L 126.245766 299.19451 
+L 125.541213 299.964427 
+L 124.836659 300.723545 
+L 124.132106 301.472161 
+L 123.427553 302.210563 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_152">
+    <path d="M 123.427553 302.210563 
+L 122.841962 303.268909 
+L 122.256372 304.306954 
+L 121.670781 305.325462 
+L 121.08519 306.325156 
+L 120.4996 307.306718 
+L 119.914009 308.270793 
+L 119.328419 309.217994 
+L 118.742828 310.148902 
+L 118.157237 311.064068 
+L 117.571647 311.964014 
+L 116.986056 312.84924 
+L 116.400465 313.720219 
+L 115.814875 314.577402 
+L 115.229284 315.421219 
+L 114.643693 316.252082 
+L 114.058103 317.070381 
+L 113.472512 317.876491 
+L 112.886922 318.67077 
+L 112.301331 319.45356 
+L 111.71574 320.225188 
+L 111.13015 320.985969 
+L 110.544559 321.736204 
+L 109.958968 322.47618 
+L 109.373378 323.206175 
+L 108.787787 323.926453 
+L 108.202197 324.637271 
+L 107.616606 325.338874 
+L 107.031015 326.031498 
+L 106.445425 326.715368 
+L 105.859834 327.390705 
+L 105.274243 328.057718 
+L 104.688653 328.716611 
+L 104.103062 329.367577 
+L 103.517471 330.010807 
+L 102.931881 330.646481 
+L 102.34629 331.274775 
+L 101.7607 331.895858 
+L 101.175109 332.509894 
+L 100.589518 333.117042 
+L 100.003928 333.717453 
+L 99.418337 334.311277 
+L 98.832746 334.898655 
+L 98.247156 335.479727 
+L 97.661565 336.054625 
+L 97.075974 336.623481 
+L 96.490384 337.186419 
+L 95.904793 337.743562 
+L 95.319203 338.295028 
+" clip-path="url(#p3dee5a5a57)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6121,9 +6166,19 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.611875 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.987891 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -6133,6 +6188,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6205,41 +6285,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6275,19 +6320,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6326,109 +6371,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p66bcfd2819">
+  <clipPath id="p3dee5a5a57">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfbd230267e)">
+   <g clip-path="url(#p764c5e4d0b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image274abf036f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imagefee4cf0a3f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc188663dab" d="M 0 0 
+       <path id="m00368c5929" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc188663dab" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc188663dab" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc188663dab" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc188663dab" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc188663dab" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc188663dab" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc188663dab" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc188663dab" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc188663dab" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc188663dab" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc188663dab" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc188663dab" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00368c5929" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m3d521f95f9" d="M 0 0 
+       <path id="md9f6f4fb68" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3d521f95f9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md9f6f4fb68" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2ebcb80172" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image49533041e3" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mecace9a284" d="M 0 0 
+       <path id="m44503280e4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44503280e4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44503280e4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44503280e4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44503280e4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mecace9a284" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44503280e4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-24T07:32:44Z  ·  Linux chungus x86_64  ·  commit 6ed05ade  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.845703 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.987891 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2867,19 +2867,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3196.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3385.400391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3448.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.400391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.1875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3573.974609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.761719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.335938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.119141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.921875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.300781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.640625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.001953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.525391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.638672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.330078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.113281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.916016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.294922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.917969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.609375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.412109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.199219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.822266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.445312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.232422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.855469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.939453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.802734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.783203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.40625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.193359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5187.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.767578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.341797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.929688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.792969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5485.974609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.353516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.830078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.208984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.685547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.064453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.273438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.060547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.636719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.048828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.572266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.048828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.490234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.376953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.755859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.035156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6751.990234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.171875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.072266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.859375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6958.972656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.251953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.460938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.244141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.425781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.212891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.095703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.359375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.882812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.091797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.615234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7556.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.173828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.552734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.427734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfbd230267e">
+  <clipPath id="p764c5e4d0b">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.17625pt" height="386.202469pt" viewBox="0 0 569.17625 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.424219pt" height="386.202469pt" viewBox="0 0 570.424219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M -0 386.202469 
-L 569.17625 386.202469 
-L 569.17625 0 
+L 570.424219 386.202469 
+L 570.424219 0 
 L -0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.713125 104.1264 
-L 291.338125 104.1264 
-L 291.338125 74.7432 
-L 186.713125 74.7432 
+    <path d="M 187.337109 104.1264 
+L 291.962109 104.1264 
+L 291.962109 74.7432 
+L 187.337109 74.7432 
 z
-" clip-path="url(#p8852518683)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.338125 104.1264 
-L 395.963125 104.1264 
-L 395.963125 74.7432 
-L 291.338125 74.7432 
+    <path d="M 291.962109 104.1264 
+L 396.587109 104.1264 
+L 396.587109 74.7432 
+L 291.962109 74.7432 
 z
-" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.963125 104.1264 
-L 500.588125 104.1264 
-L 500.588125 74.7432 
-L 395.963125 74.7432 
+    <path d="M 396.587109 104.1264 
+L 501.212109 104.1264 
+L 501.212109 74.7432 
+L 396.587109 74.7432 
 z
-" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.713125 133.5096 
-L 291.338125 133.5096 
-L 291.338125 104.1264 
-L 186.713125 104.1264 
+    <path d="M 187.337109 133.5096 
+L 291.962109 133.5096 
+L 291.962109 104.1264 
+L 187.337109 104.1264 
 z
-" clip-path="url(#p8852518683)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.338125 133.5096 
-L 395.963125 133.5096 
-L 395.963125 104.1264 
-L 291.338125 104.1264 
+    <path d="M 291.962109 133.5096 
+L 396.587109 133.5096 
+L 396.587109 104.1264 
+L 291.962109 104.1264 
 z
-" clip-path="url(#p8852518683)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.963125 133.5096 
-L 500.588125 133.5096 
-L 500.588125 104.1264 
-L 395.963125 104.1264 
+    <path d="M 396.587109 133.5096 
+L 501.212109 133.5096 
+L 501.212109 104.1264 
+L 396.587109 104.1264 
 z
-" clip-path="url(#p8852518683)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.713125 162.8928 
-L 291.338125 162.8928 
-L 291.338125 133.5096 
-L 186.713125 133.5096 
+    <path d="M 187.337109 162.8928 
+L 291.962109 162.8928 
+L 291.962109 133.5096 
+L 187.337109 133.5096 
 z
-" clip-path="url(#p8852518683)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.338125 162.8928 
-L 395.963125 162.8928 
-L 395.963125 133.5096 
-L 291.338125 133.5096 
+    <path d="M 291.962109 162.8928 
+L 396.587109 162.8928 
+L 396.587109 133.5096 
+L 291.962109 133.5096 
 z
-" clip-path="url(#p8852518683)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.963125 162.8928 
-L 500.588125 162.8928 
-L 500.588125 133.5096 
-L 395.963125 133.5096 
+    <path d="M 396.587109 162.8928 
+L 501.212109 162.8928 
+L 501.212109 133.5096 
+L 396.587109 133.5096 
 z
-" clip-path="url(#p8852518683)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.713125 192.276 
-L 291.338125 192.276 
-L 291.338125 162.8928 
-L 186.713125 162.8928 
+    <path d="M 187.337109 192.276 
+L 291.962109 192.276 
+L 291.962109 162.8928 
+L 187.337109 162.8928 
 z
-" clip-path="url(#p8852518683)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.338125 192.276 
-L 395.963125 192.276 
-L 395.963125 162.8928 
-L 291.338125 162.8928 
+    <path d="M 291.962109 192.276 
+L 396.587109 192.276 
+L 396.587109 162.8928 
+L 291.962109 162.8928 
 z
-" clip-path="url(#p8852518683)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.963125 192.276 
-L 500.588125 192.276 
-L 500.588125 162.8928 
-L 395.963125 162.8928 
+    <path d="M 396.587109 192.276 
+L 501.212109 192.276 
+L 501.212109 162.8928 
+L 396.587109 162.8928 
 z
-" clip-path="url(#p8852518683)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.713125 221.6592 
-L 291.338125 221.6592 
-L 291.338125 192.276 
-L 186.713125 192.276 
+    <path d="M 187.337109 221.6592 
+L 291.962109 221.6592 
+L 291.962109 192.276 
+L 187.337109 192.276 
 z
-" clip-path="url(#p8852518683)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.338125 221.6592 
-L 395.963125 221.6592 
-L 395.963125 192.276 
-L 291.338125 192.276 
+    <path d="M 291.962109 221.6592 
+L 396.587109 221.6592 
+L 396.587109 192.276 
+L 291.962109 192.276 
 z
-" clip-path="url(#p8852518683)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.963125 221.6592 
-L 500.588125 221.6592 
-L 500.588125 192.276 
-L 395.963125 192.276 
+    <path d="M 396.587109 221.6592 
+L 501.212109 221.6592 
+L 501.212109 192.276 
+L 396.587109 192.276 
 z
-" clip-path="url(#p8852518683)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.713125 251.0424 
-L 291.338125 251.0424 
-L 291.338125 221.6592 
-L 186.713125 221.6592 
+    <path d="M 187.337109 251.0424 
+L 291.962109 251.0424 
+L 291.962109 221.6592 
+L 187.337109 221.6592 
 z
-" clip-path="url(#p8852518683)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.338125 251.0424 
-L 395.963125 251.0424 
-L 395.963125 221.6592 
-L 291.338125 221.6592 
+    <path d="M 291.962109 251.0424 
+L 396.587109 251.0424 
+L 396.587109 221.6592 
+L 291.962109 221.6592 
 z
-" clip-path="url(#p8852518683)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.963125 251.0424 
-L 500.588125 251.0424 
-L 500.588125 221.6592 
-L 395.963125 221.6592 
+    <path d="M 396.587109 251.0424 
+L 501.212109 251.0424 
+L 501.212109 221.6592 
+L 396.587109 221.6592 
 z
-" clip-path="url(#p8852518683)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.713125 280.4256 
-L 291.338125 280.4256 
-L 291.338125 251.0424 
-L 186.713125 251.0424 
+    <path d="M 187.337109 280.4256 
+L 291.962109 280.4256 
+L 291.962109 251.0424 
+L 187.337109 251.0424 
 z
-" clip-path="url(#p8852518683)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.338125 280.4256 
-L 395.963125 280.4256 
-L 395.963125 251.0424 
-L 291.338125 251.0424 
+    <path d="M 291.962109 280.4256 
+L 396.587109 280.4256 
+L 396.587109 251.0424 
+L 291.962109 251.0424 
 z
-" clip-path="url(#p8852518683)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.963125 280.4256 
-L 500.588125 280.4256 
-L 500.588125 251.0424 
-L 395.963125 251.0424 
+    <path d="M 396.587109 280.4256 
+L 501.212109 280.4256 
+L 501.212109 251.0424 
+L 396.587109 251.0424 
 z
-" clip-path="url(#p8852518683)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.713125 309.8088 
-L 291.338125 309.8088 
-L 291.338125 280.4256 
-L 186.713125 280.4256 
+    <path d="M 187.337109 309.8088 
+L 291.962109 309.8088 
+L 291.962109 280.4256 
+L 187.337109 280.4256 
 z
-" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.338125 309.8088 
-L 395.963125 309.8088 
-L 395.963125 280.4256 
-L 291.338125 280.4256 
+    <path d="M 291.962109 309.8088 
+L 396.587109 309.8088 
+L 396.587109 280.4256 
+L 291.962109 280.4256 
 z
-" clip-path="url(#p8852518683)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.963125 309.8088 
-L 500.588125 309.8088 
-L 500.588125 280.4256 
-L 395.963125 280.4256 
+    <path d="M 396.587109 309.8088 
+L 501.212109 309.8088 
+L 501.212109 280.4256 
+L 396.587109 280.4256 
 z
-" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.713125 339.192 
-L 291.338125 339.192 
-L 291.338125 309.8088 
-L 186.713125 309.8088 
+    <path d="M 187.337109 339.192 
+L 291.962109 339.192 
+L 291.962109 309.8088 
+L 187.337109 309.8088 
 z
-" clip-path="url(#p8852518683)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.338125 339.192 
-L 395.963125 339.192 
-L 395.963125 309.8088 
-L 291.338125 309.8088 
+    <path d="M 291.962109 339.192 
+L 396.587109 339.192 
+L 396.587109 309.8088 
+L 291.962109 309.8088 
 z
-" clip-path="url(#p8852518683)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.963125 339.192 
-L 500.588125 339.192 
-L 500.588125 309.8088 
-L 395.963125 309.8088 
+    <path d="M 396.587109 339.192 
+L 501.212109 339.192 
+L 501.212109 309.8088 
+L 396.587109 309.8088 
 z
-" clip-path="url(#p8852518683)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pecaffa111a)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.700391 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.324375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.984609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.608594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.556719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.180703 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.908437 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.532422 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.638125 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.262109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.574375 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.015625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.639609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.640625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.27625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.900234 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.574375 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.560625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.640625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.969375 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.593359 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.574375 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.560625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.640625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.001875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.625859 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.574375 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.560625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.640625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.539375 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.163359 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.574375 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.560625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.640625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.845625 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.469609 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.574375 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.560625 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.640625 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.264609 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.3475 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.971484 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(226.37375 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.997734 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 35 -->
-    <g transform="translate(338.084375 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.708359 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
@@ -1887,28 +1887,48 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 272 -->
-    <g transform="translate(439.92625 267.9415) scale(0.08 -0.08)">
+    <!-- 262 -->
+    <g transform="translate(440.550234 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.4625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.086484 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1973,7 +1993,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.574375 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1983,21 +2003,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.560625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.184609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.185625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.809609 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.68375 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.307734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2008,7 +2028,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.574375 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.198359 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2018,13 +2038,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.105625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.729609 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.275625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.899609 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2040,7 +2060,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.189844 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.813828 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2113,36 +2133,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2184,7 +2174,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-26T00:03:38Z  ·  Linux chungus x86_64  ·  commit 4fb5715b  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-01T05:47:05Z  ·  Linux chungus x86_64  ·  commit 807ce38d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2320,19 +2310,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2371,110 +2361,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.525391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.3125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3583.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.673828 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.460938 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.244141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.767578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.046875 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3924.902344 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.765625 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4024.947266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.650391 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.763672 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.455078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.238281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.761719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.041016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.419922 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.042969 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.734375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4590.914062 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.537109 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.324219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4749.947266 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.570312 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.357422 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4908.980469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.064453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4983.927734 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5038.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.318359 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5197.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.466797 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.054688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5402.917969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.099609 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5590.955078 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.810547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.189453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.398438 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5935.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.761719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.173828 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.173828 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6217.957031 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.615234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.402344 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.501953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6489.880859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.636719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.296875 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.505859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.197266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6895.984375 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.376953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.585938 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.550781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.337891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.121094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.220703 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.484375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.007812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.216797 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.740234 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.103516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.298828 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.677734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.560547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.769531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.552734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.625 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3379.248047 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.871094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3506.347656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3538.134766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.496094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.283203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3693.066406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.869141 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3879.248047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.769531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.472656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.585938 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.277344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4266.060547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.863281 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4452.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.865234 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.556641 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.736328 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.359375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4704.146484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.769531 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.392578 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4863.179688 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.802734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.75 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5120.353516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5152.140625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.501953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5279.289062 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.498047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.876953 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.921875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5545.300781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.777344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5672.15625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.632812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5799.011719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5838.220703 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.996094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.519531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.996094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.779297 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.058594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.4375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6392.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.324219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.458984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.558594 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.9375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6809.119141 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6882.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.806641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.919922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7016.199219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.408203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.373047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7176.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7256.042969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7351.306641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.830078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7452.039062 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.5625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.925781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7650.337891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.5 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7769.283203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7821.382812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.591797 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7888.375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8852518683">
-   <rect x="82.088125" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pecaffa111a">
+   <rect x="82.712109" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-26T00:03:38Z",
+  "date": "2026-07-01T05:47:05Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "4fb5715b",
+  "git_commit": "807ce38d",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 42.28,
-   "decompress_mbps": 194.68
+   "compress_mbps": 41.69,
+   "decompress_mbps": 188.49
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 38.68,
-   "decompress_mbps": 221.88
+   "compress_mbps": 38.31,
+   "decompress_mbps": 214.72
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 35.74,
-   "decompress_mbps": 240.79
+   "compress_mbps": 35.43,
+   "decompress_mbps": 233.39
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 28.35,
-   "decompress_mbps": 241.59
+   "compress_mbps": 28.03,
+   "decompress_mbps": 234.66
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 27.39,
-   "decompress_mbps": 245.31
+   "compress_mbps": 27.2,
+   "decompress_mbps": 237.48
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 252.52
+   "compress_mbps": 25.3,
+   "decompress_mbps": 243.66
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 20.64,
-   "decompress_mbps": 252.34
+   "compress_mbps": 20.57,
+   "decompress_mbps": 242.45
   },
   {
    "compressor": "native",
@@ -84,18 +84,18 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.26,
-   "decompress_mbps": 253.87
+   "compress_mbps": 9.24,
+   "decompress_mbps": 244.06
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 9,
-   "out_size": 52111,
-   "ratio": 0.3426,
-   "compress_mbps": 1.8,
-   "decompress_mbps": 254.15
+   "out_size": 53059,
+   "ratio": 0.3489,
+   "compress_mbps": 3.19,
+   "decompress_mbps": 244.07
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 39.33,
-   "decompress_mbps": 187.05
+   "compress_mbps": 39.09,
+   "decompress_mbps": 179.9
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 36.25,
-   "decompress_mbps": 202.22
+   "compress_mbps": 35.81,
+   "decompress_mbps": 195.41
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 33.82,
-   "decompress_mbps": 220.58
+   "compress_mbps": 33.54,
+   "decompress_mbps": 213.15
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 26.22,
-   "decompress_mbps": 224.79
+   "compress_mbps": 25.93,
+   "decompress_mbps": 216.62
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 25.53,
-   "decompress_mbps": 226.88
+   "compress_mbps": 25.2,
+   "decompress_mbps": 218.77
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 24.21,
-   "decompress_mbps": 230.18
+   "compress_mbps": 24.11,
+   "decompress_mbps": 223.21
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.43,
-   "decompress_mbps": 230.26
+   "compress_mbps": 21.64,
+   "decompress_mbps": 222.8
   },
   {
    "compressor": "native",
@@ -174,18 +174,18 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 9.01,
-   "decompress_mbps": 230.54
+   "compress_mbps": 8.92,
+   "decompress_mbps": 223.67
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 9,
-   "out_size": 46881,
-   "ratio": 0.3745,
-   "compress_mbps": 2.06,
-   "decompress_mbps": 229.99
+   "out_size": 47620,
+   "ratio": 0.3804,
+   "compress_mbps": 3.39,
+   "decompress_mbps": 224.03
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 34.82,
-   "decompress_mbps": 222.03
+   "compress_mbps": 34.37,
+   "decompress_mbps": 217.15
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.61,
-   "decompress_mbps": 227.42
+   "compress_mbps": 33.54,
+   "decompress_mbps": 222.09
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.66,
-   "decompress_mbps": 231.53
+   "compress_mbps": 32.35,
+   "decompress_mbps": 228.08
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.71,
-   "decompress_mbps": 240.41
+   "compress_mbps": 30.64,
+   "decompress_mbps": 236.18
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.16,
-   "decompress_mbps": 245.88
+   "compress_mbps": 29.96,
+   "decompress_mbps": 241.62
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 248.36
+   "compress_mbps": 29.39,
+   "decompress_mbps": 242.97
   },
   {
    "compressor": "native",
@@ -255,7 +255,7 @@
    "out_size": 7929,
    "ratio": 0.3223,
    "compress_mbps": 25.9,
-   "decompress_mbps": 250.71
+   "decompress_mbps": 245.52
   },
   {
    "compressor": "native",
@@ -265,17 +265,17 @@
    "out_size": 7929,
    "ratio": 0.3223,
    "compress_mbps": 9.75,
-   "decompress_mbps": 251.25
+   "decompress_mbps": 245.38
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 9,
-   "out_size": 7727,
-   "ratio": 0.3141,
-   "compress_mbps": 2.38,
-   "decompress_mbps": 253.18
+   "out_size": 7801,
+   "ratio": 0.3171,
+   "compress_mbps": 4.25,
+   "decompress_mbps": 245.48
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 150.14
+   "compress_mbps": 23.6,
+   "decompress_mbps": 149.35
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 152.34
+   "compress_mbps": 23.08,
+   "decompress_mbps": 150.86
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.56,
-   "decompress_mbps": 155.74
+   "compress_mbps": 22.7,
+   "decompress_mbps": 154.83
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 158.49
+   "compress_mbps": 21.62,
+   "decompress_mbps": 156.97
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.13,
-   "decompress_mbps": 160.08
+   "compress_mbps": 21.43,
+   "decompress_mbps": 157.98
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 20.78,
-   "decompress_mbps": 160.05
+   "compress_mbps": 21.06,
+   "decompress_mbps": 158.67
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.06,
-   "decompress_mbps": 160.57
+   "compress_mbps": 19.34,
+   "decompress_mbps": 158.99
   },
   {
    "compressor": "native",
@@ -354,18 +354,18 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.04,
-   "decompress_mbps": 155.73
+   "compress_mbps": 7.06,
+   "decompress_mbps": 159.22
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 9,
-   "out_size": 3027,
-   "ratio": 0.2715,
-   "compress_mbps": 2.34,
-   "decompress_mbps": 159.15
+   "out_size": 3056,
+   "ratio": 0.2741,
+   "compress_mbps": 4.12,
+   "decompress_mbps": 158.99
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.69,
-   "decompress_mbps": 68.98
+   "compress_mbps": 11.77,
+   "decompress_mbps": 69.21
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.59,
-   "decompress_mbps": 69.53
+   "compress_mbps": 11.66,
+   "decompress_mbps": 69.73
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.53,
-   "decompress_mbps": 69.5
+   "compress_mbps": 11.58,
+   "decompress_mbps": 69.58
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.34,
-   "decompress_mbps": 69.94
+   "compress_mbps": 11.43,
+   "decompress_mbps": 69.92
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.31,
-   "decompress_mbps": 70.2
+   "compress_mbps": 11.45,
+   "decompress_mbps": 70.08
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 70.27
+   "compress_mbps": 11.45,
+   "decompress_mbps": 70.38
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 70.4
+   "compress_mbps": 11.22,
+   "decompress_mbps": 70.48
   },
   {
    "compressor": "native",
@@ -444,18 +444,18 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.82,
-   "decompress_mbps": 70.43
+   "compress_mbps": 3.84,
+   "decompress_mbps": 70.65
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 9,
-   "out_size": 1190,
-   "ratio": 0.3198,
-   "compress_mbps": 2.1,
-   "decompress_mbps": 70.55
+   "out_size": 1205,
+   "ratio": 0.3238,
+   "compress_mbps": 3.43,
+   "decompress_mbps": 70.47
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 68.32,
-   "decompress_mbps": 355.17
+   "compress_mbps": 68.21,
+   "decompress_mbps": 341.79
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 63.82,
-   "decompress_mbps": 380.28
+   "compress_mbps": 64.19,
+   "decompress_mbps": 368.36
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 63.11,
-   "decompress_mbps": 406.23
+   "compress_mbps": 62.7,
+   "decompress_mbps": 389.61
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 58.48,
-   "decompress_mbps": 428.56
+   "compress_mbps": 59.09,
+   "decompress_mbps": 410.29
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 57.77,
-   "decompress_mbps": 410.96
+   "compress_mbps": 58.0,
+   "decompress_mbps": 394.98
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 54.52,
-   "decompress_mbps": 425.34
+   "compress_mbps": 54.46,
+   "decompress_mbps": 408.18
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.26,
-   "decompress_mbps": 429.99
+   "compress_mbps": 20.25,
+   "decompress_mbps": 410.94
   },
   {
    "compressor": "native",
@@ -534,18 +534,18 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.27,
-   "decompress_mbps": 433.9
+   "compress_mbps": 7.3,
+   "decompress_mbps": 417.52
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 9,
-   "out_size": 178311,
-   "ratio": 0.1732,
-   "compress_mbps": 1.19,
-   "decompress_mbps": 434.41
+   "out_size": 183445,
+   "ratio": 0.1781,
+   "compress_mbps": 2.68,
+   "decompress_mbps": 419.84
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 45.8,
-   "decompress_mbps": 204.64
+   "compress_mbps": 45.64,
+   "decompress_mbps": 197.78
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 41.82,
-   "decompress_mbps": 220.98
+   "compress_mbps": 41.47,
+   "decompress_mbps": 214.0
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 38.32,
-   "decompress_mbps": 245.69
+   "compress_mbps": 37.76,
+   "decompress_mbps": 238.16
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 30.55,
-   "decompress_mbps": 250.03
+   "compress_mbps": 30.3,
+   "decompress_mbps": 242.18
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 29.42,
-   "decompress_mbps": 251.77
+   "compress_mbps": 29.27,
+   "decompress_mbps": 243.4
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 27.29,
-   "decompress_mbps": 258.64
+   "compress_mbps": 27.14,
+   "decompress_mbps": 249.34
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 259.09
+   "compress_mbps": 22.48,
+   "decompress_mbps": 250.3
   },
   {
    "compressor": "native",
@@ -624,18 +624,18 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 10.05,
-   "decompress_mbps": 259.54
+   "compress_mbps": 9.96,
+   "decompress_mbps": 250.66
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 9,
-   "out_size": 138661,
-   "ratio": 0.3249,
-   "compress_mbps": 1.82,
-   "decompress_mbps": 260.16
+   "out_size": 140996,
+   "ratio": 0.3304,
+   "compress_mbps": 3.21,
+   "decompress_mbps": 250.98
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 40.55,
-   "decompress_mbps": 176.28
+   "compress_mbps": 39.91,
+   "decompress_mbps": 171.31
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 36.75,
-   "decompress_mbps": 196.24
+   "compress_mbps": 36.29,
+   "decompress_mbps": 190.26
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 33.55,
-   "decompress_mbps": 215.91
+   "compress_mbps": 33.07,
+   "decompress_mbps": 209.94
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 24.25,
-   "decompress_mbps": 219.47
+   "compress_mbps": 23.98,
+   "decompress_mbps": 212.69
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 23.33,
-   "decompress_mbps": 219.86
+   "compress_mbps": 23.07,
+   "decompress_mbps": 211.94
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 223.68
+   "compress_mbps": 21.38,
+   "decompress_mbps": 216.03
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.72,
-   "decompress_mbps": 223.66
+   "compress_mbps": 18.45,
+   "decompress_mbps": 215.78
   },
   {
    "compressor": "native",
@@ -714,18 +714,18 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.5,
-   "decompress_mbps": 223.84
+   "compress_mbps": 8.47,
+   "decompress_mbps": 215.89
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 9,
-   "out_size": 186472,
-   "ratio": 0.387,
-   "compress_mbps": 1.77,
-   "decompress_mbps": 223.88
+   "out_size": 190711,
+   "ratio": 0.3958,
+   "compress_mbps": 3.02,
+   "decompress_mbps": 216.04
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 129.97,
-   "decompress_mbps": 491.97
+   "compress_mbps": 127.78,
+   "decompress_mbps": 462.82
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 115.39,
-   "decompress_mbps": 518.75
+   "compress_mbps": 113.0,
+   "decompress_mbps": 487.14
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 98.32,
-   "decompress_mbps": 560.55
+   "compress_mbps": 96.61,
+   "decompress_mbps": 528.66
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 77.99,
-   "decompress_mbps": 474.88
+   "compress_mbps": 77.63,
+   "decompress_mbps": 445.95
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 74.88,
-   "decompress_mbps": 507.44
+   "compress_mbps": 74.19,
+   "decompress_mbps": 477.83
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 66.98,
-   "decompress_mbps": 555.6
+   "compress_mbps": 66.51,
+   "decompress_mbps": 525.31
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 37.95,
-   "decompress_mbps": 592.41
+   "compress_mbps": 37.81,
+   "decompress_mbps": 560.12
   },
   {
    "compressor": "native",
@@ -804,18 +804,18 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.87,
-   "decompress_mbps": 637.23
+   "compress_mbps": 16.83,
+   "decompress_mbps": 601.41
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 9,
-   "out_size": 51490,
-   "ratio": 0.1003,
-   "compress_mbps": 1.08,
-   "decompress_mbps": 650.48
+   "out_size": 52729,
+   "ratio": 0.1027,
+   "compress_mbps": 3.37,
+   "decompress_mbps": 613.42
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.6,
-   "decompress_mbps": 188.53
+   "compress_mbps": 26.67,
+   "decompress_mbps": 183.93
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.98,
-   "decompress_mbps": 191.46
+   "compress_mbps": 26.1,
+   "decompress_mbps": 186.89
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.42,
-   "decompress_mbps": 195.56
+   "compress_mbps": 25.25,
+   "decompress_mbps": 191.74
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.14,
-   "decompress_mbps": 192.66
+   "compress_mbps": 23.24,
+   "decompress_mbps": 197.6
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 21.78,
-   "decompress_mbps": 211.73
+   "compress_mbps": 22.8,
+   "decompress_mbps": 206.87
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.61,
-   "decompress_mbps": 217.57
+   "compress_mbps": 21.46,
+   "decompress_mbps": 211.46
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.57,
-   "decompress_mbps": 218.24
+   "compress_mbps": 17.37,
+   "decompress_mbps": 213.02
   },
   {
    "compressor": "native",
@@ -894,18 +894,18 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.35,
-   "decompress_mbps": 220.89
+   "compress_mbps": 5.29,
+   "decompress_mbps": 214.0
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 9,
-   "out_size": 12278,
-   "ratio": 0.3211,
-   "compress_mbps": 1.82,
-   "decompress_mbps": 223.12
+   "out_size": 12501,
+   "ratio": 0.3269,
+   "compress_mbps": 3.32,
+   "decompress_mbps": 216.58
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.94,
-   "decompress_mbps": 74.21
+   "compress_mbps": 13.09,
+   "decompress_mbps": 75.45
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.93,
-   "decompress_mbps": 75.13
+   "compress_mbps": 13.11,
+   "decompress_mbps": 75.61
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.91,
-   "decompress_mbps": 75.25
+   "compress_mbps": 13.11,
+   "decompress_mbps": 75.52
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 11.56,
-   "decompress_mbps": 75.85
+   "compress_mbps": 12.88,
+   "decompress_mbps": 76.29
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 76.26
+   "compress_mbps": 12.88,
+   "decompress_mbps": 76.1
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.91,
-   "decompress_mbps": 76.33
+   "compress_mbps": 12.88,
+   "decompress_mbps": 76.18
   },
   {
    "compressor": "native",
@@ -975,7 +975,7 @@
    "out_size": 1729,
    "ratio": 0.409,
    "compress_mbps": 12.74,
-   "decompress_mbps": 76.06
+   "decompress_mbps": 76.2
   },
   {
    "compressor": "native",
@@ -985,17 +985,17 @@
    "out_size": 1729,
    "ratio": 0.409,
    "compress_mbps": 4.22,
-   "decompress_mbps": 76.16
+   "decompress_mbps": 76.44
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 9,
-   "out_size": 1696,
-   "ratio": 0.4012,
-   "compress_mbps": 2.5,
-   "decompress_mbps": 75.94
+   "out_size": 1708,
+   "ratio": 0.4041,
+   "compress_mbps": 3.94,
+   "decompress_mbps": 76.38
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 42.19,
-   "decompress_mbps": 180.86
+   "compress_mbps": 42.04,
+   "decompress_mbps": 174.48
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 38.02,
-   "decompress_mbps": 197.28
+   "compress_mbps": 37.87,
+   "decompress_mbps": 191.25
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 34.95,
-   "decompress_mbps": 218.39
+   "compress_mbps": 34.45,
+   "decompress_mbps": 212.44
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 26.31,
-   "decompress_mbps": 220.15
+   "compress_mbps": 26.08,
+   "decompress_mbps": 213.56
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 219.93
+   "compress_mbps": 25.43,
+   "decompress_mbps": 213.84
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.74,
-   "decompress_mbps": 225.76
+   "compress_mbps": 23.48,
+   "decompress_mbps": 219.29
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 225.83
+   "compress_mbps": 19.71,
+   "decompress_mbps": 217.65
   },
   {
    "compressor": "native",
@@ -4044,18 +4044,18 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 9.06,
-   "decompress_mbps": 233.13
+   "compress_mbps": 9.03,
+   "decompress_mbps": 226.55
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 9,
-   "out_size": 3712344,
-   "ratio": 0.3642,
-   "compress_mbps": 1.78,
-   "decompress_mbps": 229.68
+   "out_size": 3790405,
+   "ratio": 0.3719,
+   "compress_mbps": 3.11,
+   "decompress_mbps": 226.97
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 55.28,
-   "decompress_mbps": 196.77
+   "compress_mbps": 54.52,
+   "decompress_mbps": 189.32
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 51.28,
-   "decompress_mbps": 207.44
+   "compress_mbps": 51.24,
+   "decompress_mbps": 194.58
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 48.65,
-   "decompress_mbps": 214.79
+   "compress_mbps": 48.36,
+   "decompress_mbps": 204.9
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 39.82,
-   "decompress_mbps": 223.92
+   "compress_mbps": 39.81,
+   "decompress_mbps": 210.78
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 228.53
+   "compress_mbps": 37.8,
+   "decompress_mbps": 219.04
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 33.07,
-   "decompress_mbps": 234.22
+   "compress_mbps": 33.34,
+   "decompress_mbps": 222.66
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 22.29,
-   "decompress_mbps": 234.38
+   "compress_mbps": 22.06,
+   "decompress_mbps": 223.08
   },
   {
    "compressor": "native",
@@ -4134,18 +4134,18 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.84,
-   "decompress_mbps": 227.63
+   "compress_mbps": 6.86,
+   "decompress_mbps": 225.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 9,
-   "out_size": 18518350,
-   "ratio": 0.3615,
-   "compress_mbps": 1.62,
-   "decompress_mbps": 234.51
+   "out_size": 18705121,
+   "ratio": 0.3652,
+   "compress_mbps": 3.2,
+   "decompress_mbps": 223.83
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 55.61,
-   "decompress_mbps": 211.63
+   "compress_mbps": 54.71,
+   "decompress_mbps": 206.03
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 51.0,
-   "decompress_mbps": 219.06
+   "compress_mbps": 50.32,
+   "decompress_mbps": 215.29
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 44.85,
-   "decompress_mbps": 230.36
+   "compress_mbps": 44.06,
+   "decompress_mbps": 226.58
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 32.41,
-   "decompress_mbps": 213.32
+   "compress_mbps": 32.0,
+   "decompress_mbps": 210.73
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.71,
-   "decompress_mbps": 211.57
+   "compress_mbps": 30.4,
+   "decompress_mbps": 206.52
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.9,
-   "decompress_mbps": 218.52
+   "compress_mbps": 27.85,
+   "decompress_mbps": 211.93
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 222.37
+   "compress_mbps": 21.07,
+   "decompress_mbps": 213.99
   },
   {
    "compressor": "native",
@@ -4224,18 +4224,18 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.18,
-   "decompress_mbps": 225.68
+   "compress_mbps": 8.24,
+   "decompress_mbps": 219.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 9,
-   "out_size": 3520112,
-   "ratio": 0.3531,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 235.07
+   "out_size": 3594656,
+   "ratio": 0.3605,
+   "compress_mbps": 3.0,
+   "decompress_mbps": 225.74
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 141.29,
-   "decompress_mbps": 623.5
+   "compress_mbps": 139.76,
+   "decompress_mbps": 599.04
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 120.28,
-   "decompress_mbps": 696.85
+   "compress_mbps": 118.74,
+   "decompress_mbps": 666.81
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 101.79,
-   "decompress_mbps": 771.67
+   "compress_mbps": 99.84,
+   "decompress_mbps": 714.34
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 88.28,
-   "decompress_mbps": 776.08
+   "compress_mbps": 87.31,
+   "decompress_mbps": 741.86
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 85.2,
-   "decompress_mbps": 851.06
+   "compress_mbps": 85.16,
+   "decompress_mbps": 822.23
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 78.16,
-   "decompress_mbps": 920.26
+   "compress_mbps": 77.11,
+   "decompress_mbps": 877.77
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 44.1,
-   "decompress_mbps": 930.05
+   "compress_mbps": 43.81,
+   "decompress_mbps": 891.63
   },
   {
    "compressor": "native",
@@ -4314,18 +4314,18 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 23.04,
-   "decompress_mbps": 923.97
+   "compress_mbps": 22.94,
+   "decompress_mbps": 874.52
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 9,
-   "out_size": 2868751,
-   "ratio": 0.0855,
-   "compress_mbps": 0.88,
-   "decompress_mbps": 841.46
+   "out_size": 3024127,
+   "ratio": 0.0901,
+   "compress_mbps": 2.79,
+   "decompress_mbps": 902.55
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 40.55,
-   "decompress_mbps": 135.89
+   "compress_mbps": 39.71,
+   "decompress_mbps": 129.82
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.55,
-   "decompress_mbps": 139.4
+   "compress_mbps": 37.95,
+   "decompress_mbps": 132.95
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 37.63,
-   "decompress_mbps": 144.01
+   "compress_mbps": 36.95,
+   "decompress_mbps": 137.66
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 31.26,
-   "decompress_mbps": 152.68
+   "compress_mbps": 31.11,
+   "decompress_mbps": 144.96
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 157.45
+   "compress_mbps": 30.36,
+   "decompress_mbps": 150.27
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 29.45,
-   "decompress_mbps": 160.18
+   "compress_mbps": 29.23,
+   "decompress_mbps": 152.02
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 161.35
+   "compress_mbps": 25.81,
+   "decompress_mbps": 153.15
   },
   {
    "compressor": "native",
@@ -4405,17 +4405,17 @@
    "out_size": 3165909,
    "ratio": 0.5146,
    "compress_mbps": 6.81,
-   "decompress_mbps": 161.77
+   "decompress_mbps": 155.53
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 9,
-   "out_size": 3017696,
-   "ratio": 0.4905,
-   "compress_mbps": 2.28,
-   "decompress_mbps": 167.69
+   "out_size": 3054135,
+   "ratio": 0.4964,
+   "compress_mbps": 3.76,
+   "decompress_mbps": 156.0
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 58.73,
-   "decompress_mbps": 225.04
+   "compress_mbps": 57.88,
+   "decompress_mbps": 228.73
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 54.88,
-   "decompress_mbps": 230.93
+   "compress_mbps": 54.41,
+   "decompress_mbps": 236.8
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 52.59,
-   "decompress_mbps": 237.11
+   "compress_mbps": 53.12,
+   "decompress_mbps": 243.66
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 47.94,
-   "decompress_mbps": 246.93
+   "compress_mbps": 48.29,
+   "decompress_mbps": 254.72
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 47.62,
-   "decompress_mbps": 243.17
+   "compress_mbps": 48.67,
+   "decompress_mbps": 257.44
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 47.9,
-   "decompress_mbps": 259.4
+   "compress_mbps": 48.37,
+   "decompress_mbps": 266.52
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 45.17,
-   "decompress_mbps": 263.52
+   "compress_mbps": 45.2,
+   "decompress_mbps": 270.83
   },
   {
    "compressor": "native",
@@ -4494,18 +4494,18 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.24,
-   "decompress_mbps": 276.62
+   "compress_mbps": 12.41,
+   "decompress_mbps": 262.32
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 9,
-   "out_size": 3647083,
-   "ratio": 0.3616,
-   "compress_mbps": 2.73,
-   "decompress_mbps": 275.07
+   "out_size": 3693258,
+   "ratio": 0.3662,
+   "compress_mbps": 4.95,
+   "decompress_mbps": 265.68
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 50.4,
-   "decompress_mbps": 231.87
+   "compress_mbps": 50.59,
+   "decompress_mbps": 216.78
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 44.62,
-   "decompress_mbps": 242.56
+   "compress_mbps": 44.2,
+   "decompress_mbps": 237.91
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 38.18,
-   "decompress_mbps": 278.92
+   "compress_mbps": 36.96,
+   "decompress_mbps": 267.74
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 27.05,
-   "decompress_mbps": 270.87
+   "compress_mbps": 27.03,
+   "decompress_mbps": 264.98
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.91,
-   "decompress_mbps": 285.58
+   "compress_mbps": 24.75,
+   "decompress_mbps": 274.63
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.56,
-   "decompress_mbps": 283.2
+   "compress_mbps": 20.53,
+   "decompress_mbps": 278.13
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 13.24,
-   "decompress_mbps": 305.97
+   "compress_mbps": 13.14,
+   "decompress_mbps": 292.01
   },
   {
    "compressor": "native",
@@ -4584,18 +4584,18 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.63,
-   "decompress_mbps": 299.17
+   "compress_mbps": 7.62,
+   "decompress_mbps": 271.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 9,
-   "out_size": 1724560,
-   "ratio": 0.2602,
-   "compress_mbps": 1.15,
-   "decompress_mbps": 289.62
+   "out_size": 1793832,
+   "ratio": 0.2707,
+   "compress_mbps": 2.43,
+   "decompress_mbps": 293.67
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 73.66,
-   "decompress_mbps": 305.25
+   "compress_mbps": 71.96,
+   "decompress_mbps": 294.07
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 66.15,
-   "decompress_mbps": 325.74
+   "compress_mbps": 65.25,
+   "decompress_mbps": 311.78
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 60.41,
-   "decompress_mbps": 338.54
+   "compress_mbps": 59.61,
+   "decompress_mbps": 325.17
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 49.67,
-   "decompress_mbps": 346.6
+   "compress_mbps": 49.38,
+   "decompress_mbps": 335.04
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 48.02,
-   "decompress_mbps": 358.06
+   "compress_mbps": 47.51,
+   "decompress_mbps": 343.75
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 44.55,
-   "decompress_mbps": 368.3
+   "compress_mbps": 44.41,
+   "decompress_mbps": 352.93
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 33.04,
-   "decompress_mbps": 366.61
+   "compress_mbps": 32.97,
+   "decompress_mbps": 348.86
   },
   {
    "compressor": "native",
@@ -4674,18 +4674,18 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.78,
-   "decompress_mbps": 340.66
+   "compress_mbps": 12.74,
+   "decompress_mbps": 330.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 9,
-   "out_size": 5169629,
-   "ratio": 0.2393,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 372.65
+   "out_size": 5225578,
+   "ratio": 0.2419,
+   "compress_mbps": 3.67,
+   "decompress_mbps": 356.2
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 35.46,
-   "decompress_mbps": 135.52
+   "compress_mbps": 34.83,
+   "decompress_mbps": 128.95
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 33.51,
-   "decompress_mbps": 135.93
+   "compress_mbps": 33.24,
+   "decompress_mbps": 131.0
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 31.72,
-   "decompress_mbps": 143.21
+   "compress_mbps": 31.24,
+   "decompress_mbps": 136.67
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 26.49,
-   "decompress_mbps": 143.69
+   "compress_mbps": 26.46,
+   "decompress_mbps": 137.98
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 26.17,
-   "decompress_mbps": 145.36
+   "compress_mbps": 25.86,
+   "decompress_mbps": 135.79
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 25.4,
-   "decompress_mbps": 143.31
+   "compress_mbps": 24.87,
+   "decompress_mbps": 138.08
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 24.23,
-   "decompress_mbps": 143.33
+   "compress_mbps": 23.97,
+   "decompress_mbps": 138.09
   },
   {
    "compressor": "native",
@@ -4764,18 +4764,18 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.21,
-   "decompress_mbps": 147.13
+   "compress_mbps": 6.22,
+   "decompress_mbps": 138.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 9,
-   "out_size": 5261135,
-   "ratio": 0.7255,
-   "compress_mbps": 2.57,
-   "decompress_mbps": 143.72
+   "out_size": 5301868,
+   "ratio": 0.7311,
+   "compress_mbps": 3.69,
+   "decompress_mbps": 137.95
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 54.24,
-   "decompress_mbps": 231.99
+   "compress_mbps": 54.14,
+   "decompress_mbps": 224.08
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 49.43,
-   "decompress_mbps": 251.46
+   "compress_mbps": 48.86,
+   "decompress_mbps": 243.49
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 46.39,
-   "decompress_mbps": 271.43
+   "compress_mbps": 45.66,
+   "decompress_mbps": 262.06
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 37.46,
-   "decompress_mbps": 277.68
+   "compress_mbps": 37.09,
+   "decompress_mbps": 258.27
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 36.04,
-   "decompress_mbps": 283.77
+   "compress_mbps": 35.62,
+   "decompress_mbps": 272.29
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 32.45,
-   "decompress_mbps": 291.37
+   "compress_mbps": 32.25,
+   "decompress_mbps": 279.77
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 292.15
+   "compress_mbps": 24.93,
+   "decompress_mbps": 281.2
   },
   {
    "compressor": "native",
@@ -4854,18 +4854,18 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 292.29
+   "compress_mbps": 11.48,
+   "decompress_mbps": 280.93
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 9,
-   "out_size": 11638957,
-   "ratio": 0.2807,
-   "compress_mbps": 1.6,
-   "decompress_mbps": 293.08
+   "out_size": 11868965,
+   "ratio": 0.2863,
+   "compress_mbps": 3.3,
+   "decompress_mbps": 280.23
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 35.1,
-   "decompress_mbps": 129.86
+   "compress_mbps": 34.71,
+   "decompress_mbps": 124.18
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 35.23,
-   "decompress_mbps": 129.98
+   "compress_mbps": 34.6,
+   "decompress_mbps": 125.43
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 35.26,
-   "decompress_mbps": 132.95
+   "compress_mbps": 34.31,
+   "decompress_mbps": 126.78
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 33.3,
-   "decompress_mbps": 121.43
+   "compress_mbps": 32.73,
+   "decompress_mbps": 114.46
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.1,
-   "decompress_mbps": 122.39
+   "compress_mbps": 32.96,
+   "decompress_mbps": 115.86
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.26,
-   "decompress_mbps": 122.55
+   "compress_mbps": 32.98,
+   "decompress_mbps": 116.41
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 123.91
+   "compress_mbps": 33.15,
+   "decompress_mbps": 117.76
   },
   {
    "compressor": "native",
@@ -4944,18 +4944,18 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.7,
-   "decompress_mbps": 125.24
+   "compress_mbps": 4.74,
+   "decompress_mbps": 119.19
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 9,
-   "out_size": 5825680,
-   "ratio": 0.6875,
-   "compress_mbps": 3.52,
-   "decompress_mbps": 125.06
+   "out_size": 5949045,
+   "ratio": 0.702,
+   "compress_mbps": 4.46,
+   "decompress_mbps": 120.09
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 111.85,
-   "decompress_mbps": 429.63
+   "compress_mbps": 109.72,
+   "decompress_mbps": 443.92
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 98.62,
-   "decompress_mbps": 488.99
+   "compress_mbps": 94.98,
+   "decompress_mbps": 464.84
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 86.21,
-   "decompress_mbps": 585.23
+   "compress_mbps": 85.18,
+   "decompress_mbps": 559.65
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 69.99,
-   "decompress_mbps": 577.41
+   "compress_mbps": 69.81,
+   "decompress_mbps": 552.0
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 67.92,
-   "decompress_mbps": 634.07
+   "compress_mbps": 67.35,
+   "decompress_mbps": 602.87
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 62.24,
-   "decompress_mbps": 682.88
+   "compress_mbps": 61.73,
+   "decompress_mbps": 648.73
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 41.8,
-   "decompress_mbps": 696.04
+   "compress_mbps": 41.47,
+   "decompress_mbps": 662.31
   },
   {
    "compressor": "native",
@@ -5034,18 +5034,18 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 703.78
+   "compress_mbps": 20.42,
+   "decompress_mbps": 596.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 9,
-   "out_size": 637424,
-   "ratio": 0.1192,
-   "compress_mbps": 1.17,
-   "decompress_mbps": 689.18
+   "out_size": 656466,
+   "ratio": 0.1228,
+   "compress_mbps": 2.94,
+   "decompress_mbps": 656.04
   },
   {
    "compressor": "zlib",
@@ -17255,6 +17255,236 @@
    "out_size": 629349,
    "ratio": 0.1177,
    "compress_mbps": 4.73,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 52111,
+   "ratio": 0.3426,
+   "compress_mbps": 1.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46881,
+   "ratio": 0.3745,
+   "compress_mbps": 2.07,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 2.41,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3027,
+   "ratio": 0.2715,
+   "compress_mbps": 2.37,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1190,
+   "ratio": 0.3198,
+   "compress_mbps": 2.12,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 178311,
+   "ratio": 0.1732,
+   "compress_mbps": 1.24,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138661,
+   "ratio": 0.3249,
+   "compress_mbps": 1.83,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 186472,
+   "ratio": 0.387,
+   "compress_mbps": 1.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51490,
+   "ratio": 0.1003,
+   "compress_mbps": 1.11,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 12278,
+   "ratio": 0.3211,
+   "compress_mbps": 1.85,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1696,
+   "ratio": 0.4012,
+   "compress_mbps": 2.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3712344,
+   "ratio": 0.3642,
+   "compress_mbps": 1.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18518350,
+   "ratio": 0.3615,
+   "compress_mbps": 1.66,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3520112,
+   "ratio": 0.3531,
+   "compress_mbps": 1.28,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2868751,
+   "ratio": 0.0855,
+   "compress_mbps": 0.9,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 3017696,
+   "ratio": 0.4905,
+   "compress_mbps": 2.31,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3647083,
+   "ratio": 0.3616,
+   "compress_mbps": 2.76,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1724560,
+   "ratio": 0.2602,
+   "compress_mbps": 1.15,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5169629,
+   "ratio": 0.2393,
+   "compress_mbps": 1.67,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5261135,
+   "ratio": 0.7255,
+   "compress_mbps": 2.63,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11638957,
+   "ratio": 0.2807,
+   "compress_mbps": 1.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5825680,
+   "ratio": 0.6875,
+   "compress_mbps": 3.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637424,
+   "ratio": 0.1192,
+   "compress_mbps": 1.18,
    "decompress_mbps": null
   }
  ]

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -26,11 +26,12 @@ in_project_shell() {
 # back over the existing dashboard, then re-plot. The reference compressors are
 # not re-measured — their ratio is deterministic and their MB/s drifts <~3%
 # run-to-run (verified across regens) — so this skips the ~2 h external-comparator
-# rebuild entirely. The dominant remaining cost is native's own optimal-parse L9
-# (~1 MB/s); pass a level list to skip it when the Lean change does not touch the
-# L9 path (the prior L9 rows are kept by the upsert merge).
-#   bench/run.sh --native-only                  # all 9 native levels (~14 min)
-#   bench/run.sh --native-only 1,2,3,4,5,6,7,8  # skip the slow L9 (~half the time)
+# rebuild entirely. The dominant remaining cost is native's own optimal-parse at
+# levels 9 (L9-fast) and 10 (exact crown, ~1 MB/s); pass a level list to skip
+# them when the Lean change does not touch that path (the prior rows are kept by
+# the upsert merge).
+#   bench/run.sh --native-only                  # all 10 native levels, incl. the L10 crown (~14 min)
+#   bench/run.sh --native-only 1,2,3,4,5,6,7,8  # skip the slow L9/L10 (~half the time)
 if [ "${1:-}" = "--native-only" ]; then
   [ -f "$OUT" ] || { echo "no existing $OUT to splice into — run a full bench/run.sh first" >&2; exit 1; }
   TMP="$(mktemp --suffix=.json)"


### PR DESCRIPTION
This PR adds a cheaper approximate-optimal LZ parser and deploys it as a new level-9 tier, moving the exact backward-DP crown to level 10. **Level-9 semantics change:** native level 9 was the exact max-ratio crown and is now the faster L9-fast tier — callers pinning `level = 9` for absolute best ratio should now pass `level = 10` (the zlib/FFI bindings are a separate 0–9 path and are unchanged).

L9-fast makes three cost cuts versus the exact DP — a single DP round (no round-2 refit), no length-code boundary scan, and a shallower candidate cache (chain depth 64) — reaching near the crown's ratio at ~2× its speed. A knob sweep (measured on Silesia, chungus) put the operating point at chain depth 64 with the boundary scan off, landing ~20% *outside* the L8→L9 mixing frontier: a genuine new Pareto point, not something reachable by blending the existing tiers. On alice29.txt the tier ordering is L10 crown 52111 ≤ L9-fast 53059 < L8 54127.

Correctness is nearly free because the fast parser reuses the exact DP's choice-array format and its re-verifying emitter `optimalEmit`: the validity and encodability contracts in `LZ77OptimalCorrect` are stated for arbitrary choice arrays, so the L9-fast lemmas are the exact ones with `computeChoicesFast` substituted, and `deflateDynamicBlocksOptimalFast`'s roundtrip quadruple in `DeflateBlockSplit` is a byte-for-byte twin of the exact one. The `deflateRaw` dispatch gains a level-9 (fast) / level-10 (exact) split, threaded through the three roundtrip theorems in `DeflateRoundtrip`. Every branch stays proven, with no new axioms and 0 sorries; the tests exercise both parsers through the native and zlib-FFI decoders and pin the tier ordering. Levels ≥ 10 alias the crown; above the `optimalMaxSize` memory gate both tiers fall through to the split path.

🤖 Prepared with Claude Code