### PR TITLE
perf: niceLen early-out ladder in the chain walk

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -788,13 +788,13 @@ theorem winMask_lt (n : Nat) : (n &&& 0x7FFF) < chainWinSize := by
     emitted match. Reuses `lz77Greedy`'s `hash3`/`countMatch`/`trailing` helpers
     (and their proofs). -/
 def lz77Chain (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (niceLen : Nat := 258) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
-    (mainLoop data windowSize hashSize maxChain
+    (mainLoop data windowSize hashSize maxChain niceLen
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap).toArray
 where
   /-- Walk the `prev` chain up to `fuel` steps from `cand`, keeping the longest
@@ -802,18 +802,20 @@ where
       out-of-range link (`cand ≥ pos`, incl. the `data.size` sentinel). `prev`
       is the fixed-size circular ring indexed by `cand &&& 0x7FFF`; its contents
       are a pure heuristic, so the windowing never enters the validity proof. -/
-  chainWalk (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen : Nat)
+  chainWalk (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen niceLen : Nat)
       (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen bestPos : Nat) : Nat × Nat :=
     if fuel = 0 then (bestLen, bestPos)
     else if hc : cand < pos ∧ pos - cand ≤ windowSize then
       have hcand : cand + maxLen ≤ data.size := by omega
       let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
       let (bl, bp) := if ml > bestLen then (ml, cand) else (bestLen, bestPos)
-      -- Early stop: a match of the maximum possible length cannot be beaten, so
-      -- stop walking the chain. Provably zero ratio loss; on repetitive input
-      -- (matches reach `maxLen` immediately) this restores near-greedy speed.
-      if bl ≥ maxLen then (bl, bp)
-      else chainWalk data prev windowSize pos maxLen hpm prev[cand &&& 0x7FFF]! (fuel - 1) bl bp
+      -- Early stop: once the best length reaches the level's `niceLen` cutoff (or
+      -- the maximum possible `maxLen`, whichever is smaller) the match is already
+      -- good enough, so stop walking the chain (libdeflate `nice_match_length`).
+      -- The `maxLen` stop alone is provably zero ratio loss; a `niceLen < maxLen`
+      -- cutoff trades a little ratio for a shorter walk at the deep levels.
+      if bl ≥ min niceLen maxLen then (bl, bp)
+      else chainWalk data prev windowSize pos maxLen niceLen hpm prev[cand &&& 0x7FFF]! (fuel - 1) bl bp
     else (bestLen, bestPos)
   termination_by fuel
   decreasing_by omega
@@ -836,7 +838,7 @@ where
     else (hashTable, prev)
   termination_by matchLen - j
   decreasing_by all_goals omega
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain niceLen : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
@@ -845,7 +847,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let m := chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let m := chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := m.1
       let matchPos := m.2
       if hge : matchLen ≥ 3 then
@@ -853,13 +855,13 @@ where
           have : data.size - (pos + matchLen) < data.size - pos := by omega
           let (hashTable, prev) := updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
           .reference matchLen (pos - matchPos) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+            mainLoop data windowSize hashSize maxChain niceLen hashTable prev (pos + matchLen) insertCap
         else
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+            mainLoop data windowSize hashSize maxChain niceLen hashTable prev (pos + 1) insertCap
       else
         .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+          mainLoop data windowSize hashSize maxChain niceLen hashTable prev (pos + 1) insertCap
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
@@ -888,7 +890,7 @@ small `Nat`) instead of `chainWalkGuarded`, which stays as the proof bridge. -/
 /-- Proven-bounds copy of `lz77Chain.chainWalk`: the circular read
     `prev[cand &&& 0x7FFF]` is in range because the mask gives
     `cand &&& 0x7FFF < chainWinSize` (`winMask_lt`) and `hps : min chainWinSize data.size ≤ prev.size`. -/
-def chainWalkFast (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen : Nat)
+def chainWalkFast (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen niceLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
     (cand fuel bestLen bestPos : Nat) : Nat × Nat :=
   if fuel = 0 then (bestLen, bestPos)
@@ -896,8 +898,8 @@ def chainWalkFast (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen :
     have hcand : cand + maxLen ≤ data.size := by omega
     let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
     let (bl, bp) := if ml > bestLen then (ml, cand) else (bestLen, bestPos)
-    if bl ≥ maxLen then (bl, bp)
-    else chainWalkFast data prev windowSize pos maxLen hpm hps
+    if bl ≥ min niceLen maxLen then (bl, bp)
+    else chainWalkFast data prev windowSize pos maxLen niceLen hpm hps
       (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega)) (fuel - 1) bl bp
   else (bestLen, bestPos)
 termination_by fuel
@@ -907,12 +909,12 @@ decreasing_by omega
     inner loop; the (unreachable, since `prev` is the fixed 32768-entry ring)
     fallback is the original panic-checked walk, so this equals `lz77Chain.chainWalk`. -/
 @[inline] def chainWalkGuarded (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
     (cand fuel bestLen bestPos : Nat) : Nat × Nat :=
   if hps : min chainWinSize data.size ≤ prev.size then
-    chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos
+    chainWalkFast data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos
   else
-    lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+    lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos
 
 /-- Packed-result copy of `chainWalkFast` (Wave 5 de-boxing): the identical
     walk, but the `(bestLen, bestPos)` accumulator is carried and returned as
@@ -922,7 +924,7 @@ decreasing_by omega
     `min 258 _ < 512`, so the call sites decode exactly with `% 512` / `/ 512`
     (`chainWalkGuardedPacked_mod`/`_div` in `LZ77ChainCorrect`, via the
     lockstep equality `chainWalkPacked_eq`). -/
-def chainWalkPacked (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen : Nat)
+def chainWalkPacked (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen niceLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
     (cand fuel bestLen bestPos : Nat) : Nat :=
   if fuel = 0 then bestPos * 512 + bestLen
@@ -936,14 +938,21 @@ def chainWalkPacked (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen
         data[cand + bestLen]'(by omega) != data[pos + bestLen]'(by omega)
       else false
     if skip then
-      chainWalkPacked data prev windowSize pos maxLen hpm hps
+      -- Prefilter miss keeps `bestLen` unchanged; mirror `chainWalkFast`'s early
+      -- stop so the two stay in lockstep (`chainWalkPacked_eq` holds for *any*
+      -- `bestLen`, unconditionally). From the matcher call sites — which start at
+      -- `bestLen = 0` and, on the non-skip branch, return the moment `bestLen`
+      -- reaches the cutoff — every recursive call has `bestLen < min niceLen maxLen`,
+      -- so this test is a well-predicted always-false branch on the hot skip path.
+      if bestLen ≥ min niceLen maxLen then bestPos * 512 + bestLen
+      else chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps
         (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega)) (fuel - 1) bestLen bestPos
     else
       let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
       let bl := if ml > bestLen then ml else bestLen
       let bp := if ml > bestLen then cand else bestPos
-      if bl ≥ maxLen then bp * 512 + bl
-      else chainWalkPacked data prev windowSize pos maxLen hpm hps
+      if bl ≥ min niceLen maxLen then bp * 512 + bl
+      else chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps
         (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega)) (fuel - 1) bl bp
   else bestPos * 512 + bestLen
 termination_by fuel
@@ -954,12 +963,12 @@ decreasing_by all_goals omega
     this equals `bestPos * 512 + bestLen` of `lz77Chain.chainWalk`
     (`chainWalkGuardedPacked_eq`). -/
 @[inline] def chainWalkGuardedPacked (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
     (cand fuel bestLen bestPos : Nat) : Nat :=
   if hps : min chainWinSize data.size ≤ prev.size then
-    chainWalkPacked data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos
+    chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos
   else
-    let p := lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+    let p := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos
     p.2 * 512 + p.1
 
 /-- Proven-bounds copy of `lz77Chain.updateHashes`: the bucket index `hsh` is
@@ -1045,16 +1054,16 @@ decreasing_by all_goals omega
     tokens) and `lz77GreedyIter.trailing`; only the token-emitting `mainLoop`
     differs (push vs. cons). Proven equal to `lz77Chain` in `LZ77ChainCorrect`. -/
 def lz77ChainIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (niceLen : Nat := 258) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap
+    mainLoop data windowSize hashSize maxChain insertCap niceLen
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap niceLen : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
@@ -1064,7 +1073,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1072,13 +1081,13 @@ where
           have : data.size - (pos + matchLen) < data.size - pos := by omega
           let (hashTable, prev) :=
             updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+          mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + matchLen)
             (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + 1)
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + 1)
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
@@ -1107,17 +1116,17 @@ where
     `updateHashes` and `lz77Greedy.trailing`. Equal-quality contracts proven in
     `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
     (mainLoop data windowSize hashSize maxChain
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch).toArray
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen).toArray
 where
   mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch : Nat) : List LZ77Token :=
+      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
@@ -1125,7 +1134,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let m := lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let m := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := m.1
       let matchPos := m.2
       if hge : matchLen ≥ 3 then
@@ -1140,7 +1149,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let m2 :=
-                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
               let matchLen2 := m2.1
               let matchPos2 := m2.2
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1151,39 +1160,39 @@ where
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                   .literal (data[pos]'(by omega)) ::
                     .reference matchLen2 (pos + 1 - matchPos2) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen
                 else
                   -- matchLen2 spills past data: keep match at pos
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                   .reference matchLen (pos - matchPos) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
               else
                 -- No better match at pos+1: keep match at pos
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                 .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
               .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
+                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
           else
             -- Near end of data: keep match at pos
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
+              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
         else
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch
+            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen
       else
         .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch
+          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
@@ -1195,16 +1204,16 @@ where
     token-emitting `mainLoop` differs (push vs. cons). Proven equal to
     `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
@@ -1214,7 +1223,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1228,7 +1237,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let r2 :=
-                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
               let matchLen2 := r2 % 512
               let matchPos2 := r2 / 512
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1236,37 +1245,37 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1 + matchLen2)
                     (acc.push (.literal (data[pos]'(by omega))) |>.push
                       (.reference matchLen2 (pos + 1 - matchPos2)))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                     (acc.push (.reference matchLen (pos - matchPos)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                 (acc.push (.reference matchLen (pos - matchPos)))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
               (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
@@ -1295,17 +1304,17 @@ termination_by data.size - pos
     identical control flow and chain state, `Array UInt32` accumulator.
     Equal to `(lz77ChainIter ..).map packTok` (`lz77ChainIterP_eq`). -/
 def lz77ChainIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (niceLen : Nat := 258) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap
+    mainLoop data windowSize hashSize maxChain insertCap niceLen
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap niceLen : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
@@ -1315,7 +1324,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1323,13 +1332,13 @@ where
           have : data.size - (pos + matchLen) < data.size - pos := by omega
           let (hashTable, prev) :=
             updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+          mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + matchLen)
             (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + 1)
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       trailingP data pos acc
@@ -1340,17 +1349,17 @@ where
     identical control flow and chain state, `Array UInt32` accumulator.
     Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
 def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
@@ -1360,7 +1369,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1377,7 +1386,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let r2 :=
-                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
               let matchLen2 := r2 % 512
               let matchPos2 := r2 / 512
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1385,20 +1394,20 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1 + matchLen2)
                     (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                       (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                     (acc.push (packTok (.reference matchLen (pos - matchPos))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               -- Gated: first match already long; skip the lookahead, but still insert
@@ -1406,17 +1415,17 @@ where
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       trailingP data pos acc

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -598,15 +598,36 @@ def goodMatch (level : UInt8) : Nat :=
   if level ≤ 6 then 8
   else 259
 
+/-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
+    the chain walk stops as soon as the best match reaches this length, since a
+    match this long is already good enough — burning the rest of the depth budget
+    to lengthen it further rarely pays for itself. The ladder starts from
+    libdeflate's values (L2=10, L3=14, L4=30, L5=30, L6=65, L7=130, L8=L9=258).
+    Level 1 keeps `258` (no early-out) to leave the measured `deflate_fast` corner
+    (#2726) untouched — at chain depth 4 the walk is already short, so a cutoff
+    buys little there. `258` (the max match length, ≥ every `maxLen`) disables the
+    cutoff: the walk then stops only on the full-match / fuel condition, exactly as
+    before this knob existed. The cutoff never enters correctness — the chain is a
+    heuristic re-verified at emission — so any value keeps the encoder contracts. -/
+def niceLen (level : UInt8) : Nat :=
+  if level ≤ 1 then 258
+  else if level ≤ 2 then 10
+  else if level ≤ 3 then 14
+  else if level ≤ 4 then 30
+  else if level ≤ 5 then 30
+  else if level ≤ 6 then 65
+  else if level ≤ 7 then 130
+  else 258
+
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
     greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
     lazy variant, which improves ratio at equal window/chain depth. Both share the
-    same `(chainDepth, insertCap)` ladder and satisfy the same encoder contracts
-    (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the choice is
-    transparent to the roundtrip proof. -/
+    same `(chainDepth, insertCap, niceLen)` ladder and satisfy the same encoder
+    contracts (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the
+    choice is transparent to the roundtrip proof. -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
-  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level)
-  else lz77ChainIter data (chainDepth level) 32768 (insertCap level)
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  else lz77ChainIter data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
     dispatch over the packed matcher twins, producing one unboxed `UInt32`
@@ -614,8 +635,8 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
     `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
     downstream consumers still run on `lzMatch` — stage B moves them here. -/
 def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
-  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level)
-  else lz77ChainIterP data (chainDepth level) 32768 (insertCap level)
+  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  else lz77ChainIterP data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-! ## Self-contained block-split dynamic compression
 

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -34,25 +34,25 @@ theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level)
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
       (by omega) (by omega)
-  · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)
 
 theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
     lzMatch data level = #[] := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) hz
-  · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) hz
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) hz
+  · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) (niceLen level) hz
 
 theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
     Deflate.Spec.resolveLZ77 (tokensToSymbols (lzMatch data level)) [] =
       some data.data.toList := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (by omega)
-  · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (by omega)
+  · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (niceLen level) (by omega)
 
 set_option maxHeartbeats 800000 in
 /-- One self-contained chunk block: its bits append to `bw`, it preserves `wf`,

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -19,12 +19,12 @@ open Zip.Native.Deflate (lz77Chain lz77Greedy)
     (or empty): the invariant `Q` on `(bestLen, bestPos)` is preserved because
     every update records `countMatch`'s verified result at a guarded candidate. -/
 theorem chainWalk_spec (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
     (cand fuel bestLen bestPos : Nat)
     (hb : bestLen = 0 ∨ (bestPos < pos ∧ pos - bestPos ≤ windowSize ∧
         bestPos + maxLen ≤ data.size ∧
         (∀ i, i < bestLen → data[pos + i]! = data[bestPos + i]!) ∧ bestLen ≤ maxLen)) :
-    let r := lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+    let r := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos
     r.1 = 0 ∨ (r.2 < pos ∧ pos - r.2 ≤ windowSize ∧ r.2 + maxLen ≤ data.size ∧
         (∀ i, i < r.1 → data[pos + i]! = data[r.2 + i]!) ∧ r.1 ≤ maxLen) := by
   induction fuel generalizing cand bestLen bestPos with
@@ -91,10 +91,10 @@ theorem guardedSet_eq {α : Type} (a : Array α) (i : Nat) (v : α) :
 /-- `lz77Chain.mainLoop` produces a valid decomposition from `pos`. Mirrors
     `lz77Greedy.mainLoop_valid`; the reference case uses `chainWalk_spec` (which
     holds for *any* `prev` array) in place of the inline single-probe match. -/
-theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
+theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77Chain.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap) := by
+      (lz77Chain.mainLoop data windowSize hashSize maxChain niceLen hashTable prev pos insertCap) := by
   unfold lz77Chain.mainLoop
   split
   · rename_i hlt
@@ -102,7 +102,7 @@ theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChai
     simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-      windowSize pos (min 258 (data.size - pos)) (by omega)
+      windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
       hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
     split
     · rename_i hge
@@ -114,30 +114,30 @@ theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChai
           · intro i hi
             rw [Nat.sub_sub_self (Nat.le_of_lt hQ.1)]
             exact hQ.2.2.2.1 i hi
-          · exact lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ hw
+          · exact lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ _ hw
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+          (lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+        (lz77Chain_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- `lz77Chain` produces a valid decomposition of the input data. -/
-theorem lz77Chain_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77Chain_valid (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77Chain data maxChain windowSize insertCap).toList := by
+    ValidDecomp data 0 (lz77Chain data maxChain windowSize insertCap niceLen).toList := by
   simp only [lz77Chain]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77Chain_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap hw
+  · simp only; exact lz77Chain_mainLoop_valid data windowSize 65536 maxChain niceLen _ _ 0 insertCap hw
 
 /-- Resolving the LZ77 tokens produced by `lz77Chain` recovers the original data. -/
-theorem lz77Chain_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77Chain_resolves (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77Chain data maxChain windowSize insertCap)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77Chain data maxChain windowSize insertCap niceLen)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77Chain_valid data maxChain windowSize insertCap hw)
+  validDecomp_resolves data _ (lz77Chain_valid data maxChain windowSize insertCap niceLen hw)
 
 /-! ## Encodability -/
 
@@ -148,9 +148,9 @@ private def Enc (t : LZ77Token) : Prop :=
   | .literal _ => True
   | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
 
-theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
+theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77Chain.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap, Enc t := by
+    ∀ t ∈ lz77Chain.mainLoop data windowSize hashSize maxChain niceLen hashTable prev pos insertCap, Enc t := by
   unfold lz77Chain.mainLoop
   split
   · rename_i hlt
@@ -158,7 +158,7 @@ theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize max
     simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-      windowSize pos (min 258 (data.size - pos)) (by omega)
+      windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
       hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
     split
     · rename_i hge
@@ -169,15 +169,15 @@ theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize max
         · intro t ht
           cases ht with
           | head => exact ⟨hge, by omega, by omega, by omega⟩
-          | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+          | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77Chain_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     -- `trailing` emits only literals
     exact trailing_encodable data pos t ht
@@ -185,9 +185,9 @@ termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- Every token `lz77Chain` emits satisfies the encoder bounds. -/
-theorem lz77Chain_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77Chain_encodable (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77Chain data maxChain windowSize insertCap).toList,
+    ∀ t ∈ (lz77Chain data maxChain windowSize insertCap niceLen).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -196,7 +196,7 @@ theorem lz77Chain_encodable (data : ByteArray) (maxChain windowSize insertCap : 
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77Chain_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap hw hws t ht
+    exact lz77Chain_mainLoop_encodable data windowSize 65536 maxChain niceLen _ _ 0 insertCap hw hws t ht
 
 /-! ## Proven-bounds matcher equivalences (Wave 2d)
 
@@ -212,10 +212,10 @@ exactly as before the conversion. -/
     panic-checked reference walk: the bodies differ only in how `prev[cand]` is
     accessed (`'h` vs `!`), and `getElem!_pos` bridges the two. -/
 theorem chainWalkFast_eq (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
     (cand fuel bestLen bestPos : Nat) :
-    chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos =
-      lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos := by
+    chainWalkFast data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos =
+      lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos := by
   induction fuel generalizing cand bestLen bestPos with
   | zero => rw [chainWalkFast, lz77Chain.chainWalk]; simp only [↓reduceIte]
   | succ k ih =>
@@ -228,10 +228,10 @@ theorem chainWalkFast_eq (data : ByteArray) (prev : Array Nat)
 
 /-- One runtime guard collapses to the reference walk. -/
 theorem chainWalkGuarded_eq (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
     (cand fuel bestLen bestPos : Nat) :
-    chainWalkGuarded data prev windowSize pos maxLen hpm cand fuel bestLen bestPos =
-      lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos := by
+    chainWalkGuarded data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos =
+      lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos := by
   unfold chainWalkGuarded
   split
   · exact chainWalkFast_eq ..
@@ -266,11 +266,11 @@ theorem countMatch_le_of_byte_ne (data : ByteArray) (cand pos maxLen : Nat)
     walk: identical control flow, with the pair accumulator carried as
     `bestPos * 512 + bestLen` at every step. -/
 theorem chainWalkPacked_eq (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : min chainWinSize data.size ≤ prev.size)
     (cand fuel bestLen bestPos : Nat) :
-    chainWalkPacked data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos =
-      (chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos).2 * 512 +
-        (chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos).1 := by
+    chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos =
+      (chainWalkFast data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos).2 * 512 +
+        (chainWalkFast data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos).1 := by
   induction fuel generalizing cand bestLen bestPos with
   | zero => rw [chainWalkPacked, chainWalkFast]; simp only [↓reduceIte]
   | succ k ih =>
@@ -282,7 +282,8 @@ theorem chainWalkPacked_eq (data : ByteArray) (prev : Array Nat)
       -- The prefilter `skip` only fires when the byte at offset `bestLen`
       -- mismatches; then `countMatch ≤ bestLen` (contrapositive of
       -- `countMatch_matches`), so the un-prefiltered `chainWalkFast` does not
-      -- update either and recurses with `(bestLen, bestPos)` — same as the skip.
+      -- update either and takes the same early-stop / recurse decision on
+      -- `bestLen ≥ min niceLen maxLen` — matching the packed skip branch.
       by_cases hbl : bestLen < maxLen
       · simp only [dif_pos hbl]
         by_cases hbyte : data[cand + bestLen]'(by omega) = data[pos + bestLen]'(by omega)
@@ -290,36 +291,40 @@ theorem chainWalkPacked_eq (data : ByteArray) (prev : Array Nat)
           rw [hbyte]
           simp only [bne_self_eq_false, Bool.false_eq_true, ↓reduceIte]
           by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
-          · by_cases hb : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ maxLen
+          · by_cases hb : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ min niceLen maxLen
             · simp only [hml, hb, ↓reduceIte]
             · simp only [hml, hb, ↓reduceIte, ih]
-          · by_cases hb : bestLen ≥ maxLen
+          · by_cases hb : bestLen ≥ min niceLen maxLen
             · simp only [hml, hb, ↓reduceIte]
             · simp only [hml, hb, ↓reduceIte, ih]
-        · -- bytes differ → skip = true → both sides recurse with (bestLen, bestPos)
+        · -- bytes differ → skip = true → both sides take the `bestLen ≥ min niceLen maxLen`
+          -- early-stop / recurse decision with `(bestLen, bestPos)` unchanged
           have hne! : data[cand + bestLen]! ≠ data[pos + bestLen]! := by
             rw [getElem!_pos data (cand + bestLen) (by omega),
               getElem!_pos data (pos + bestLen) (by omega)]
             exact hbyte
           have hle := countMatch_le_of_byte_ne data cand pos maxLen hcand hpm bestLen hne!
-          simp only [bne_iff_ne.mpr hbyte, ↓reduceIte, Nat.not_lt.mpr hle,
-            Nat.not_le.mpr hbl, ih]
-      · -- bestLen ≥ maxLen → skip = false; countMatch ≤ maxLen ≤ bestLen, no update
+          by_cases hb : bestLen ≥ min niceLen maxLen
+          · simp only [bne_iff_ne.mpr hbyte, ↓reduceIte, Nat.not_lt.mpr hle, hb]
+          · simp only [bne_iff_ne.mpr hbyte, ↓reduceIte, Nat.not_lt.mpr hle, hb, ih]
+      · -- bestLen ≥ maxLen → skip = false; countMatch ≤ maxLen ≤ bestLen, no update, early stop
         simp only [dif_neg hbl, Bool.false_eq_true, ↓reduceIte]
         have hle : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≤ bestLen :=
           Nat.le_trans (lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm).2
             (Nat.le_of_not_lt hbl)
-        simp only [Nat.not_lt.mpr hle, ge_iff_le, Nat.le_of_not_lt hbl, ↓reduceIte]
+        have hbmin : min niceLen maxLen ≤ bestLen :=
+          Nat.le_trans (Nat.min_le_right _ _) (Nat.le_of_not_lt hbl)
+        simp only [Nat.not_lt.mpr hle, ge_iff_le, hbmin, ↓reduceIte]
     · simp only [dif_neg hc]
 
 /-- One runtime guard collapses the packed walk to the packed image of the
     reference walk. -/
 theorem chainWalkGuardedPacked_eq (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
     (cand fuel bestLen bestPos : Nat) :
-    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel bestLen bestPos =
-      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos).2 * 512 +
-        (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos).1 := by
+    chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).2 * 512 +
+        (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos).1 := by
   unfold chainWalkGuardedPacked
   split
   · rw [chainWalkPacked_eq, chainWalkFast_eq]
@@ -328,31 +333,31 @@ theorem chainWalkGuardedPacked_eq (data : ByteArray) (prev : Array Nat)
 /-- From a zero-initialised best length, the reference walk's best length
     never exceeds `maxLen` (specialisation of `chainWalk_spec`). -/
 theorem chainWalk_fst_le (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat) :
-    (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).1 ≤ maxLen := by
-  obtain h0 | hQ := chainWalk_spec data prev windowSize pos maxLen hpm cand fuel 0 0 (Or.inl rfl)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat) :
+    (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).1 ≤ maxLen := by
+  obtain h0 | hQ := chainWalk_spec data prev windowSize pos maxLen niceLen hpm cand fuel 0 0 (Or.inl rfl)
   · omega
   · exact hQ.2.2.2.2
 
 /-- Decode the packed walk's best length: with `maxLen < 512` the low bits are
     exactly the reference walk's `bestLen`. -/
 theorem chainWalkGuardedPacked_mod (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
     (hml : maxLen ≤ 511) :
-    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel 0 0 % 512 =
-      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).1 := by
+    chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel 0 0 % 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).1 := by
   rw [chainWalkGuardedPacked_eq]
-  have h := chainWalk_fst_le data prev windowSize pos maxLen hpm cand fuel
+  have h := chainWalk_fst_le data prev windowSize pos maxLen niceLen hpm cand fuel
   omega
 
 /-- Decode the packed walk's best position (the high bits). -/
 theorem chainWalkGuardedPacked_div (data : ByteArray) (prev : Array Nat)
-    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
     (hml : maxLen ≤ 511) :
-    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel 0 0 / 512 =
-      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).2 := by
+    chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel 0 0 / 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel 0 0).2 := by
   rw [chainWalkGuardedPacked_eq]
-  have h := chainWalk_fst_le data prev windowSize pos maxLen hpm cand fuel
+  have h := chainWalk_fst_le data prev windowSize pos maxLen niceLen hpm cand fuel
   omega
 
 /-- Every matcher call site clamps `maxLen` to `min 258 _`; this discharges
@@ -452,10 +457,10 @@ theorem trailing_eq (data : ByteArray) (pos : Nat) (acc : Array LZ77Token) :
 /-- The iterative chain `mainLoop` is the accumulator form of the recursive one.
     The `chainWalk`/`updateHashes` helpers are shared, so the only difference is
     push vs. cons at each emission. -/
-private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxChain insertCap niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos acc =
-    acc ++ (lz77Chain.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap).toArray := by
+    lz77ChainIter.mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev pos acc =
+    acc ++ (lz77Chain.mainLoop data windowSize hashSize maxChain niceLen hashTable prev pos insertCap).toArray := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainIter.mainLoop lz77Chain.mainLoop
@@ -475,35 +480,35 @@ private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxCha
       exact trailing_eq data pos acc
 
 /-- `lz77ChainIter` produces exactly the same tokens as `lz77Chain`. -/
-theorem lz77ChainIter_eq_lz77Chain (data : ByteArray) (maxChain windowSize insertCap : Nat) :
-    lz77ChainIter data maxChain windowSize insertCap = lz77Chain data maxChain windowSize insertCap := by
+theorem lz77ChainIter_eq_lz77Chain (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat) :
+    lz77ChainIter data maxChain windowSize insertCap niceLen = lz77Chain data maxChain windowSize insertCap niceLen := by
   unfold lz77ChainIter lz77Chain
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chain]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainIter_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainIter_valid (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainIter data maxChain windowSize insertCap).toList := by
-  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_valid data maxChain windowSize insertCap hw
+    ValidDecomp data 0 (lz77ChainIter data maxChain windowSize insertCap niceLen).toList := by
+  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_valid data maxChain windowSize insertCap niceLen hw
 
-theorem lz77ChainIter_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainIter_resolves (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainIter data maxChain windowSize insertCap)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainIter data maxChain windowSize insertCap niceLen)) [] =
       some data.data.toList := by
-  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_resolves data maxChain windowSize insertCap hw
+  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_resolves data maxChain windowSize insertCap niceLen hw
 
-theorem lz77ChainIter_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainIter_encodable (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainIter data maxChain windowSize insertCap).toList,
+    ∀ t ∈ (lz77ChainIter data maxChain windowSize insertCap niceLen).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
-  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_encodable data maxChain windowSize insertCap hw hws
+  rw [lz77ChainIter_eq_lz77Chain]; exact lz77Chain_encodable data maxChain windowSize insertCap niceLen hw hws
 
 /-- The chain matcher emits no tokens on empty input. -/
-theorem lz77ChainIter_empty (data : ByteArray) (maxChain windowSize insertCap : Nat)
-    (hzero : data.size = 0) : lz77ChainIter data maxChain windowSize insertCap = #[] := by
+theorem lz77ChainIter_empty (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
+    (hzero : data.size = 0) : lz77ChainIter data maxChain windowSize insertCap niceLen = #[] := by
   rw [lz77ChainIter_eq_lz77Chain]
   simp only [lz77Chain, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -25,9 +25,9 @@ set_option backward.split false in
     reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
     lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
 theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch : Nat) (hw : windowSize > 0) :
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -35,7 +35,7 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
     simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-      windowSize pos (min 258 (data.size - pos)) (by omega)
+      windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
       hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
     split
     · rename_i hge
@@ -49,7 +49,7 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
             split
             · have hspec2 := chainWalk_spec data
                 (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) niceLen (by omega)
                 (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
                   lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
                 maxChain 0 0 (Or.inl rfl)
@@ -61,38 +61,38 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                   · exact .literal (by omega) (getElem!_pos data pos (by omega))
                       (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
                         (fun i hi => hQ2.2.2.2.1 i hi)
-                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw))
+                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw))
                 · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen hw)
 
 /-! ## Encodability -/
 
@@ -104,8 +104,8 @@ private def Enc (t : LZ77Token) : Prop :=
 
 set_option backward.split false in
 theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch, Enc t := by
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -113,7 +113,7 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
     simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-      windowSize pos (min 258 (data.size - pos)) (by omega)
+      windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
       hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
     split
     · rename_i hge
@@ -127,7 +127,7 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
             split
             · have hspec2 := chainWalk_spec data
                 (prev.set! (pos &&& 0x7FFF) hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) niceLen (by omega)
                 (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
                   lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
                 maxChain 0 0 (Or.inl rfl)
@@ -142,40 +142,40 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                     | tail _ h =>
                       cases h with
                       | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
                   | head => exact ⟨hge, by omega, by omega, by omega⟩
-                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -184,17 +184,17 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
     one — identical branch structure, push vs. cons at each emission (two pushes in
     the lookahead arm). -/
-private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch).toArray := by
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen).toArray := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
@@ -241,37 +241,37 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
       exact trailing_eq data pos acc
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
-theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat) :
-    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch =
-      lz77ChainLazy data maxChain windowSize insertCap goodMatch := by
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat) :
+    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen =
+      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen := by
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch hw
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen hw
 
-theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen hw
 
-theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).toList,
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
-theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
-    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch = #[] := by
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen = #[] := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
   simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -47,11 +47,11 @@ private theorem trailingP_eq (data : ByteArray) (pos : Nat) (acc : Array LZ77Tok
 
 /-- The packed greedy `mainLoop` is the packed image of the boxed one:
     identical control flow and chain state, `packTok` at each push. -/
-private theorem mainLoopP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+private theorem mainLoopP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainIterP.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+    lz77ChainIterP.mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev pos
         (acc.map packTok) =
-      (lz77ChainIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+      (lz77ChainIter.mainLoop data windowSize hashSize maxChain insertCap niceLen hashTable prev pos
         acc).map packTok := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
@@ -67,23 +67,23 @@ private theorem mainLoopP_eq (data : ByteArray) (windowSize hashSize maxChain in
       exact trailingP_eq data pos acc
 
 /-- `lz77ChainIterP` produces exactly the `packTok` image of `lz77ChainIter`. -/
-theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Nat) :
-    lz77ChainIterP data maxChain windowSize insertCap =
-      (lz77ChainIter data maxChain windowSize insertCap).map packTok := by
+theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat) :
+    lz77ChainIterP data maxChain windowSize insertCap niceLen =
+      (lz77ChainIter data maxChain windowSize insertCap niceLen).map packTok := by
   unfold lz77ChainIterP lz77ChainIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+      mainLoopP_eq data windowSize 65536 maxChain insertCap niceLen _ _ 0 #[]
 
 /-- The packed lazy `mainLoop` is the packed image of the boxed one. The gate
     (`matchLen < goodMatch`) is applied identically in both, so the branch tree
     stays in lockstep — one extra split versus the ungated proof. -/
-private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos
         (acc.map packTok) =
-      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos
         acc).map packTok := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
@@ -111,14 +111,14 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
 
 /-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
     `lz77ChainLazyIter`. -/
-theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat) :
-    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch =
-      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).map packTok := by
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen =
+      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch _ _ 0 #[]
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen _ _ 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -126,27 +126,27 @@ theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap 
 existing encodability theorems provide for the whole stream. -/
 
 /-- The boxed view of the packed greedy matcher is the boxed greedy matcher. -/
-theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainIterP data maxChain windowSize insertCap).map unpackTok =
-      lz77ChainIter data maxChain windowSize insertCap := by
-  have henc := lz77ChainIter_encodable data maxChain windowSize insertCap hw hws
+    (lz77ChainIterP data maxChain windowSize insertCap niceLen).map unpackTok =
+      lz77ChainIter data maxChain windowSize insertCap niceLen := by
+  have henc := lz77ChainIter_encodable data maxChain windowSize insertCap niceLen hw hws
   rw [lz77ChainIterP_eq, Array.map_map]
-  have hcongr : Array.map (unpackTok ∘ packTok) (lz77ChainIter data maxChain windowSize insertCap) =
-      Array.map id (lz77ChainIter data maxChain windowSize insertCap) :=
+  have hcongr : Array.map (unpackTok ∘ packTok) (lz77ChainIter data maxChain windowSize insertCap niceLen) =
+      Array.map id (lz77ChainIter data maxChain windowSize insertCap niceLen) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
-theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch).map unpackTok =
-      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch := by
-  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch hw hws
+    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen hw hws
   rw [lz77ChainLazyIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok)
-        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch) =
-      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch) :=
+        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
@@ -157,8 +157,8 @@ theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
     lzMatchP data level = (lzMatch data level).map packTok := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level)
-  · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
     stage B+ consumers of `lzMatchP` inherit every `lzMatch` contract through
@@ -167,9 +167,9 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
     (lzMatchP data level).map unpackTok = lzMatch data level := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level)
+  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
       (by omega) (by omega)
-  · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)
 
 /-! ## Stages B+C: the packed base candidate equals the boxed one


### PR DESCRIPTION
This PR adds a `niceLen` cutoff to the hash-chain match finder: the walk now stops as soon as the best match reaches `min niceLen maxLen` (libdeflate's `nice_match_length`) instead of only on fuel exhaustion or a full 258-byte match. A per-level ladder next to `chainDepth` sets the cutoff from libdeflate's values (L2=10, L3=14, L4=30, L5=30, L6=65, L7=130, L8=L9=258); level 1 keeps 258 to leave the measured `deflate_fast` corner (#2726) untouched, and `niceLen = 258` reproduces the prior behaviour exactly since `maxLen ≤ 258` at every call site.

The parameter threads through the whole chain-walk family (`chainWalk`/`chainWalkFast`/`chainWalkPacked` and their guarded wrappers) and both matcher families (greedy/lazy, boxed/packed). Chain state stays heuristic-only — every emitted match is re-verified at emission by `countMatch` plus the window guards — so the `lzMatch_{encodable,empty,resolves}` contracts are untouched; the proof churn is re-threading the parameter through the packed/guarded equivalence twins. `chainWalkPacked`'s prefilter skip path gains the same early stop so it stays byte-for-byte equal to the reference walk unconditionally.

Measured (same-environment interleaved before/after — see the PR comment for graphs and the build-environment caveat), this lands a small fast-level win at negligible ratio cost: +3.1% at L2 and +2.2% at L3 (where the low niceLen values fire), tapering to neutral by L6–L7, +1.1% overall on Canterbury, with `max |Δratio| = 0.0158`. The deep-level speedup the issue hypothesised does not appear with libdeflate's values — on our matcher, matches rarely reach 65/130 bytes at L6/L7, so those cutoffs are near-inactive (their Δratio ≈ 0). What lands here is therefore the correct, verified `niceLen` knob and ladder — the first candidate knob of #2698 — plus the fast-level win; the deep-level value sweep and hull validation stay in #2698.

Closes #2735

🤖 Prepared with Claude Code