### PR TITLE
doc: warn that cross-worktree binaries are not layout-comparable (perf-pr-graphs)

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -228,6 +228,24 @@ artifacts move into `$W`.
      then `git worktree remove --force $W/before`) and pass
      `$W/perf_before.json` as BEFORE.
 
+   **Cross-worktree build caveat (this bites — read it).** A binary built in a
+   *separate* worktree (the `$W/before` merge-base build above) is **not
+   code-layout-comparable** to the AFTER binary built in your main worktree. Lean
+   `.o` files are deterministic, but the two worktrees embed different absolute
+   paths and can link objects into a different layout, which shifts i-cache
+   alignment of hot loops and produces a **uniform ~5–15% speed offset across ALL
+   levels** — a pure artifact, not the PR. The tell: the offset appears at levels
+   your PR does not touch (e.g. L1–8 for an L10-only change) and is roughly
+   constant, largest on the fast/bandwidth-bound levels. It survives interleaving
+   and shows ~1.00× same-binary drift, so it looks *real* — do not trust it. When
+   a stale baseline forces a merge-base rebuild, **build BOTH commits in the SAME
+   worktree** to isolate the source change: `git checkout <parent>` in the main
+   worktree, `lake build bench-report`, copy the binary aside; `git checkout` back
+   to the PR branch, rebuild, copy aside; then compare the two saved binaries.
+   Only a same-worktree pair is honest about whether L1–N moved. (If the two
+   binaries differ by a uniform offset at untouched levels, it is the worktree,
+   not your code — the untouched levels must overlay to within ~1%.)
+
    **Cross-session caveat.** BEFORE (recorded earlier) and AFTER (measured now)
    are different sessions, so a small single-digit-% speed delta can be
    cross-session / machine-load noise rather than the PR. Before reading a fine


### PR DESCRIPTION
This PR adds a "Cross-worktree build caveat" to the perf-pr-graphs skill's stale-baseline fallback. When a stale dashboard forces a merge-base rebuild, the skill currently builds that BEFORE binary in a separate worktree — but such a binary is not code-layout-comparable to the AFTER binary built in the main worktree. The two embed different absolute paths and can link objects into a different layout, shifting instruction-cache alignment of hot loops and producing a uniform ~5-15% speed offset across all levels. That artifact survives interleaving and shows ~1.00x same-binary drift, so it masquerades as a real regression even at levels the PR does not touch. The caveat instructs building both commits in the same worktree to isolate the source change, with the rule that untouched levels must overlay to within ~1%. It was found the hard way while producing the graphs for https://github.com/kim-em/lean-zip/pull/2729.

🤖 Prepared with Claude Code