### PR TITLE
perf: observation-divergence block splitting at L4-L8 on packed tokens

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1048,7 +1048,10 @@ def chooseSplitsArbitratedSized (toks : Array LZ77Token) : List Nat × List Size
     to `deflateDynamicBlocksSharedAtTokens data toks chooseSplitsArbitrated`
     (`deflateDynamicBlocksSharedSized_eq`), but the winning partition's
     per-block `tokenFreqs` + `dynamicCodeLengths` run once (during sizing)
-    instead of twice. -/
+    instead of twice. Retired from the `deflateRaw` dispatch by #2737 — the
+    observation-divergence split (`deflateDynamicBlocksSharedAtP`) picks
+    boundaries with no sizing pass at all — but kept, with its proofs and
+    conformance tests, as the arbitrated reference pipeline. -/
 def deflateDynamicBlocksSharedSized (data : ByteArray) (toks : Array LZ77Token) : ByteArray :=
   if data.size == 0 then
     let f := tokenFreqs #[]
@@ -1057,6 +1060,153 @@ def deflateDynamicBlocksSharedSized (data : ByteArray) (toks : Array LZ77Token) 
   else
     let c := chooseSplitsArbitratedSized toks
     (emitSharedBlocksAtSized data toks c.1 c.2 0 BitWriter.empty).flush
+
+/-! ## Packed observation-divergence block splitting (#2737)
+
+The libdeflate-style divergence heuristic and the shared-window block emitter,
+both walking the `packTok`-encoded `UInt32` stream directly — the packed twins
+of `chooseSplitsHeuristic` and `emitSharedBlocksAt`. This is what lets the
+mid-band levels (4–7) afford per-block Huffman trees at all: the per-block
+frequency pass runs on `tokenFreqsP` (dense packed tables) and the emit on
+`emitTokensWithCodesP`, so the split candidate never materializes boxed
+`LZ77Token`s and never touches the `findTableCode` linear scans. At level 8 the
+same pipeline **replaces** the `chooseSplitsArbitrated` sizing pass: libdeflate
+picks boundaries with the streaming heuristic alone (no exact-bits arbitration),
+and the sizing pass — two extra boxed `tokenFreqs`+`symbolBitCount` walks over
+the whole token stream — was ~18% of level-8 cycles. The heuristic stays
+proof-free: the emitter clamps every cut (`emitSharedBlocksAtP` mirrors
+`emitSharedBlocksAt`'s clamping exactly), and the roundtrip transfers from the
+boxed reference via `deflateDynamicBlocksSharedAtP_eq`
+(`Zip/Spec/LZ77PackedCorrect.lean`). -/
+
+/-- Observation class of a packed token (`splitTokenClass` over the packed
+    fields, conformance-tested in `ZipTest/PackedTokens.lean`): literals (tag
+    bit clear) map to 0–7 by bits 7,6,0 of the byte field; references map to 8
+    (length < 9) or 9. -/
+@[inline] def splitTokenClassP (w : UInt32) : Nat :=
+  if w &&& ((1 : UInt32) <<< 31) = 0 then
+    (((w.toUInt8 >>> 5) &&& 6) ||| (w.toUInt8 &&& 1)).toNat
+  else
+    splitNumLiteralClasses + (if ((w >>> 16) &&& 0x7FFF).toNat ≥ 9 then 1 else 0)
+
+/-- Output bytes a packed token contributes (`splitTokenBytes` over the packed
+    fields): 1 for a literal, the length field for a reference. -/
+@[inline] def splitTokenBytesP (w : UInt32) : Nat :=
+  if w &&& ((1 : UInt32) <<< 31) = 0 then 1
+  else ((w >>> 16) &&& 0x7FFF).toNat
+
+/-- Packed twin of `chooseSplitsHeuristic`: entropy-divergence cut points
+    computed directly from the packed token stream — same constants, same
+    per-token floors/ceiling, same window-merge cadence, with
+    `splitTokenClassP`/`splitTokenBytesP` in place of the boxed accessors.
+    Heuristic-only (the emitter clamps arbitrary cuts), so it carries no proof
+    obligations; `ZipTest/PackedTokens.lean` pins it to the boxed heuristic
+    over the `unpackTok` view. -/
+def chooseSplitsHeuristicP (toks : Array UInt32) : List Nat := Id.run do
+  let mut totalBytes := 0
+  for t in toks do
+    totalBytes := totalBytes + splitTokenBytesP t
+  let mut old : Array Nat := Array.replicate splitNumClasses 0
+  let mut oldTot := 0
+  let mut new : Array Nat := Array.replicate splitNumClasses 0
+  let mut newTot := 0
+  let mut blockBytes := 0
+  let mut doneBytes := 0
+  let mut cuts : Array Nat := #[]
+  for h : i in [0:toks.size] do
+    let t := toks[i]
+    let c := splitTokenClassP t
+    new := new.set! c (new.getD c 0 + 1)
+    newTot := newTot + 1
+    blockBytes := blockBytes + splitTokenBytesP t
+    doneBytes := doneBytes + splitTokenBytesP t
+    if blockBytes ≥ splitMinBlockBytes && totalBytes - doneBytes ≥ splitMinBlockBytes then
+      let cut :=
+        blockBytes ≥ splitSoftMaxBlockBytes ||
+        (newTot ≥ splitCheckTokens && oldTot > 0 &&
+          splitEndBlockCheck old oldTot new newTot blockBytes)
+      if cut then
+        cuts := cuts.push (i + 1)
+        old := Array.replicate splitNumClasses 0
+        oldTot := 0
+        new := Array.replicate splitNumClasses 0
+        newTot := 0
+        blockBytes := 0
+      else if newTot ≥ splitCheckTokens then
+        for j in [0:splitNumClasses] do
+          old := old.set! j (old.getD j 0 + new.getD j 0)
+        oldTot := oldTot + newTot
+        new := Array.replicate splitNumClasses 0
+        newTot := 0
+  return cuts.toList
+
+/-- Packed twin of `emitDynBlock`: one dynamic Huffman block from a packed
+    token group onto a running writer, with `emitTokensWithCodesP` in place of
+    `emitTokensWithCodes`. Equal to `emitDynBlock` over the boxed view
+    (`emitDynBlockP_eq` in `Zip/Spec/LZ77PackedCorrect.lean`). -/
+def emitDynBlockP (bw : BitWriter) (data : ByteArray) (ptoks : Array UInt32)
+    (litLens distLens : List Nat)
+    (hlit : litLens.length = 286) (hdist : distLens.length = 30)
+    (isFinal : Bool) : BitWriter :=
+  let litCodes := canonicalCodes (litLens.toArray.map Nat.toUInt8)
+  let distCodes := canonicalCodes (distLens.toArray.map Nat.toUInt8)
+  let bw := bw.writeBits 1 (if isFinal then 1 else 0)  -- BFINAL (1 bit)
+  let bw := bw.writeBits 2 2                            -- BTYPE = 10 (dynamic)
+  let bw := writeDynamicHeader bw litLens distLens
+  have hlit_size : litCodes.size ≥ 286 := by
+    show (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size ≥ 286
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have hdist_size : distCodes.size ≥ 30 := by
+    show (canonicalCodes (distLens.toArray.map Nat.toUInt8)).size ≥ 30
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have h256 : 256 < litCodes.size := by
+    show 256 < (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  let bw := if data.size == 0 then bw
+            else emitTokensWithCodesP bw ptoks litCodes distCodes hlit_size hdist_size 0
+  let (code, len) := litCodes[256]'h256
+  bw.writeHuffCode code len
+
+/-- Packed twin of `emitSharedBlock`: the group's frequencies come from
+    `tokenFreqsP` (dense packed tables) and the emit from `emitDynBlockP`. -/
+def emitSharedBlockP (bw : BitWriter) (data : ByteArray) (group : Array UInt32)
+    (isFinal : Bool) : BitWriter :=
+  let f := tokenFreqsP group
+  let lens := dynamicCodeLengths f.1 f.2
+  emitDynBlockP bw data group lens.1 lens.2
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 isFinal
+
+/-- Packed twin of `emitSharedBlocksAt`: emit shared-window blocks at explicit
+    cut points directly from the packed token stream. Same clamping — every cut
+    is forced into `(pos, toks.size]`, so **any** cuts list yields a valid total
+    partition and the boundary heuristic stays proof-free. -/
+def emitSharedBlocksAtP (data : ByteArray) (toks : Array UInt32) (cuts : List Nat)
+    (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let bw := emitSharedBlockP bw data (toks.extract pos j) (decide (j ≥ toks.size))
+  if j ≥ toks.size then bw
+  else emitSharedBlocksAtP data toks cuts.tail j bw
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- The packed observation-divergence shared-window split candidate: emit the
+    packed token stream as shared-window dynamic blocks at the given cut points
+    (in `deflateRaw`, the `chooseSplitsHeuristicP` boundaries). Byte-identical
+    to the boxed reference
+    `deflateDynamicBlocksSharedAtTokens data (toks.map unpackTok) (fun _ => cuts)`
+    (`deflateDynamicBlocksSharedAtP_eq`), through which the roundtrip and
+    padding theorems transfer for **any** cut list. -/
+def deflateDynamicBlocksSharedAtP (data : ByteArray) (toks : Array UInt32)
+    (cuts : List Nat) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitSharedBlocksAtP data toks cuts 0 BitWriter.empty).flush
 
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
@@ -1325,21 +1475,31 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     So callers pinning `level = 9` for absolute best ratio should now pass 10.
     (The zlib/FFI bindings are a separate 0–9 path and are unchanged.)
 
-    Level 0 = stored; levels 1–7 run the single-block cost-model dispatch
-    (`deflateRawBase`). At the max-compression tiers (level ≥ 8) two block-split
-    streams are also tried, and the smallest of all candidates is emitted:
-      * self-contained split — per-chunk Huffman trees, fresh window per chunk
-        (wins on locally-varying statistics, e.g. structured binary);
-      * cross-block (shared-window) split — one whole-file match pass, token stream
-        partitioned per block, references cross block boundaries (wins on large
-        text, where the self-contained split loses cross-chunk matches). The
-        partition comes from the entropy-divergence heuristic arbitrated in
-        exact bits against the fixed `sharedTokChunk` cadence
-        (`chooseSplitsArbitrated`), so it cuts where the symbol statistics
-        shift and never sizes worse than the fixed cadence; emission reuses
-        the winner's per-block trees from the sizing pass
-        (`deflateDynamicBlocksSharedSized`, = the reference candidate by
-        `deflateDynamicBlocksSharedSized_eq`).
+    Level 0 = stored; levels 1–3 run the single-block cost-model dispatch
+    (`deflateRawBase`). Levels 4–8 (#2737) additionally try the cross-block
+    (shared-window) split candidate — one whole-file match pass, token stream
+    partitioned per block, references cross block boundaries — with the
+    partition chosen by the packed observation-divergence heuristic
+    (`chooseSplitsHeuristicP`, libdeflate's streaming boundary check): each
+    block gets its own frequency-fit Huffman trees, recovering most of the
+    ratio a single whole-file tree leaves on large or heterogeneous inputs
+    (zlib refits trees every ~16K symbols; the whole-file tree was why the
+    mid-band was dominated). When the heuristic proposes no cuts (inputs
+    below ~2·`splitMinBlockBytes` output bytes, since both sides of a cut
+    must clear the floor) the split candidate would be a single dynamic block
+    the base already sizes, so the dispatch skips it and small inputs pay
+    nothing.
+
+    At level 8 this **replaces** the arbitrated split
+    (`chooseSplitsArbitrated` + `deflateDynamicBlocksSharedSized`, retired
+    from the dispatch by #2737 but kept as the proven reference): the
+    exact-bits arbitration guarded the heuristic against sizing worse than
+    the fixed `sharedTokChunk` cadence, but paid two extra boxed whole-stream
+    sizing walks (`findTableCode` linear scans + boxed `tokenFreqs`, ~18% of
+    level-8 cycles) for it — a guard libdeflate does without. `pickSmaller`
+    against the base still bounds any heuristic misfire at the single-block
+    ratio.
+
     At levels 9 and 10 (and within the `optimalMaxSize` memory gate) the dispatch
     switches to a cost-model DP parse (grouped into blocks on the fixed
     `sharedTokChunk` cadence, emitted as `pickSmaller(base, optimal)`), choosing
@@ -1374,22 +1534,16 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     `pickSmaller`, *not* nested inside the dynamic branch: on large heterogeneous
     inputs a single dynamic tree loses to fixed Huffman, so a base-internal gate
     would never reach the split even though it wins by 15–19%. `pickSmaller`
-    guarantees we never regress below the base; the default level 6 stays
-    single-block so it pays no extra compress time. All branches are
+    guarantees we never regress below the base. All branches are
     roundtrip-verified.
 
-    The split entry sits at level ≥ 8 (was ≥ 7): the single-block → split transition is
-    a hard ~2.5–3× compress-speed cliff (a second whole-file encode plus the partition
-    sizing), and levels 7 and 8 both paid it, landing coincident (they differed only in
-    chain depth, which saturates). Promoting level 7 to the *strongest single-block*
-    point (full lazy lookahead, chain depth 256) de-collapses the pair: level 7 fills the
-    empty band between level 6 and the split tier — on Canterbury outside the prior hull,
-    on Silesia a distinct Pareto-efficient point on it — while level 8 still emits the
-    split ratio level 7 used to carry (same candidate, deeper chain; empirically
-    equal-or-better on the measured corpora). The matcher knobs cannot separate the two
-    split levels (chain depth and the lazy gate are quality-for-speed tradeoffs that
-    trace one frontier); pushing the frontier itself out is the work of #2696 (chain
-    self-throttle) and #2638 (near-optimal parse). See #2698.
+    The split tier starts at level 4 (#2737; previously level ≥ 8, and before
+    that ≥ 7 — see #2698 for that history): with the boundaries chosen by the
+    cheap streaming heuristic and the whole split pipeline on packed tokens,
+    the split candidate's cost is one extra emit-speed pass over the token
+    stream (no sizing passes, no boxed tokens), affordable across the lazy
+    band where the matcher dominates. Levels 1–3 (`deflate_fast`, emit-bound)
+    stay single-block.
 
     Before any of that, an `incompressiblePrescan` reads a bounded sample (≤128 KiB,
     short-circuited on the first compressible region) and, on unambiguously
@@ -1401,12 +1555,11 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if incompressiblePrescan data then deflateStoredPure data
-  else if 8 ≤ level then
+  else if 4 ≤ level then
     -- One *packed* matcher pass shared by the base and shared-split candidates
     -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
-    -- The base candidate consumes the packed words end-to-end (freqs *and*
-    -- emit, stage C); the shared-split candidate still unpacks once (stage D
-    -- moves it onto packed words).
+    -- Both candidates consume the packed words end-to-end (freqs *and* emit):
+    -- no branch materializes boxed tokens.
     let ptokens := lzMatchP data level
     if level == 9 ∧ data.size ≤ optimalMaxSize then
       -- Level 9 (#2638): the cheaper **L9-fast** approximate-optimal parse — near
@@ -1426,14 +1579,16 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       pickSmaller (deflateRawBaseP data ptokens)
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
-      -- Level 8 (and level 9/10 above the memory gate): base vs cross-block
-      -- shared-window split. The self-contained split is not a candidate here
-      -- (nor at L9/L10 since #2640): it pays a full per-chunk match pass and
-      -- never sized smallest on the measured corpora. Level 7 no longer enters
-      -- here — it is the top single-block point (see the dispatch docstring), so
-      -- the split tier starts at level 8.
-      pickSmaller (deflateRawBaseP data ptokens)
-        (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))
+      -- Levels 4–8 (and level 9/10 above the memory gate): base vs cross-block
+      -- shared-window split at the observation-divergence boundaries (#2737).
+      -- No cuts ⇒ the split would be a single dynamic block the base already
+      -- sizes, so skip the second emit entirely (every input under
+      -- ~2·splitMinBlockBytes takes this path).
+      let cuts := chooseSplitsHeuristicP ptokens
+      if cuts.isEmpty then deflateRawBaseP data ptokens
+      else
+        pickSmaller (deflateRawBaseP data ptokens)
+          (deflateDynamicBlocksSharedAtP data ptokens cuts)
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1500,9 +1500,12 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     exact-bits arbitration guarded the heuristic against sizing worse than
     the fixed `sharedTokChunk` cadence, but paid two extra boxed whole-stream
     sizing walks (`findTableCode` linear scans + boxed `tokenFreqs`, ~18% of
-    level-8 cycles) for it — a guard libdeflate does without. `pickSmaller`
-    against the base still bounds any heuristic misfire at the single-block
-    ratio.
+    level-8 cycles) for it. Instead, level 8 *emits* the fixed-cadence
+    partition as a third `pickSmaller` candidate: the min over emitted
+    candidates decides by the same quantity the sizing pass computed
+    (⌈bits/8⌉), so level 8 is never worse than the retired arbitration on
+    any input, and one packed emit pass is far cheaper than the two boxed
+    sizing walks it replaces.
 
     At levels 9 and 10 (and within the `optimalMaxSize` memory gate) the dispatch
     switches to a cost-model DP parse (grouped into blocks on the fixed
@@ -1588,11 +1591,27 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       -- No cuts ⇒ the split would be a single dynamic block the base already
       -- sizes, so skip the second emit entirely (every input under
       -- ~2·splitMinBlockBytes takes this path).
+      let base := deflateRawBaseP data ptokens
       let cuts := chooseSplitsHeuristicP ptokens
-      if cuts.isEmpty then deflateRawBaseP data ptokens
-      else
-        pickSmaller (deflateRawBaseP data ptokens)
-          (deflateDynamicBlocksSharedAtP data ptokens cuts)
+      let withObs :=
+        if cuts.isEmpty then base
+        else pickSmaller base (deflateDynamicBlocksSharedAtP data ptokens cuts)
+      if 8 ≤ level then
+        -- Max-ratio split tier: also *emit* the fixed-cadence partition and keep
+        -- the smallest. The old L8 arbitration picked between the heuristic and
+        -- cadence partitions by exact bit sizing; taking the min over the two
+        -- *emitted* candidates decides by the same quantity (⌈bits/8⌉), so this
+        -- is never worse than the retired sizing pass on any input — at the cost
+        -- of one extra packed emit pass instead of two boxed sizing walks.
+        -- Measured (Silesia): the divergence cuts alone lose only on sao
+        -- (+0.6pp, a statistically uniform star catalog the cadence handles
+        -- better); this candidate closes exactly that hole. L4–L7 skip it: they
+        -- had no split tier before, so there is nothing to not-regress, and the
+        -- divergence cuts already capture the mid-band win at one extra emit.
+        pickSmaller withObs
+          (deflateDynamicBlocksSharedAtP data ptokens
+            (fixedCadenceCuts sharedTokChunk ptokens.size))
+      else withObs
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -545,10 +545,21 @@ theorem dynBlockBytesWith_dynHeaderCodes (litFreqs distFreqs : Array Nat) (litLe
 -- and the `SizeHelpers` conformance tests are unaffected.
 attribute [irreducible] symbolBitCount fixedBlockBytes dynBlockBytes dynBlockBytesWith
 
-/-- Hash-chain search depth per compression level (levels ≥ 5). Higher levels
+/-- Hash-chain search depth per compression level. Higher levels generally
     search deeper for longer matches (better ratio on diverse input) at higher
     cost; the `chainWalk` early-stop keeps repetitive input fast at any depth.
     The ratio gain saturates around 256–512 (measured), so level 9 caps there.
+
+    The mid-band values are the `mid-sweep` optimum for the #2737 ladder
+    (Silesia grid over chain × `goodMatch` × split, then interleaved pinned
+    timing): L4 = 64 (with the lazy gate, the old L5 point), L5 = 128 (gate
+    off — `goodMatch` buys more ratio per cycle than deepening the chain, so
+    L5 = (128, gate off) dominates the old L7 = (256, gate off)). **L6's depth
+    drops back to 64 on purpose**: the split tier starts there, and at equal
+    cycles the observation-divergence split + a shallow chain beats a deep
+    chain without the split — the block-split, not the chain, is L6's budget.
+    L7/L8 deepen the chain again within the split tier (256/512); past that
+    the chain saturates.
 
     Level 1 is the `deflate_fast` corner (#2726): depth `4` is exactly zlib
     `-1`'s `max_chain`. A tokens-held-constant attribution on Silesia (see
@@ -567,9 +578,9 @@ def chainDepth (level : UInt8) : Nat :=
   if level ≤ 1 then 4
   else if level ≤ 2 then 16
   else if level ≤ 3 then 32
-  else if level ≤ 4 then 48
-  else if level ≤ 5 then 64
-  else if level ≤ 6 then 128
+  else if level ≤ 4 then 64
+  else if level ≤ 5 then 128
+  else if level ≤ 6 then 64
   else if level ≤ 7 then 256
   else if level ≤ 8 then 512
   else 1024
@@ -593,9 +604,14 @@ def insertCap (level : UInt8) : Nat :=
 /-- Lazy `good_match` threshold (zlib-style): the lazy matcher skips the
     one-byte-lookahead probe once the first match is at least this long, since a
     long first match is rarely improved by deferral. Lower → more gating (faster,
-    slightly worse ratio). `259 > 258` disables gating. SPIKE: uniform 8. -/
+    slightly worse ratio). `259 > 258` disables gating.
+
+    Only L4 keeps the gate (#2737 `mid-sweep`): disabling it gains ~16bp of
+    Silesia geomean ratio at *any* chain depth — more ratio per cycle than
+    deepening the chain — so every level from 5 up spends its first budget
+    increment here. -/
 def goodMatch (level : UInt8) : Nat :=
-  if level ≤ 6 then 8
+  if level ≤ 4 then 8
   else 259
 
 /-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
@@ -1066,7 +1082,7 @@ def deflateDynamicBlocksSharedSized (data : ByteArray) (toks : Array LZ77Token) 
 The libdeflate-style divergence heuristic and the shared-window block emitter,
 both walking the `packTok`-encoded `UInt32` stream directly — the packed twins
 of `chooseSplitsHeuristic` and `emitSharedBlocksAt`. This is what lets the
-mid-band levels (4–7) afford per-block Huffman trees at all: the per-block
+mid-band levels (6–8) afford per-block Huffman trees at all: the per-block
 frequency pass runs on `tokenFreqsP` (dense packed tables) and the emit on
 `emitTokensWithCodesP`, so the split candidate never materializes boxed
 `LZ77Token`s and never touches the `findTableCode` linear scans. At level 8 the
@@ -1101,8 +1117,13 @@ boxed reference via `deflateDynamicBlocksSharedAtP_eq`
     `splitTokenClassP`/`splitTokenBytesP` in place of the boxed accessors.
     Heuristic-only (the emitter clamps arbitrary cuts), so it carries no proof
     obligations; `ZipTest/PackedTokens.lean` pins it to the boxed heuristic
-    over the `unpackTok` view. -/
-def chooseSplitsHeuristicP (toks : Array UInt32) : List Nat := Id.run do
+    over the `unpackTok` view. The block floor/ceiling and check cadence are
+    defaulted parameters so the `mid-sweep` tuning tool can grid them without
+    touching the dispatch (which always calls with the tuned defaults). -/
+def chooseSplitsHeuristicP (toks : Array UInt32)
+    (minBlockBytes : Nat := splitMinBlockBytes)
+    (softMaxBlockBytes : Nat := splitSoftMaxBlockBytes)
+    (checkTokens : Nat := splitCheckTokens) : List Nat := Id.run do
   let mut totalBytes := 0
   for t in toks do
     totalBytes := totalBytes + splitTokenBytesP t
@@ -1120,10 +1141,10 @@ def chooseSplitsHeuristicP (toks : Array UInt32) : List Nat := Id.run do
     newTot := newTot + 1
     blockBytes := blockBytes + splitTokenBytesP t
     doneBytes := doneBytes + splitTokenBytesP t
-    if blockBytes ≥ splitMinBlockBytes && totalBytes - doneBytes ≥ splitMinBlockBytes then
+    if blockBytes ≥ minBlockBytes && totalBytes - doneBytes ≥ minBlockBytes then
       let cut :=
-        blockBytes ≥ splitSoftMaxBlockBytes ||
-        (newTot ≥ splitCheckTokens && oldTot > 0 &&
+        blockBytes ≥ softMaxBlockBytes ||
+        (newTot ≥ checkTokens && oldTot > 0 &&
           splitEndBlockCheck old oldTot new newTot blockBytes)
       if cut then
         cuts := cuts.push (i + 1)
@@ -1132,7 +1153,7 @@ def chooseSplitsHeuristicP (toks : Array UInt32) : List Nat := Id.run do
         new := Array.replicate splitNumClasses 0
         newTot := 0
         blockBytes := 0
-      else if newTot ≥ splitCheckTokens then
+      else if newTot ≥ checkTokens then
         for j in [0:splitNumClasses] do
           old := old.set! j (old.getD j 0 + new.getD j 0)
         oldTot := oldTot + newTot
@@ -1479,8 +1500,8 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     So callers pinning `level = 9` for absolute best ratio should now pass 10.
     (The zlib/FFI bindings are a separate 0–9 path and are unchanged.)
 
-    Level 0 = stored; levels 1–3 run the single-block cost-model dispatch
-    (`deflateRawBase`). Levels 4–8 (#2737) additionally try the cross-block
+    Level 0 = stored; levels 1–5 run the single-block cost-model dispatch
+    (`deflateRawBase`); levels 6–8 (#2737) additionally try the cross-block
     (shared-window) split candidate — one whole-file match pass, token stream
     partitioned per block, references cross block boundaries — with the
     partition chosen by the packed observation-divergence heuristic
@@ -1493,6 +1514,23 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     must clear the floor) the split candidate would be a single dynamic block
     the base already sizes, so the dispatch skips it and small inputs pay
     nothing.
+
+    The mid-band ladder (L4–L8) is the `mid-sweep`-chosen union of the old
+    single-block frontier and the split frontier, so neither trades territory
+    for the other (Silesia geomean, pinned interleaved timing):
+
+      * **L4** — single-block, chain 64, lazy gate on: 38.8 MB/s @ 0.3330
+        (the old L5 point; dominates the old L4).
+      * **L5** — single-block, chain 128, gate off: 29.7 @ 0.3304 (dominates
+        the old L7 = single-block chain 256: gate-off buys more ratio per
+        cycle than chain depth).
+      * **L6** — split, chain 64, gate off: 20.1 @ 0.3245.
+      * **L7** — split, chain 256, gate off: 17.1 @ 0.3232.
+      * **L8** — split + emitted fixed-cadence candidate, chain 512: 11.4 @
+        0.3228 — the old L8's exact geomean ratio, ~20% faster.
+
+    Every old L4–L8 point is dominated by (or within 1% of) the new curve's
+    mixing frontier, and the split points sit far outside the old one.
 
     At level 8 this **replaces** the arbitrated split
     (`chooseSplitsArbitrated` + `deflateDynamicBlocksSharedSized`, retired
@@ -1544,13 +1582,15 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     guarantees we never regress below the base. All branches are
     roundtrip-verified.
 
-    The split tier starts at level 4 (#2737; previously level ≥ 8, and before
+    The split tier starts at level 6 (#2737; previously level ≥ 8, and before
     that ≥ 7 — see #2698 for that history): with the boundaries chosen by the
     cheap streaming heuristic and the whole split pipeline on packed tokens,
     the split candidate's cost is one extra emit-speed pass over the token
-    stream (no sizing passes, no boxed tokens), affordable across the lazy
-    band where the matcher dominates. Levels 1–3 (`deflate_fast`, emit-bound)
-    stay single-block.
+    stream (no sizing passes, no boxed tokens). Levels 4–5 stay single-block
+    on purpose — they carry the old mid-band's high-speed points (the split's
+    extra emit pass would push them off that territory), while levels 6–8
+    spend the same cycles on per-block trees instead of deeper chains.
+    Levels 1–3 (`deflate_fast`, emit-bound) stay single-block greedy.
 
     Before any of that, an `incompressiblePrescan` reads a bounded sample (≤128 KiB,
     short-circuited on the first compressible region) and, on unambiguously
@@ -1562,7 +1602,7 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if incompressiblePrescan data then deflateStoredPure data
-  else if 4 ≤ level then
+  else if 6 ≤ level then
     -- One *packed* matcher pass shared by the base and shared-split candidates
     -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
     -- Both candidates consume the packed words end-to-end (freqs *and* emit):
@@ -1586,7 +1626,7 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       pickSmaller (deflateRawBaseP data ptokens)
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
-      -- Levels 4–8 (and level 9/10 above the memory gate): base vs cross-block
+      -- Levels 6–8 (and level 9/10 above the memory gate): base vs cross-block
       -- shared-window split at the observation-divergence boundaries (#2737).
       -- No cuts ⇒ the split would be a single dynamic block the base already
       -- sizes, so skip the second emit entirely (every input under

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1179,7 +1179,11 @@ def emitSharedBlockP (bw : BitWriter) (data : ByteArray) (group : Array UInt32)
 /-- Packed twin of `emitSharedBlocksAt`: emit shared-window blocks at explicit
     cut points directly from the packed token stream. Same clamping — every cut
     is forced into `(pos, toks.size]`, so **any** cuts list yields a valid total
-    partition and the boundary heuristic stays proof-free. -/
+    partition and the boundary heuristic stays proof-free. The clamping makes
+    arbitrary cuts correctness-safe, not performance-safe: a pathological list
+    (non-monotone, dense) degrades to one-token blocks, each paying a full tree
+    header. `deflateRaw` only ever feeds it `chooseSplitsHeuristicP`'s strictly
+    increasing, byte-floored cuts. -/
 def emitSharedBlocksAtP (data : ByteArray) (toks : Array UInt32) (cuts : List Nat)
     (pos : Nat) (bw : BitWriter) : BitWriter :=
   let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -617,20 +617,30 @@ def goodMatch (level : UInt8) : Nat :=
 /-- Per-level `niceLen` cutoff (libdeflate `nice_match_length`, `deflate_compress.c`):
     the chain walk stops as soon as the best match reaches this length, since a
     match this long is already good enough — burning the rest of the depth budget
-    to lengthen it further rarely pays for itself. The ladder starts from
-    libdeflate's values (L2=10, L3=14, L4=30, L5=30, L6=65, L7=130, L8=L9=258).
-    Level 1 keeps `258` (no early-out) to leave the measured `deflate_fast` corner
-    (#2726) untouched — at chain depth 4 the walk is already short, so a cutoff
-    buys little there. `258` (the max match length, ≥ every `maxLen`) disables the
-    cutoff: the walk then stops only on the full-match / fuel condition, exactly as
-    before this knob existed. The cutoff never enters correctness — the chain is a
-    heuristic re-verified at emission — so any value keeps the encoder contracts. -/
+    to lengthen it further rarely pays for itself. L2/L3 keep libdeflate's values
+    (10/14, #2744); level 1 keeps `258` (no early-out) to leave the measured
+    `deflate_fast` corner (#2726) untouched — at chain depth 4 the walk is
+    already short, so a cutoff buys little there.
+
+    The mid-band values were re-gridded for the #2737 remapped ladder
+    (`mid-sweep --time`, Silesia): **L4 disables the cutoff** — at chain 64
+    with the lazy gate on, every `niceLen` value times identically (the gate
+    already skips the probes the cutoff would save) and lower cutoffs only
+    cost ratio (nl30 +11bp, nl65 +3.5bp corpus-total), so the early-out is a
+    pure loss there. L5/L6 (gate off) sit at the measured knee `65` (nl30
+    gains ~3% speed for +10bp — a poor trade; nl130/258 return ≤1bp for the
+    speed given up); L7's chain-256 walk earns `130`; L8 (the max split tier)
+    disables the cutoff — nl130 times within 1% but emits more bytes, and L8's
+    cadence guard promises old-L8 ratio parity. `258` (the max match length,
+    ≥ every `maxLen`) disables the cutoff: the walk then stops only on the
+    full-match / fuel condition, exactly as before this knob existed. The
+    cutoff never enters correctness — the chain is a heuristic re-verified at
+    emission — so any value keeps the encoder contracts. -/
 def niceLen (level : UInt8) : Nat :=
   if level ≤ 1 then 258
   else if level ≤ 2 then 10
   else if level ≤ 3 then 14
-  else if level ≤ 4 then 30
-  else if level ≤ 5 then 30
+  else if level ≤ 4 then 258
   else if level ≤ 6 then 65
   else if level ≤ 7 then 130
   else 258

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -137,9 +137,11 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
               (inflate_deflateRawBase data level _ hsize)
               (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
           · split
-            · -- levels 4–8, no divergence cuts: base only (#2737)
+            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
+              -- base only (#2737)
               exact inflate_deflateRawBase data level _ hsize
-            · -- levels 4–8: observation-divergence split candidate (#2737); the
+            · -- levels 4–8 (and 9/10 above the optimal-size gate): observation-
+              -- divergence split candidate (#2737); the
               -- roundtrip holds for any cut selector.
               exact inflate_pickSmaller _ _ data maxOutputSize
                 (inflate_deflateRawBase data level _ hsize)
@@ -244,7 +246,8 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_pad data level)
               (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
           · split
-            · -- levels 4–8, no divergence cuts: base only (#2737)
+            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
+              -- base only (#2737)
               exact deflateRawBase_pad data level
             · exact pickSmaller_bytesToBits
                 (P := fun bits => ∃ (contentBits padding : List Bool),
@@ -425,7 +428,8 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_goR_pad data level)
               (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
           · split
-            · -- levels 4–8, no divergence cuts: base only (#2737)
+            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
+              -- base only (#2737)
               exact deflateRawBase_goR_pad data level
             · exact pickSmaller_bytesToBits
                 (P := fun bits => ∃ remaining,

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -13,7 +13,7 @@ Proves the unified roundtrip theorem for `deflateRaw`:
 `deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
 block; level ≥ 1 runs the single-block cost-model dispatch `deflateRawBase`
 (stored / fixed / dynamic, all sized from one hash-chain token pass, emitting
-only the smallest); levels 4–8 additionally compare the cross-block
+only the smallest); levels 6–8 additionally compare the cross-block
 shared-window split at the observation-divergence boundaries (#2737) against
 that base via `pickSmaller`, so the split is a first-class candidate that can
 only ever win; and levels 9/10 compare the near-optimal / exact-DP candidates
@@ -110,7 +110,7 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The incompressible pre-scan
     and the level-0 path both dispatch to `deflateStoredPure` directly; the
-    cost-model stored fallback is covered by `deflateRawBase`; the level-4–8
+    cost-model stored fallback is covered by `deflateRawBase`; the level-6–8
     split and level-9/10 optimal candidates are covered by the `pickSmaller`
     cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
@@ -156,7 +156,7 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
             · -- level 8: obs candidate vs the emitted fixed-cadence partition
               exact inflate_pickSmaller _ _ data maxOutputSize hobs
                 (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
-            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+            · -- levels 6–7 (and 9/10 above the optimal-size gate)
               exact hobs
       · exact inflate_deflateRawBase data level _ hsize
 
@@ -281,7 +281,7 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
                 (P := fun bits => ∃ (contentBits padding : List Bool),
                   bits = contentBits ++ padding ∧ padding.length < 8)
                 _ _ hobs (deflateDynamicBlocksSharedAt_pad data _ level)
-            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+            · -- levels 6–7 (and 9/10 above the optimal-size gate)
               exact hobs
       · exact deflateRawBase_pad data level
 
@@ -483,7 +483,7 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
                   Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
                     remaining.length < 8)
                 _ _ hobs (deflateDynamicBlocksSharedAt_goR_pad data _ level)
-            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+            · -- levels 6–7 (and 9/10 above the optimal-size gate)
               exact hobs
       · exact deflateRawBase_goR_pad data level
 

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -118,8 +118,24 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     Zip.Native.Inflate.inflateReference (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
+  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
+  -- The obs-divergence candidate (`withObs`): base when the heuristic proposes
+  -- no cuts, else pickSmaller of base and the cut-list split (#2737). The
+  -- roundtrip holds for any cut selector.
+  have hobs : Zip.Native.Inflate.inflateReference
+      (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+        deflateRawBase data level
+      else
+        pickSmaller (deflateRawBase data level)
+          (deflateDynamicBlocksSharedAt data
+            (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))
+      maxOutputSize = .ok data := by
+    split
+    · exact inflate_deflateRawBase data level _ hsize
+    · exact inflate_pickSmaller _ _ data maxOutputSize
+        (inflate_deflateRawBase data level _ hsize)
+        (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
   split
   · exact inflate_deflateStoredPure data _ (by omega)
   -- The incompressible pre-scan routes straight to the same stored block.
@@ -137,15 +153,11 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
               (inflate_deflateRawBase data level _ hsize)
               (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
           · split
-            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
-              -- base only (#2737)
-              exact inflate_deflateRawBase data level _ hsize
-            · -- levels 4–8 (and 9/10 above the optimal-size gate): observation-
-              -- divergence split candidate (#2737); the
-              -- roundtrip holds for any cut selector.
-              exact inflate_pickSmaller _ _ data maxOutputSize
-                (inflate_deflateRawBase data level _ hsize)
+            · -- level 8: obs candidate vs the emitted fixed-cadence partition
+              exact inflate_pickSmaller _ _ data maxOutputSize hobs
                 (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
+            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+              exact hobs
       · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -217,13 +229,31 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       padding.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
+  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
   have hstored : ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data)
         = contentBits ++ padding ∧ padding.length < 8 :=
     ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
       [], by simp only [List.append_nil], by decide⟩
+  -- The obs-divergence candidate (`withObs`, #2737): base or pickSmaller of
+  -- base and the cut-list split.
+  have hobs : ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits
+        (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+          deflateRawBase data level
+        else
+          pickSmaller (deflateRawBase data level)
+            (deflateDynamicBlocksSharedAt data
+              (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))
+        = contentBits ++ padding ∧ padding.length < 8 := by
+    split
+    · exact deflateRawBase_pad data level
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ (contentBits padding : List Bool),
+          bits = contentBits ++ padding ∧ padding.length < 8)
+        _ _ (deflateRawBase_pad data level)
+        (deflateDynamicBlocksSharedAt_pad data _ level)
   split
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact hstored
@@ -246,14 +276,13 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_pad data level)
               (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
           · split
-            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
-              -- base only (#2737)
-              exact deflateRawBase_pad data level
-            · exact pickSmaller_bytesToBits
+            · -- level 8: obs candidate vs the emitted fixed-cadence partition
+              exact pickSmaller_bytesToBits
                 (P := fun bits => ∃ (contentBits padding : List Bool),
                   bits = contentBits ++ padding ∧ padding.length < 8)
-                _ _ (deflateRawBase_pad data level)
-                (deflateDynamicBlocksSharedAt_pad data _ level)
+                _ _ hobs (deflateDynamicBlocksSharedAt_pad data _ level)
+            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+              exact hobs
       · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -397,13 +426,33 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
+  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
   have hstored : ∃ remaining,
       Deflate.Spec.decode.goR
           (Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 :=
     ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
+  -- The obs-divergence candidate (`withObs`, #2737): base or pickSmaller of
+  -- base and the cut-list split.
+  have hobs : ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits
+            (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+              deflateRawBase data level
+            else
+              pickSmaller (deflateRawBase data level)
+                (deflateDynamicBlocksSharedAt data
+                  (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+    split
+    · exact deflateRawBase_goR_pad data level
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ remaining,
+          Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+            remaining.length < 8)
+        _ _ (deflateRawBase_goR_pad data level)
+        (deflateDynamicBlocksSharedAt_goR_pad data _ level)
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact hstored
@@ -428,15 +477,14 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_goR_pad data level)
               (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
           · split
-            · -- levels 4–8 (and 9/10 above the optimal-size gate), no divergence cuts:
-              -- base only (#2737)
-              exact deflateRawBase_goR_pad data level
-            · exact pickSmaller_bytesToBits
+            · -- level 8: obs candidate vs the emitted fixed-cadence partition
+              exact pickSmaller_bytesToBits
                 (P := fun bits => ∃ remaining,
                   Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
                     remaining.length < 8)
-                _ _ (deflateRawBase_goR_pad data level)
-                (deflateDynamicBlocksSharedAt_goR_pad data _ level)
+                _ _ hobs (deflateDynamicBlocksSharedAt_goR_pad data _ level)
+            · -- levels 4–7 (and 9/10 above the optimal-size gate)
+              exact hobs
       · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -13,18 +13,21 @@ Proves the unified roundtrip theorem for `deflateRaw`:
 `deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
 block; level ≥ 1 runs the single-block cost-model dispatch `deflateRawBase`
 (stored / fixed / dynamic, all sized from one hash-chain token pass, emitting
-only the smallest); and level ≥ 8 additionally compares two block-split streams
-(self-contained #2524 and cross-block shared-window #2525) against that base via
-`pickSmaller`, so the split is a first-class candidate that can only ever win.
+only the smallest); levels 4–8 additionally compare the cross-block
+shared-window split at the observation-divergence boundaries (#2737) against
+that base via `pickSmaller`, so the split is a first-class candidate that can
+only ever win; and levels 9/10 compare the near-optimal / exact-DP candidates
+instead.
 
 This composes:
 - `inflate_deflateRawBase` — the stored / fixed / dynamic base, in turn built
   from `inflate_deflateStoredPure`, `inflate_deflateFixedBlock`,
   `inflate_deflateDynamicBlock`
-- `inflate_deflateDynamicBlocksSC` / `inflate_deflateDynamicBlocksSharedAt` — the
-  two block-split candidates (`Zip/Spec/DeflateBlockSplit.lean`); the shared-window
-  candidate holds for any boundary selector, so the entropy-divergence partition
-  (`chooseSplitsArbitrated`, #2528) needs no proof of its own
+- `inflate_deflateDynamicBlocksSharedAt` — the shared-window block-split
+  candidate (`Zip/Spec/DeflateBlockSplit.lean`); it holds for **any** boundary
+  selector, so the observation-divergence partition (`chooseSplitsHeuristicP`,
+  #2737) needs no proof of its own — the packed emit pipeline transfers via
+  `deflateDynamicBlocksSharedAtP_eq` (`Zip/Spec/LZ77PackedCorrect.lean`)
 - `inflate_pickSmaller` — selecting the smaller of two roundtripping candidates
 -/
 
@@ -107,14 +110,15 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The incompressible pre-scan
     and the level-0 path both dispatch to `deflateStoredPure` directly; the
-    cost-model stored fallback is covered by `deflateRawBase`; the level-≥8
-    block-split candidates are covered by the `pickSmaller` cases. -/
+    cost-model stored fallback is covered by `deflateRawBase`; the level-4–8
+    split and level-9/10 optimal candidates are covered by the `pickSmaller`
+    cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflateReference (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
   split
   · exact inflate_deflateStoredPure data _ (by omega)
@@ -132,9 +136,14 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
             exact inflate_pickSmaller _ _ data maxOutputSize
               (inflate_deflateRawBase data level _ hsize)
               (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
-          · exact inflate_pickSmaller _ _ data maxOutputSize
-              (inflate_deflateRawBase data level _ hsize)
-              (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize)
+          · split
+            · -- levels 4–8, no divergence cuts: base only (#2737)
+              exact inflate_deflateRawBase data level _ hsize
+            · -- levels 4–8: observation-divergence split candidate (#2737); the
+              -- roundtrip holds for any cut selector.
+              exact inflate_pickSmaller _ _ data maxOutputSize
+                (inflate_deflateRawBase data level _ hsize)
+                (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
       · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -206,7 +215,7 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       padding.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
   have hstored : ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data)
@@ -234,11 +243,14 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
                 bits = contentBits ++ padding ∧ padding.length < 8)
               _ _ (deflateRawBase_pad data level)
               (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
-          · exact pickSmaller_bytesToBits
-              (P := fun bits => ∃ (contentBits padding : List Bool),
-                bits = contentBits ++ padding ∧ padding.length < 8)
-              _ _ (deflateRawBase_pad data level)
-              (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level)
+          · split
+            · -- levels 4–8, no divergence cuts: base only (#2737)
+              exact deflateRawBase_pad data level
+            · exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ (contentBits padding : List Bool),
+                  bits = contentBits ++ padding ∧ padding.length < 8)
+                _ _ (deflateRawBase_pad data level)
+                (deflateDynamicBlocksSharedAt_pad data _ level)
       · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -382,7 +394,7 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+  rw [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
     deflateDynamicBlocksSharedAt_def]
   have hstored : ∃ remaining,
       Deflate.Spec.decode.goR
@@ -412,12 +424,15 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
                   remaining.length < 8)
               _ _ (deflateRawBase_goR_pad data level)
               (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
-          · exact pickSmaller_bytesToBits
-              (P := fun bits => ∃ remaining,
-                Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                  remaining.length < 8)
-              _ _ (deflateRawBase_goR_pad data level)
-              (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level)
+          · split
+            · -- levels 4–8, no divergence cuts: base only (#2737)
+              exact deflateRawBase_goR_pad data level
+            · exact pickSmaller_bytesToBits
+                (P := fun bits => ∃ remaining,
+                  Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                    remaining.length < 8)
+                _ _ (deflateRawBase_goR_pad data level)
+                (deflateDynamicBlocksSharedAt_goR_pad data _ level)
       · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -197,4 +197,88 @@ theorem deflateRawBase_def (data : ByteArray) (level : UInt8) :
   simp only [dynBlockBytesWith_dynHeaderCodes, deflateDynamicBlockCorePWith_dynHeaderCodes,
     deflateFixedBlockP_eq, deflateDynamicBlockCoreP_eq, tokenFreqsP_eq, lzMatchP_map]
 
+/-! ## The packed shared-window split candidate equals the boxed one (#2737)
+
+`deflateDynamicBlocksSharedAtP` is the observation-divergence split candidate
+on packed tokens end-to-end: per block, `tokenFreqsP` for the trees and
+`emitTokensWithCodesP` (inside `emitDynBlockP`) for the emit. The equalities
+below recover the boxed reference
+`deflateDynamicBlocksSharedAtTokens … (fun _ => cuts)` for **every** word
+array and **every** cut list, so the whole `deflateDynamicBlocksSharedAt`
+spec quadruple (`Zip/Spec/DeflateBlockSplit.lean`, quantified over an
+arbitrary selector) transfers by a rewrite — the packed heuristic
+`chooseSplitsHeuristicP` never appears in a proof. -/
+
+/-- `Array.extract` commutes with `Array.map` (no core lemma at this
+    toolchain): the group a packed emitter cuts out of the packed stream views
+    to the group the boxed emitter cuts out of the boxed stream. -/
+private theorem extract_map {α β : Type} (f : α → β) (a : Array α) (s e : Nat) :
+    (a.map f).extract s e = (a.extract s e).map f := by
+  ext i hi₁ hi₂
+  · simp only [Array.size_extract, Array.size_map]
+  · simp only [Array.getElem_extract, Array.getElem_map]
+
+/-- The packed per-block emitter is the boxed one over the `unpackTok` view:
+    the bodies are identical up to `emitTokensWithCodesP_eq`. -/
+theorem emitDynBlockP_eq (bw : BitWriter) (data : ByteArray) (ws : Array UInt32)
+    (litLens distLens : List Nat)
+    (hlit : litLens.length = 286) (hdist : distLens.length = 30) (isFinal : Bool) :
+    emitDynBlockP bw data ws litLens distLens hlit hdist isFinal =
+      emitDynBlock bw data (ws.map unpackTok) litLens distLens hlit hdist isFinal := by
+  unfold emitDynBlockP emitDynBlock
+  simp only [emitTokensWithCodesP_eq]
+
+/-- The packed shared-window block emitter is the boxed one over the
+    `unpackTok` view: the trees agree by `tokenFreqsP_eq`, the emit by
+    `emitDynBlockP_eq`. -/
+theorem emitSharedBlockP_eq (bw : BitWriter) (data : ByteArray) (ws : Array UInt32)
+    (isFinal : Bool) :
+    emitSharedBlockP bw data ws isFinal =
+      emitSharedBlock bw data (ws.map unpackTok) isFinal := by
+  unfold emitSharedBlockP emitSharedBlock
+  simp only [tokenFreqsP_eq, emitDynBlockP_eq]
+
+/-- The packed cut-list block fold is the boxed one over the `unpackTok` view
+    (fuel-quantified form for the induction): the map preserves size, so the
+    clamped cuts coincide, and each block agrees by `emitSharedBlockP_eq` +
+    `extract_map`. -/
+private theorem emitSharedBlocksAtP_eq_fuel (data : ByteArray) (ws : Array UInt32) :
+    ∀ (fuel pos : Nat), ws.size - pos < fuel → ∀ (cuts : List Nat) (bw : BitWriter),
+      emitSharedBlocksAtP data ws cuts pos bw =
+        emitSharedBlocksAt data (ws.map unpackTok) cuts pos bw := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts bw
+    conv => lhs; unfold emitSharedBlocksAtP
+    conv => rhs; unfold emitSharedBlocksAt
+    simp only [Array.size_map, emitSharedBlockP_eq, extract_map]
+    by_cases hend : min (max (cuts.headD ws.size) (pos + 1)) ws.size ≥ ws.size
+    · simp only [if_pos hend]
+    · simp only [if_neg hend]
+      exact ih (min (max (cuts.headD ws.size) (pos + 1)) ws.size) (by omega) cuts.tail _
+
+/-- The packed cut-list block fold is the boxed one over the `unpackTok` view,
+    for any cut list and start position. -/
+theorem emitSharedBlocksAtP_eq (data : ByteArray) (ws : Array UInt32)
+    (cuts : List Nat) (pos : Nat) (bw : BitWriter) :
+    emitSharedBlocksAtP data ws cuts pos bw =
+      emitSharedBlocksAt data (ws.map unpackTok) cuts pos bw :=
+  emitSharedBlocksAtP_eq_fuel data ws (ws.size - pos + 1) pos (by omega) cuts bw
+
+/-- The packed observation-divergence split candidate is byte-identical to the
+    boxed reference at the same (constant) cut list: `deflateRaw`'s level 4–8
+    split branch and the roundtrip proofs see
+    `deflateDynamicBlocksSharedAtTokens … (fun _ => cuts)` through this
+    rewrite, and the `DeflateBlockSplit` theorems hold for any selector. -/
+theorem deflateDynamicBlocksSharedAtP_eq (data : ByteArray) (ws : Array UInt32)
+    (cuts : List Nat) :
+    deflateDynamicBlocksSharedAtP data ws cuts =
+      deflateDynamicBlocksSharedAtTokens data (ws.map unpackTok) (fun _ => cuts) := by
+  unfold deflateDynamicBlocksSharedAtP deflateDynamicBlocksSharedAtTokens
+  split
+  · rfl
+  · rw [emitSharedBlocksAtP_eq]
+
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -209,6 +209,25 @@ spec quadruple (`Zip/Spec/DeflateBlockSplit.lean`, quantified over an
 arbitrary selector) transfers by a rewrite — the packed heuristic
 `chooseSplitsHeuristicP` never appears in a proof. -/
 
+/-- The packed observation class is the boxed one over the `unpackTok` view —
+    unconditionally, for every word: both sides read exactly `unpackTok`'s
+    field expressions (`toUInt8` for literals, `(w >>> 16) &&& 0x7FFF` for the
+    match length), so the heuristic's bit tricks can never drift from the
+    packed-token layout. The `chooseSplitsHeuristicP` conformance test
+    (`ZipTest/PackedTokens.lean`) checks the full loop; this pins the
+    per-token classification. -/
+theorem splitTokenClassP_eq (w : UInt32) :
+    splitTokenClassP w = splitTokenClass (unpackTok w) := by
+  unfold splitTokenClassP splitTokenClass unpackTok
+  split <;> rfl
+
+/-- The packed per-token output-byte count is the boxed one over the
+    `unpackTok` view — unconditionally, for every word. -/
+theorem splitTokenBytesP_eq (w : UInt32) :
+    splitTokenBytesP w = splitTokenBytes (unpackTok w) := by
+  unfold splitTokenBytesP splitTokenBytes unpackTok
+  split <;> rfl
+
 /-- `Array.extract` commutes with `Array.map` (no core lemma at this
     toolchain): the group a packed emitter cuts out of the packed stream views
     to the group the boxed emitter cuts out of the boxed stream. -/

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -287,7 +287,7 @@ theorem emitSharedBlocksAtP_eq (data : ByteArray) (ws : Array UInt32)
   emitSharedBlocksAtP_eq_fuel data ws (ws.size - pos + 1) pos (by omega) cuts bw
 
 /-- The packed observation-divergence split candidate is byte-identical to the
-    boxed reference at the same (constant) cut list: `deflateRaw`'s level 4–8
+    boxed reference at the same (constant) cut list: `deflateRaw`'s level 6–8
     split branch and the roundtrip proofs see
     `deflateDynamicBlocksSharedAtTokens … (fun _ => cuts)` through this
     rewrite, and the `DeflateBlockSplit` theorems hold for any selector. -/

--- a/ZipMidSweep.lean
+++ b/ZipMidSweep.lean
@@ -1,0 +1,126 @@
+import Zip
+
+/-! # mid-sweep — mid-band (L4–L8) ladder knob sweep (#2737)
+
+Grids the mid-band compression knobs over corpus files and prints one CSV row
+per configuration, for choosing the L4–L8 ladder that unions the old
+single-block frontier with the observation-divergence split frontier:
+
+    <file>,<chain>,<goodMatch>,<minBlock>,<checkTokens>,<inBytes>,<base>,<obs>,<obsCad>,<cuts>
+
+* `chain` × `goodMatch` — the lazy matcher's depth and lazy-gate knobs
+  (`chainDepth` / `goodMatch` ladder values); one matcher pass per pair,
+  shared by all candidates below.
+* `base`   — the single-block cost-model dispatch (`deflateRawBaseP`) size:
+  the old L4–L7 behaviour at this matcher setting.
+* `obs`    — `min(base, observation-divergence split)` at the given
+  `minBlock`/`checkTokens` heuristic constants (soft max fixed at
+  `splitSoftMaxBlockBytes`): the new split-tier behaviour.
+* `obsCad` — `min(obs, fixed-cadence split)`: the L8 (max split tier)
+  behaviour with the sao-guard cadence candidate.
+* `cuts`   — number of divergence cuts the heuristic proposed.
+
+Ratios are deterministic, so this needs no pinning or quiet machine; speed
+verdicts for the chosen ladder come from paired interleaved `bench-report`
+runs (see the #2745 PR discussion).
+
+Usage: lake exe mid-sweep <file> [<file> ...]
+       lake exe mid-sweep --time <file> [<file> ...]
+
+`--time` runs the ladder-candidate configurations (see `timedConfigs`) over the
+files round-robin (config-interleaved so ambient machine drift cancels across
+configs, reps interleaved likewise) and prints per-config corpus MB/s per rep.
+Pin it (`bench/pin_core.sh`) and run on a quiet machine.
+-/
+
+open Zip.Native.Deflate
+
+/-- Matcher chain depths bracketing the old L4–L8 ladder values. -/
+def chainGrid : List Nat := [48, 64, 128, 256, 512]
+
+/-- Lazy `good_match` gate: 8 (old L4–L6 gating) or 259 (disabled, old L7+). -/
+def gmGrid : List Nat := [8, 259]
+
+/-- `(minBlockBytes, checkTokens)` variants for the divergence heuristic
+    (soft max fixed): the #2527 default (10000, 512), libdeflate's floor
+    (5000), a coarser floor, and a finer check cadence. -/
+def splitVariants : List (Nat × Nat) := [(10000, 512), (5000, 512), (20000, 512), (10000, 256)]
+
+/-- One mid-band candidate: matcher knobs plus which candidates to emit.
+    `mode`: 0 = single-block base only, 1 = base + obs split,
+    2 = base + obs split + fixed-cadence split. -/
+structure TimedConfig where
+  label : String
+  chain : Nat
+  gm : Nat
+  mode : Nat
+
+/-- The ladder candidates whose speed decides the L4–L8 assignment. -/
+def timedConfigs : List TimedConfig := [
+  ⟨"base-64-8",      64, 8,   0⟩,
+  ⟨"base-128-8",    128, 8,   0⟩,
+  ⟨"base-128-259",  128, 259, 0⟩,
+  ⟨"base-256-259",  256, 259, 0⟩,
+  ⟨"split-48-259",   48, 259, 1⟩,
+  ⟨"split-64-8",     64, 8,   1⟩,
+  ⟨"split-64-259",   64, 259, 1⟩,
+  ⟨"split-128-8",   128, 8,   1⟩,
+  ⟨"split-128-259", 128, 259, 1⟩,
+  ⟨"split-256-259", 256, 259, 1⟩,
+  ⟨"splitcad-512-259", 512, 259, 2⟩ ]
+
+/-- Compress `data` under one candidate config, returning the emitted size
+    (consumed so the work is not dead-code-eliminated). -/
+def runConfig (cfg : TimedConfig) (data : ByteArray) : Nat :=
+  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm
+  let base := deflateRawBaseP data ptoks
+  if cfg.mode == 0 then base.size
+  else
+    let cuts := chooseSplitsHeuristicP ptoks
+    let obs := if cuts.isEmpty then base
+      else pickSmaller base (deflateDynamicBlocksSharedAtP data ptoks cuts)
+    if cfg.mode == 1 then obs.size
+    else
+      let cad := fixedCadenceCuts sharedTokChunk ptoks.size
+      if cad.isEmpty then obs.size
+      else (pickSmaller obs (deflateDynamicBlocksSharedAtP data ptoks cad)).size
+
+def timeMain (paths : List String) : IO Unit := do
+  let mut files : List ByteArray := []
+  for path in paths do
+    files := files ++ [← IO.FS.readBinFile path]
+  let total := files.foldl (fun a f => a + f.size) 0
+  IO.println s!"corpus: {paths.length} files, {total} bytes"
+  for rep in [0:3] do
+    for cfg in timedConfigs do
+      let t0 ← IO.monoNanosNow
+      let mut sink := 0
+      for f in files do
+        sink := sink + runConfig cfg f
+      let t1 ← IO.monoNanosNow
+      let mbps := total.toFloat / 1048576.0 / ((t1 - t0).toFloat / 1.0e9)
+      IO.println s!"rep {rep} {cfg.label}: {mbps} MB/s (out {sink})"
+      (← IO.getStdout).flush
+
+def main (args : List String) : IO Unit := do
+  if args.head? == some "--time" then
+    timeMain args.tail
+    return
+  for path in args do
+    let data ← IO.FS.readBinFile path
+    let name := (path.splitOn "/").getLastD path
+    for chain in chainGrid do
+      for gm in gmGrid do
+        let ptoks := lz77ChainLazyIterP data chain 32768 1000000000 gm
+        let base := (deflateRawBaseP data ptoks).size
+        let cad := fixedCadenceCuts sharedTokChunk ptoks.size
+        let cadSize := if cad.isEmpty then base
+          else min base (deflateDynamicBlocksSharedAtP data ptoks cad).size
+        for (minB, chk) in splitVariants do
+          let cuts := chooseSplitsHeuristicP ptoks minB splitSoftMaxBlockBytes chk
+          let obs := if cuts.isEmpty then base
+            else min base (deflateDynamicBlocksSharedAtP data ptoks cuts).size
+          let obsCad := min obs cadSize
+          IO.println s!"{name},{chain},{gm},{minB},{chk},{data.size},{base},{obs},{obsCad},{cuts.length}"
+      (← IO.getStderr).putStr "."
+  IO.eprintln " done"

--- a/ZipMidSweep.lean
+++ b/ZipMidSweep.lean
@@ -53,26 +53,35 @@ structure TimedConfig where
   label : String
   chain : Nat
   gm : Nat
+  nl : Nat
   mode : Nat
 
-/-- The ladder candidates whose speed decides the L4–L8 assignment. -/
+/-- The ladder candidates whose speed decides the L4–L8 assignment. The
+    knob-selection round ran chain × gm at `nl = 258` (no early-out); the
+    `niceLen` round (post-#2744 rebase) grids the early-out cutoff for each
+    chosen ladder slot's config. -/
 def timedConfigs : List TimedConfig := [
-  ⟨"base-64-8",      64, 8,   0⟩,
-  ⟨"base-128-8",    128, 8,   0⟩,
-  ⟨"base-128-259",  128, 259, 0⟩,
-  ⟨"base-256-259",  256, 259, 0⟩,
-  ⟨"split-48-259",   48, 259, 1⟩,
-  ⟨"split-64-8",     64, 8,   1⟩,
-  ⟨"split-64-259",   64, 259, 1⟩,
-  ⟨"split-128-8",   128, 8,   1⟩,
-  ⟨"split-128-259", 128, 259, 1⟩,
-  ⟨"split-256-259", 256, 259, 1⟩,
-  ⟨"splitcad-512-259", 512, 259, 2⟩ ]
+  ⟨"L4:base-64-8-nl30",       64, 8,   30,  0⟩,
+  ⟨"L4:base-64-8-nl65",       64, 8,   65,  0⟩,
+  ⟨"L4:base-64-8-nl130",      64, 8,   130, 0⟩,
+  ⟨"L4:base-64-8-nl258",      64, 8,   258, 0⟩,
+  ⟨"L5:base-128-259-nl30",   128, 259, 30,  0⟩,
+  ⟨"L5:base-128-259-nl65",   128, 259, 65,  0⟩,
+  ⟨"L5:base-128-259-nl130",  128, 259, 130, 0⟩,
+  ⟨"L5:base-128-259-nl258",  128, 259, 258, 0⟩,
+  ⟨"L6:split-64-259-nl30",    64, 259, 30,  1⟩,
+  ⟨"L6:split-64-259-nl65",    64, 259, 65,  1⟩,
+  ⟨"L6:split-64-259-nl258",   64, 259, 258, 1⟩,
+  ⟨"L7:split-256-259-nl65",  256, 259, 65,  1⟩,
+  ⟨"L7:split-256-259-nl130", 256, 259, 130, 1⟩,
+  ⟨"L7:split-256-259-nl258", 256, 259, 258, 1⟩,
+  ⟨"L8:splitcad-512-259-nl130", 512, 259, 130, 2⟩,
+  ⟨"L8:splitcad-512-259-nl258", 512, 259, 258, 2⟩ ]
 
 /-- Compress `data` under one candidate config, returning the emitted size
     (consumed so the work is not dead-code-eliminated). -/
 def runConfig (cfg : TimedConfig) (data : ByteArray) : Nat :=
-  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm
+  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm cfg.nl
   let base := deflateRawBaseP data ptoks
   if cfg.mode == 0 then base.size
   else

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -493,6 +493,25 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
     unless decomp == data do
       throw (IO.userError s!"arbitrated shared split→FFI inflate mismatch on {name}")
 
+  -- Observation-divergence dispatch (#2737): levels 4–8 route through the
+  -- packed split candidate whenever the heuristic proposes cuts. On the
+  -- heterogeneous input it must (assert, so this test really exercises the
+  -- multi-block dispatch path), and the emitted stream must roundtrip via
+  -- both inflate implementations at every level in the band.
+  unless (Zip.Native.Deflate.chooseSplitsHeuristicP
+      (Zip.Native.Deflate.lzMatchP hetero 6)).length ≥ 1 do
+    throw (IO.userError "chooseSplitsHeuristicP found no cuts on heterogeneous input")
+  for level in [4, 5, 6, 7, 8] do
+    let out := Zip.Native.Deflate.deflateRaw hetero level.toUInt8
+    match Zip.Native.Inflate.inflate out with
+    | .ok result => unless result == hetero do
+        throw (IO.userError s!"deflateRaw({level}) obs-split→native inflate mismatch")
+    | .error e =>
+        throw (IO.userError s!"deflateRaw({level}) obs-split→native inflate failed: {e}")
+    let decomp ← RawDeflate.decompress out
+    unless decomp == hetero do
+      throw (IO.userError s!"deflateRaw({level}) obs-split→FFI inflate mismatch")
+
   -- Stress the many-block cross-reference path: one token per block on a highly
   -- repetitive input, so almost every block references earlier blocks' output.
   let sharedTiny := Zip.Native.Deflate.deflateDynamicBlocksShared textRepeat 1 9

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -493,11 +493,12 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
     unless decomp == data do
       throw (IO.userError s!"arbitrated shared split→FFI inflate mismatch on {name}")
 
-  -- Observation-divergence dispatch (#2737): levels 4–8 route through the
+  -- Observation-divergence dispatch (#2737): levels 6–8 route through the
   -- packed split candidate whenever the heuristic proposes cuts. On the
   -- heterogeneous input it must (assert, so this test really exercises the
   -- multi-block dispatch path), and the emitted stream must roundtrip via
-  -- both inflate implementations at every level in the band.
+  -- both inflate implementations across the mid-band (4–5 single-block,
+  -- 6–8 split).
   unless (Zip.Native.Deflate.chooseSplitsHeuristicP
       (Zip.Native.Deflate.lzMatchP hetero 6)).length ≥ 1 do
     throw (IO.userError "chooseSplitsHeuristicP found no cuts on heterogeneous input")

--- a/ZipTest/PackedTokens.lean
+++ b/ZipTest/PackedTokens.lean
@@ -74,6 +74,32 @@ private def checkCoresP (label : String) (data : ByteArray) : IO Unit := do
         s!"{label} level {level}: deflateDynamicBlockCoreP ({dynP.size} bytes) ≠ \
            deflateDynamicBlockCore ({dynB.size} bytes)")
 
+/-- #2737 gate: the packed observation-divergence split pipeline must match
+    the boxed reference — `chooseSplitsHeuristicP` against
+    `chooseSplitsHeuristic` over the `unpackTok` view (cut-list equality), and
+    `deflateDynamicBlocksSharedAtP` against
+    `deflateDynamicBlocksSharedAtTokens … (fun _ => cuts)` (byte identity; the
+    theorem is `deflateDynamicBlocksSharedAtP_eq`,
+    `Zip/Spec/LZ77PackedCorrect.lean`) — at the heuristic's own cuts and at
+    adversarial cut lists (empty, non-monotone/out-of-range, all-ones), which
+    both emitters must clamp identically. -/
+private def checkSplitP (label : String) (data : ByteArray) : IO Unit := do
+  for level in [(4 : UInt8), 6, 8] do
+    let ptoks := lzMatchP data level
+    let toks := ptoks.map unpackTok
+    let cutsP := chooseSplitsHeuristicP ptoks
+    let cutsB := chooseSplitsHeuristic toks
+    unless cutsP == cutsB do
+      throw (IO.userError
+        s!"{label} level {level}: chooseSplitsHeuristicP {cutsP} ≠ boxed {cutsB}")
+    for cuts in [cutsP, ([] : List Nat), [0, 5, 3, 1000000000], [1]] do
+      let splitP := deflateDynamicBlocksSharedAtP data ptoks cuts
+      let splitB := deflateDynamicBlocksSharedAtTokens data toks (fun _ => cuts)
+      unless splitP == splitB do
+        throw (IO.userError
+          s!"{label} level {level}: deflateDynamicBlocksSharedAtP ({splitP.size} bytes) ≠ \
+             boxed reference ({splitB.size} bytes) at cuts {cuts}")
+
 def tests : IO Unit := do
   IO.println "  PackedTokens tests..."
   let alice ← IO.FS.readBinFile "bench/corpora/canterbury/alice29.txt"
@@ -104,6 +130,20 @@ def tests : IO Unit := do
   checkCoresP "size1" (ByteArray.mk #[42])
   checkCoresP "size2" (ByteArray.mk #[42, 42])
   checkCoresP "size3" (ByteArray.mk #[7, 7, 7])
+  -- #2737: packed split pipeline against the boxed reference. The
+  -- heterogeneous input's statistics shift well above the block-byte floor,
+  -- so the packed heuristic must propose at least one cut there (the
+  -- conformance check then covers a real multi-block partition, not just
+  -- the clamping edge cases).
+  let hetero := mkTextData 65536 ++ mkPrngData 65536 ++ mkCyclicData 65536
+  unless (chooseSplitsHeuristicP (lzMatchP hetero 6)).length ≥ 1 do
+    throw (IO.userError "chooseSplitsHeuristicP found no cuts on heterogeneous input")
+  checkSplitP "hetero192k" hetero
+  checkSplitP "alice29" alice
+  checkSplitP "text64k" (mkTextData 65536)
+  checkSplitP "prng64k" (mkPrngData 65536)
+  checkSplitP "size0" ByteArray.empty
+  checkSplitP "size1" (ByteArray.mk #[42])
   IO.println "  PackedTokens tests passed"
 
 end ZipTest.PackedTokens

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p5e9d22fe80)">
+   <g clip-path="url(#p4b86b30721)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YTYpc1x2H4f6SEKIRccCKLIwxgXjkacgga8gkC8kKsousIBDIKFMT4qFnXoI/gglYMXZHskWr1emurptZ5oL38LeL51nBr7jFue89x/sf/rod8dNyfTm9YJ3rl9MLlthub6YnLHP86PH0hDXuPZhesM7JyfSCNW6vpxesc3yYz2x78Wx6wjKH+cQAAAYJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2NlXRxfTG5a43V9PT1jmnZ/9cnrCMufbk+kJSxy/ej49YZlPXn82PWGJd+8/np6wzG5/Mz1hicu7wz33b/a76QlL/ObRe9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHjl//92zY9YoXXu8vpCcu8vX84PWGd3c30gjUuL6YXrPOLD6YXLHG5XU1PWOZQz8e3t/PpCcs8O3o+PWGJpxffT09Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxM7OX1xMb1ji/Oz+9IR1rr+ZXrDMdvnD9IQ19vvpBcscP/x2esISh3yGnJ89mp6wxv0H0wuWefr6ZnrCEtvVv6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdrZdfDO9gTe1308vgP/bvv7n9IQ1Tnx//uQ4G/kRcYIAAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7OwP3/1resMSL67vpics8+mzl9MTlvno97+dnrDEk4fvT09Y5sM//2V6whK/+9XPpycs8+WL6+kJvKG//+OL6QlLXP3pj9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj3f7jbXrECnf73fSEZU6OD7eLT6+vpiescXo2vWCdV8+nFyyxf+vp9IRltm0/PWGJ0wO+M7jdDvOddm93mL/r6MgNFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTOpgfw5k6/+2p6wjLby/9MT1hjt5tesMzug19PT1jiZNtPT1jmbjvM/+PpdrivtHtX309PWGL7+vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/wD9DY34hJ0bGAAAAABJRU5ErkJggg==" id="imagefaca7305a9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YQYrkZx2H8a6emmEYmsEEJomDiAR05T6LnCGbHMQTeAtPIASyylZEl+48gqhIIGMwnelk0tPT6ampvzv3geflZ4rP5wTfopq3nv7tjt9+up3x43J7Pb1gndsX0wuW2F7fTU9YZvf4nekJa9x/OL1gnfPz6QVrvL6dXrDO7jS/s+3q2fSEZU7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3+dXU5vWOL18XZ6wjI//cn70xOWudjem56wxO7l8+kJy/zl1d+mJyzxswfvTE9Y5nC8m56wxPWb0333746H6QlLfPD459MTlnHBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjuxfefbdMjVnh1uJ6esMyT46PpCesc7qYXrHF9Ob1gnXd/Nb1gievtZnrCMqf6Pj7ZLqYnLPPs7Pn0hCWeXn4zPWEZFywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7S+uLqc3LHGxfzA9YZ3bL6cXLLNdfzs9YY3jcXrBMrtH/5mesMQpvyEX+8fTE9Z48HB6wTJPX91NT1hiu/n39IRlXLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL77fLL6Q38UMfj9AL4n+2Lf05PWOPc/58/Ot5G/o94QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/81Xn09vWOLq9s30hGX++uzF9IRl/vDxh9MTlnjv0S+mJyzz699/Mj1hiY9++fb0hGX+cXU7PYEf6I9/+vv0hCVufvfb6QnLuGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbHc4/nmbHrHCm+NhesIy57vT7eJ7tzfTE9a4t59esM7L59MLlji+9XR6wjLbdpyesMS9E74ZvN5O8zft/uE0P9fZmQsWAEBOYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxPbnNy+mNyxxfm8/PWGdrz+fXrDMdvPd9IQ1DofpBcvs3noyPWGJ81fX0xPWuf9wesEaV6f7Nt7//jT/HrfrE33zz1ywAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPZfJx+Mwj7c4WwAAAAASUVORK5CYII=" id="image84bbf97799" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7ba4a52b53" d="M 0 0 
+       <path id="m121a652c0e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7ba4a52b53" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7ba4a52b53" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m121a652c0e" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m9e303ed699" d="M 0 0 
+       <path id="mb68207033b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m9e303ed699" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb68207033b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,60 +1303,55 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +4 -->
-    <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    <!-- -25 -->
+    <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +12 -->
-    <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    <!-- -21 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -57 -->
+    <!-- -67 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1369,12 +1364,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -86 -->
+    <!-- -88 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1416,82 +1411,52 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +9 -->
-    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    <!-- -60 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +9 -->
-    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +15 -->
-    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -8 -->
-    <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -34 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+    <!-- -23 -->
+    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1527,21 +1492,62 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -53 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -72 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -93 -->
+    <!-- -94 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
     <!-- +4 -->
     <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
@@ -2177,18 +2183,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1efea431a3" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image55a40524ed" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mcd1c933f8f" d="M 0 0 
+       <path id="mae3858eed5" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2211,7 +2217,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2225,7 +2231,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2239,7 +2245,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2252,7 +2258,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2265,7 +2271,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2278,7 +2284,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcd1c933f8f" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mae3858eed5" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2939,8 +2945,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.001562 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3010,13 +3016,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3055,109 +3061,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5e9d22fe80">
+  <clipPath id="p4b86b30721">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m0ecfb2f37f" d="M 0 0 
+       <path id="ma97dbfdbae" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0ecfb2f37f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma97dbfdbae" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mfb77c38e23" d="M 0 0 
+       <path id="m7af9cf99de" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb77c38e23" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7af9cf99de" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mfb77c38e23" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7af9cf99de" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mfb77c38e23" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7af9cf99de" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb5a439007f" d="M 0 0 
+       <path id="m3b1fe93d45" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mb5a439007f" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3b1fe93d45" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m7e7ff69de2" d="M -2.5 2.5 
+     <path id="m52d038e996" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#m7e7ff69de2" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e7ff69de2" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m52d038e996" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m52d038e996" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m76af97ab4a" d="M 0 -2.5 
+     <path id="m21ac5b7896" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#m76af97ab4a" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76af97ab4a" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m21ac5b7896" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m21ac5b7896" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="ma97b2b130c" d="M -0 3.535534 
+     <path id="m47dc2085cd" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#ma97b2b130c" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma97b2b130c" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m47dc2085cd" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m47dc2085cd" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m511383fcfe" d="M -0 2.5 
+     <path id="m0678f05679" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#m511383fcfe" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m0678f05679" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m9fb77cfb8c" d="M -0.833333 2.5 
+     <path id="m5643790a8c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#m9fb77cfb8c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fb77cfb8c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m5643790a8c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5643790a8c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mcd957e1222" d="M -1.25 2.5 
+     <path id="m87021c970a" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#mcd957e1222" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd957e1222" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m87021c970a" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87021c970a" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mf4220e5749" d="M 0 -2.5 
+     <path id="m3a9a1688ee" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#mf4220e5749" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf4220e5749" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m3a9a1688ee" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="ma54fbb8234" d="M 0 -2.5 
+     <path id="m3ad4d8b8a5" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#ma54fbb8234" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma54fbb8234" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m3ad4d8b8a5" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3ad4d8b8a5" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m531bbf9339" d="M 0 3.5 
+      <path id="m6144a077ac" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m531bbf9339" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6144a077ac" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m7e7ff69de2" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m52d038e996" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m76af97ab4a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m21ac5b7896" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#ma97b2b130c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m47dc2085cd" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m511383fcfe" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0678f05679" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m9fb77cfb8c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5643790a8c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mcd957e1222" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m87021c970a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mf4220e5749" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m3a9a1688ee" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#ma54fbb8234" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3ad4d8b8a5" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,17 +5416,17 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p45e92861ce)">
-     <use xlink:href="#m531bbf9339" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="189.634638" y="189.604975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="188.534126" y="190.642027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="185.32129" y="193.451183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="165.179564" y="205.631101" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="150.950891" y="250.636885" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="119.37967" y="288.201372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m531bbf9339" x="100.541635" y="312.810372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p300c156ebd)">
+     <use xlink:href="#m6144a077ac" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="186.58897" y="190.758474" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="169.057218" y="200.763315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="158.596848" y="212.711943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="152.867313" y="218.312857" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="150.950891" y="234.44945" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="119.37967" y="288.201372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6144a077ac" x="100.541635" y="312.810372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -5479,7 +5479,7 @@ L 227.961298 178.435116
 L 226.590001 178.601793 
 L 225.218703 178.767887 
 L 223.847406 178.9334 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
     <path d="M 223.847406 178.9334 
@@ -5531,319 +5531,319 @@ L 212.942069 182.225958
 L 212.699728 182.296589 
 L 212.457387 182.367115 
 L 212.215046 182.437536 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
     <path d="M 212.215046 182.437536 
-L 211.744621 182.598468 
-L 211.274196 182.758855 
-L 210.803771 182.918702 
-L 210.333346 183.07801 
-L 209.86292 183.236785 
-L 209.392495 183.39503 
-L 208.92207 183.552749 
-L 208.451645 183.709944 
-L 207.98122 183.866619 
-L 207.510795 184.022778 
-L 207.040369 184.178424 
-L 206.569944 184.333561 
-L 206.099519 184.488191 
-L 205.629094 184.642318 
-L 205.158669 184.795946 
-L 204.688244 184.949077 
-L 204.217818 185.101716 
-L 203.747393 185.253864 
-L 203.276968 185.405525 
-L 202.806543 185.556702 
-L 202.336118 185.707399 
-L 201.865693 185.857617 
-L 201.395268 186.007362 
-L 200.924842 186.156634 
-L 200.454417 186.305438 
-L 199.983992 186.453776 
-L 199.513567 186.601651 
-L 199.043142 186.749066 
-L 198.572717 186.896024 
-L 198.102291 187.042528 
-L 197.631866 187.18858 
-L 197.161441 187.334183 
-L 196.691016 187.47934 
-L 196.220591 187.624054 
-L 195.750166 187.768328 
-L 195.27974 187.912163 
-L 194.809315 188.055564 
-L 194.33889 188.198532 
-L 193.868465 188.341069 
-L 193.39804 188.483179 
-L 192.927615 188.624865 
-L 192.457189 188.766128 
-L 191.986764 188.906971 
-L 191.516339 189.047397 
-L 191.045914 189.187408 
-L 190.575489 189.327006 
-L 190.105064 189.466195 
-L 189.634638 189.604975 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+L 211.68117 182.626662 
+L 211.147293 182.815036 
+L 210.613417 183.002664 
+L 210.07954 183.189552 
+L 209.545663 183.375706 
+L 209.011787 183.561132 
+L 208.47791 183.745835 
+L 207.944034 183.92982 
+L 207.410157 184.113095 
+L 206.87628 184.295663 
+L 206.342404 184.47753 
+L 205.808527 184.658702 
+L 205.274651 184.839184 
+L 204.740774 185.018982 
+L 204.206897 185.1981 
+L 203.673021 185.376543 
+L 203.139144 185.554317 
+L 202.605268 185.731426 
+L 202.071391 185.907876 
+L 201.537515 186.083672 
+L 201.003638 186.258818 
+L 200.469761 186.433318 
+L 199.935885 186.607179 
+L 199.402008 186.780404 
+L 198.868132 186.952998 
+L 198.334255 187.124966 
+L 197.800378 187.296312 
+L 197.266502 187.467041 
+L 196.732625 187.637157 
+L 196.198749 187.806664 
+L 195.664872 187.975567 
+L 195.130995 188.143871 
+L 194.597119 188.311578 
+L 194.063242 188.478695 
+L 193.529366 188.645224 
+L 192.995489 188.81117 
+L 192.461612 188.976536 
+L 191.927736 189.141328 
+L 191.393859 189.305549 
+L 190.859983 189.469202 
+L 190.326106 189.632293 
+L 189.79223 189.794824 
+L 189.258353 189.956799 
+L 188.724476 190.118223 
+L 188.1906 190.279098 
+L 187.656723 190.43943 
+L 187.122847 190.599221 
+L 186.58897 190.758474 
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 189.634638 189.604975 
-L 189.611711 189.626814 
-L 189.588784 189.648642 
-L 189.565856 189.67046 
-L 189.542929 189.692268 
-L 189.520002 189.714067 
-L 189.497074 189.735855 
-L 189.474147 189.757633 
-L 189.45122 189.779401 
-L 189.428292 189.801159 
-L 189.405365 189.822907 
-L 189.382438 189.844645 
-L 189.35951 189.866374 
-L 189.336583 189.888092 
-L 189.313656 189.9098 
-L 189.290728 189.931498 
-L 189.267801 189.953187 
-L 189.244874 189.974865 
-L 189.221946 189.996534 
-L 189.199019 190.018193 
-L 189.176092 190.039841 
-L 189.153164 190.06148 
-L 189.130237 190.083109 
-L 189.10731 190.104729 
-L 189.084382 190.126338 
-L 189.061455 190.147937 
-L 189.038528 190.169527 
-L 189.0156 190.191107 
-L 188.992673 190.212677 
-L 188.969746 190.234237 
-L 188.946818 190.255787 
-L 188.923891 190.277328 
-L 188.900964 190.298859 
-L 188.878036 190.32038 
-L 188.855109 190.341891 
-L 188.832182 190.363392 
-L 188.809254 190.384884 
-L 188.786327 190.406366 
-L 188.7634 190.427838 
-L 188.740472 190.449301 
-L 188.717545 190.470753 
-L 188.694618 190.492196 
-L 188.67169 190.51363 
-L 188.648763 190.535054 
-L 188.625836 190.556468 
-L 188.602908 190.577872 
-L 188.579981 190.599267 
-L 188.557054 190.620652 
-L 188.534126 190.642027 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 190.758474 
+L 186.223725 190.989978 
+L 185.85848 191.220357 
+L 185.493235 191.449621 
+L 185.127991 191.677781 
+L 184.762746 191.904848 
+L 184.397501 192.130833 
+L 184.032256 192.355744 
+L 183.667011 192.579593 
+L 183.301766 192.80239 
+L 182.936522 193.024144 
+L 182.571277 193.244866 
+L 182.206032 193.464564 
+L 181.840787 193.683248 
+L 181.475542 193.900928 
+L 181.110297 194.117612 
+L 180.745053 194.33331 
+L 180.379808 194.548031 
+L 180.014563 194.761783 
+L 179.649318 194.974576 
+L 179.284073 195.186417 
+L 178.918828 195.397315 
+L 178.553584 195.607279 
+L 178.188339 195.816317 
+L 177.823094 196.024437 
+L 177.457849 196.231647 
+L 177.092604 196.437954 
+L 176.727359 196.643368 
+L 176.362115 196.847894 
+L 175.99687 197.051542 
+L 175.631625 197.254319 
+L 175.26638 197.456231 
+L 174.901135 197.657287 
+L 174.53589 197.857493 
+L 174.170645 198.056858 
+L 173.805401 198.255387 
+L 173.440156 198.453087 
+L 173.074911 198.649967 
+L 172.709666 198.846031 
+L 172.344421 199.041288 
+L 171.979176 199.235744 
+L 171.613932 199.429405 
+L 171.248687 199.622278 
+L 170.883442 199.814369 
+L 170.518197 200.005684 
+L 170.152952 200.196231 
+L 169.787707 200.386014 
+L 169.422463 200.57504 
+L 169.057218 200.763315 
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 188.534126 190.642027 
-L 188.467192 190.702282 
-L 188.400258 190.762461 
-L 188.333324 190.822563 
-L 188.26639 190.882589 
-L 188.199456 190.94254 
-L 188.132522 191.002414 
-L 188.065588 191.062213 
-L 187.998654 191.121937 
-L 187.931719 191.181585 
-L 187.864785 191.241159 
-L 187.797851 191.300657 
-L 187.730917 191.360081 
-L 187.663983 191.419431 
-L 187.597049 191.478706 
-L 187.530115 191.537908 
-L 187.463181 191.597035 
-L 187.396247 191.656089 
-L 187.329313 191.715069 
-L 187.262379 191.773976 
-L 187.195444 191.83281 
-L 187.12851 191.891571 
-L 187.061576 191.950259 
-L 186.994642 192.008874 
-L 186.927708 192.067418 
-L 186.860774 192.125888 
-L 186.79384 192.184287 
-L 186.726906 192.242614 
-L 186.659972 192.300869 
-L 186.593038 192.359053 
-L 186.526104 192.417166 
-L 186.459169 192.475207 
-L 186.392235 192.533177 
-L 186.325301 192.591076 
-L 186.258367 192.648905 
-L 186.191433 192.706663 
-L 186.124499 192.764351 
-L 186.057565 192.821969 
-L 185.990631 192.879517 
-L 185.923697 192.936995 
-L 185.856763 192.994403 
-L 185.789829 193.051742 
-L 185.722895 193.109012 
-L 185.65596 193.166212 
-L 185.589026 193.223344 
-L 185.522092 193.280406 
-L 185.455158 193.3374 
-L 185.388224 193.394326 
-L 185.32129 193.451183 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 200.763315 
+L 168.839293 201.045598 
+L 168.621369 201.326209 
+L 168.403445 201.605168 
+L 168.18552 201.882495 
+L 167.967596 202.158208 
+L 167.749672 202.432326 
+L 167.531747 202.704868 
+L 167.313823 202.975851 
+L 167.095898 203.245294 
+L 166.877974 203.513213 
+L 166.66005 203.779626 
+L 166.442125 204.04455 
+L 166.224201 204.308001 
+L 166.006277 204.569995 
+L 165.788352 204.830549 
+L 165.570428 205.089678 
+L 165.352503 205.347398 
+L 165.134579 205.603723 
+L 164.916655 205.85867 
+L 164.69873 206.112253 
+L 164.480806 206.364486 
+L 164.262882 206.615383 
+L 164.044957 206.864959 
+L 163.827033 207.113227 
+L 163.609108 207.360202 
+L 163.391184 207.605896 
+L 163.17326 207.850323 
+L 162.955335 208.093496 
+L 162.737411 208.335427 
+L 162.519487 208.576129 
+L 162.301562 208.815615 
+L 162.083638 209.053896 
+L 161.865713 209.290986 
+L 161.647789 209.526895 
+L 161.429865 209.761636 
+L 161.21194 209.995219 
+L 160.994016 210.227657 
+L 160.776092 210.458961 
+L 160.558167 210.689141 
+L 160.340243 210.918208 
+L 160.122318 211.146173 
+L 159.904394 211.373047 
+L 159.68647 211.59884 
+L 159.468545 211.823562 
+L 159.250621 212.047224 
+L 159.032697 212.269834 
+L 158.814772 212.491404 
+L 158.596848 212.711943 
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 185.32129 193.451183 
-L 184.901671 193.739644 
-L 184.482051 194.02636 
-L 184.062432 194.311351 
-L 183.642813 194.594639 
-L 183.223194 194.876243 
-L 182.803574 195.156183 
-L 182.383955 195.43448 
-L 181.964336 195.711152 
-L 181.544716 195.986218 
-L 181.125097 196.259696 
-L 180.705478 196.531606 
-L 180.285858 196.801964 
-L 179.866239 197.070788 
-L 179.44662 197.338096 
-L 179.027001 197.603905 
-L 178.607381 197.868231 
-L 178.187762 198.131091 
-L 177.768143 198.3925 
-L 177.348523 198.652476 
-L 176.928904 198.911033 
-L 176.509285 199.168188 
-L 176.089666 199.423954 
-L 175.670046 199.678347 
-L 175.250427 199.931382 
-L 174.830808 200.183073 
-L 174.411188 200.433434 
-L 173.991569 200.68248 
-L 173.57195 200.930223 
-L 173.15233 201.176678 
-L 172.732711 201.421858 
-L 172.313092 201.665776 
-L 171.893473 201.908445 
-L 171.473853 202.149878 
-L 171.054234 202.390087 
-L 170.634615 202.629084 
-L 170.214995 202.866882 
-L 169.795376 203.103493 
-L 169.375757 203.338928 
-L 168.956138 203.5732 
-L 168.536518 203.806318 
-L 168.116899 204.038296 
-L 167.69728 204.269144 
-L 167.27766 204.498872 
-L 166.858041 204.727493 
-L 166.438422 204.955015 
-L 166.018802 205.181451 
-L 165.599183 205.406809 
-L 165.179564 205.631101 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 212.711943 
+L 158.477483 212.835643 
+L 158.358117 212.95902 
+L 158.238752 213.082078 
+L 158.119387 213.204816 
+L 158.000021 213.327237 
+L 157.880656 213.449343 
+L 157.761291 213.571135 
+L 157.641925 213.692615 
+L 157.52256 213.813785 
+L 157.403195 213.934645 
+L 157.28383 214.055198 
+L 157.164464 214.175444 
+L 157.045099 214.295387 
+L 156.925734 214.415027 
+L 156.806368 214.534365 
+L 156.687003 214.653404 
+L 156.567638 214.772144 
+L 156.448272 214.890588 
+L 156.328907 215.008736 
+L 156.209542 215.126591 
+L 156.090177 215.244153 
+L 155.970811 215.361424 
+L 155.851446 215.478406 
+L 155.732081 215.595099 
+L 155.612715 215.711506 
+L 155.49335 215.827628 
+L 155.373985 215.943466 
+L 155.254619 216.059021 
+L 155.135254 216.174295 
+L 155.015889 216.28929 
+L 154.896524 216.404006 
+L 154.777158 216.518446 
+L 154.657793 216.632609 
+L 154.538428 216.746498 
+L 154.419062 216.860114 
+L 154.299697 216.973459 
+L 154.180332 217.086532 
+L 154.060966 217.199337 
+L 153.941601 217.311874 
+L 153.822236 217.424144 
+L 153.702871 217.536149 
+L 153.583505 217.64789 
+L 153.46414 217.759368 
+L 153.344775 217.870584 
+L 153.225409 217.98154 
+L 153.106044 218.092237 
+L 152.986679 218.202675 
+L 152.867313 218.312857 
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 165.179564 205.631101 
-L 164.883133 207.170609 
-L 164.586703 208.661672 
-L 164.290272 210.107248 
-L 163.993841 211.510029 
-L 163.697411 212.872477 
-L 163.40098 214.196846 
-L 163.104549 215.485207 
-L 162.808118 216.739467 
-L 162.511688 217.961383 
-L 162.215257 219.152583 
-L 161.918826 220.314573 
-L 161.622396 221.448751 
-L 161.325965 222.556417 
-L 161.029534 223.638784 
-L 160.733104 224.696979 
-L 160.436673 225.732061 
-L 160.140242 226.745016 
-L 159.843812 227.736771 
-L 159.547381 228.708195 
-L 159.25095 229.660106 
-L 158.95452 230.593271 
-L 158.658089 231.508415 
-L 158.361658 232.40622 
-L 158.065228 233.287332 
-L 157.768797 234.15236 
-L 157.472366 235.00188 
-L 157.175936 235.836439 
-L 156.879505 236.656555 
-L 156.583074 237.462719 
-L 156.286644 238.255397 
-L 155.990213 239.035035 
-L 155.693782 239.802053 
-L 155.397352 240.556854 
-L 155.100921 241.29982 
-L 154.80449 242.031318 
-L 154.50806 242.751696 
-L 154.211629 243.461287 
-L 153.915198 244.16041 
-L 153.618768 244.849368 
-L 153.322337 245.528452 
-L 153.025906 246.197943 
-L 152.729476 246.858108 
-L 152.433045 247.509201 
-L 152.136614 248.151471 
-L 151.840183 248.785151 
-L 151.543753 249.41047 
-L 151.247322 250.027645 
-L 150.950891 250.636885 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 218.312857 
+L 152.827388 218.71168 
+L 152.787463 219.107174 
+L 152.747537 219.499395 
+L 152.707612 219.888396 
+L 152.667686 220.27423 
+L 152.627761 220.656948 
+L 152.587835 221.0366 
+L 152.54791 221.413234 
+L 152.507984 221.786899 
+L 152.468059 222.15764 
+L 152.428133 222.525503 
+L 152.388208 222.890533 
+L 152.348282 223.252772 
+L 152.308357 223.612264 
+L 152.268432 223.969048 
+L 152.228506 224.323167 
+L 152.188581 224.674659 
+L 152.148655 225.023563 
+L 152.10873 225.369917 
+L 152.068804 225.713758 
+L 152.028879 226.055123 
+L 151.988953 226.394045 
+L 151.949028 226.730561 
+L 151.909102 227.064705 
+L 151.869177 227.396508 
+L 151.829252 227.726005 
+L 151.789326 228.053226 
+L 151.749401 228.378203 
+L 151.709475 228.700967 
+L 151.66955 229.021548 
+L 151.629624 229.339974 
+L 151.589699 229.656275 
+L 151.549773 229.970479 
+L 151.509848 230.282613 
+L 151.469922 230.592705 
+L 151.429997 230.90078 
+L 151.390072 231.206866 
+L 151.350146 231.510988 
+L 151.310221 231.81317 
+L 151.270295 232.113438 
+L 151.23037 232.411815 
+L 151.190444 232.708325 
+L 151.150519 233.002991 
+L 151.110593 233.295836 
+L 151.070668 233.586883 
+L 151.030742 233.876153 
+L 150.990817 234.163668 
+L 150.950891 234.44945 
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 250.636885 
-L 150.293158 251.81602 
-L 149.635424 252.966525 
-L 148.97769 254.08976 
-L 148.319956 255.186986 
-L 147.662223 256.259382 
-L 147.004489 257.308045 
-L 146.346755 258.334004 
-L 145.689021 259.338221 
-L 145.031288 260.321599 
-L 144.373554 261.284984 
-L 143.71582 262.229174 
-L 143.058086 263.154918 
-L 142.400352 264.062924 
-L 141.742619 264.953859 
-L 141.084885 265.828352 
-L 140.427151 266.686999 
-L 139.769417 267.530365 
-L 139.111684 268.358984 
-L 138.45395 269.173363 
-L 137.796216 269.973982 
-L 137.138482 270.7613 
-L 136.480748 271.535751 
-L 135.823015 272.297748 
-L 135.165281 273.047687 
-L 134.507547 273.785942 
-L 133.849813 274.512872 
-L 133.19208 275.22882 
-L 132.534346 275.934112 
-L 131.876612 276.629061 
-L 131.218878 277.313965 
-L 130.561145 277.989112 
-L 129.903411 278.654775 
-L 129.245677 279.311216 
-L 128.587943 279.958689 
-L 127.930209 280.597434 
-L 127.272476 281.227684 
-L 126.614742 281.849662 
-L 125.957008 282.463583 
-L 125.299274 283.069651 
-L 124.641541 283.668066 
-L 123.983807 284.259019 
-L 123.326073 284.842693 
-L 122.668339 285.419265 
-L 122.010605 285.988906 
-L 121.352872 286.551782 
-L 120.695138 287.10805 
-L 120.037404 287.657864 
+    <path d="M 150.950891 234.44945 
+L 150.293158 236.487073 
+L 149.635424 238.440683 
+L 148.97769 240.316933 
+L 148.319956 242.121719 
+L 147.662223 243.860284 
+L 147.004489 245.537316 
+L 146.346755 247.157023 
+L 145.689021 248.723195 
+L 145.031288 250.239257 
+L 144.373554 251.708318 
+L 143.71582 253.133203 
+L 143.058086 254.516492 
+L 142.400352 255.860546 
+L 141.742619 257.167528 
+L 141.084885 258.439429 
+L 140.427151 259.678083 
+L 139.769417 260.885183 
+L 139.111684 262.062299 
+L 138.45395 263.210882 
+L 137.796216 264.332285 
+L 137.138482 265.427763 
+L 136.480748 266.498488 
+L 135.823015 267.545554 
+L 135.165281 268.569984 
+L 134.507547 269.572737 
+L 133.849813 270.55471 
+L 133.19208 271.516747 
+L 132.534346 272.459642 
+L 131.876612 273.384142 
+L 131.218878 274.29095 
+L 130.561145 275.180731 
+L 129.903411 276.054114 
+L 129.245677 276.91169 
+L 128.587943 277.754023 
+L 127.930209 278.581644 
+L 127.272476 279.395059 
+L 126.614742 280.194747 
+L 125.957008 280.981165 
+L 125.299274 281.754744 
+L 124.641541 282.515898 
+L 123.983807 283.265019 
+L 123.326073 284.002483 
+L 122.668339 284.728645 
+L 122.010605 285.443848 
+L 121.352872 286.148417 
+L 120.695138 286.842664 
+L 120.037404 287.526887 
 L 119.37967 288.201372 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
     <path d="M 119.37967 288.201372 
@@ -5895,7 +5895,7 @@ L 101.719013 311.595209
 L 101.326553 312.003735 
 L 100.934094 312.40877 
 L 100.541635 312.810372 
-" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.001562 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,31 +6289,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6414,13 +6389,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6459,109 +6434,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p45e92861ce">
+  <clipPath id="p300c156ebd">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1ac558e6f1)">
+   <g clip-path="url(#p7bdb3b9abd)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+0lEQVR4nO3YsaplZx2H4b1nzjmcSXBAmcSQUmIhSLBI4zSpcyfp7CwlfUqvIfEGAkFCbESx0UIsBLUTCUMyiZOZcM6Zfdb2Ekbhk3/Y7/NcwW/BWt96+fbblx8cd6fm6efTC5Y6fnFaz7Pb7Xb//PlH0xOW+sefn01PWO7tD9+ZnrDc/idvTU9Ya39nesF6Tz6bXrDe5f3pBUv96vvvT09Y7gS/JACA/54YAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI218fPj5Oj1jtuNumJyy1P8FmPb9zMT1hqZvtanrCcud/+cP0hOUOP344PWGpw3YzPWG5Z4cn0xOWe3Bix8Pz+w+mJyx3en9ZAID/gRgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7O3/21fSG9a6/mV6w1nGbXrDevfvTC5a6mB7wf3B88mx6wnLnXz+enrDU+XaYnrDcvVM8766eTi9Y6vzs9E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud37nYnrCUrfHw/SE5e4+fTw9Yb3vvDq9YKnn2830hOW+uPrX9ITlXrs+m56w1Pbd16cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO/vjo99Nb1juzm4/PWGpV156MD1hudvtMD1hqYu7l9MTlnv3N7+dnrDcez/94fSEpQ7HbXrCcr/4/d+mJyz38PWXpycs9e6bD6cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn757e/Pk6PWO3m9mp6wlL39pfTE3iBm/1hesJy/77+fHrCct+7fG16wlLbcZuesNxX14+mJyz3+Pqz6QlL/eD+m9MTlnMzBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLT9tn16nB4BfAsdbqYXrHd2Mb2AF7i6/WZ6wnKXd1+ansALuBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tnuuE1vWG+v8b71DjfTC5bazs6mJyz3px/9bHrCcm/99ZfTE9a6e3rv3e3xMD1hvUd/n16w1qtvTC9YTjUAAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7T9w24kn6oVK9AAAAABJRU5ErkJggg==" id="image53a92f3ee2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagede25e685e8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9484910494" d="M 0 0 
+       <path id="mf5ce59eb56" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9484910494" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9484910494" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9484910494" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9484910494" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9484910494" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9484910494" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9484910494" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9484910494" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9484910494" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9484910494" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9484910494" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf5ce59eb56" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m309131da7f" d="M 0 0 
+       <path id="m472cabdbd9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m309131da7f" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m472cabdbd9" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,8 +1303,29 @@ L 512.247548 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +0 -->
-    <g transform="translate(109.820098 68.904519) scale(0.065 -0.065)">
+    <!-- -0 -->
+    <g transform="translate(111.370957 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -0 -->
+    <g transform="translate(149.241075 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -0 -->
+    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +1 -->
+    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1323,55 +1344,21 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- +0 -->
-    <g transform="translate(147.690216 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -0 -->
-    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +1 -->
-    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -0 -->
+    <!-- -1 -->
     <g transform="translate(262.85143 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +17 -->
-    <g transform="translate(297.102876 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    <!-- -1 -->
+    <g transform="translate(300.721548 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1389,58 +1376,24 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -1 -->
+    <!-- -2 -->
     <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- +3 -->
+    <!-- +0 -->
     <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- +0 -->
-    <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(490.072138 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1635,6 +1588,40 @@ z
    <g id="text_55">
     <!-- -3 -->
     <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1845,6 +1832,18 @@ z
    <g id="text_80">
     <!-- +7 -->
     <g transform="translate(299.170688 245.658775) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2093,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imaged4579cfc40" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0eeea53abc" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m64fcc7c6ee" d="M 0 0 
+       <path id="mcd12853107" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd12853107" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.001562 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2954,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1ac558e6f1">
+  <clipPath id="p7bdb3b9abd">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.396875pt" height="386.202469pt" viewBox="0 0 570.396875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.396875 386.202469 
-L 570.396875 0 
+L 569.186094 386.202469 
+L 569.186094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.323438 104.1264 
-L 291.948438 104.1264 
-L 291.948438 74.7432 
-L 187.323438 74.7432 
+    <path d="M 186.718047 104.1264 
+L 291.343047 104.1264 
+L 291.343047 74.7432 
+L 186.718047 74.7432 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.948438 104.1264 
-L 396.573438 104.1264 
-L 396.573438 74.7432 
-L 291.948438 74.7432 
+    <path d="M 291.343047 104.1264 
+L 395.968047 104.1264 
+L 395.968047 74.7432 
+L 291.343047 74.7432 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.573438 104.1264 
-L 501.198438 104.1264 
-L 501.198438 74.7432 
-L 396.573438 74.7432 
+    <path d="M 395.968047 104.1264 
+L 500.593047 104.1264 
+L 500.593047 74.7432 
+L 395.968047 74.7432 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.323438 133.5096 
-L 291.948438 133.5096 
-L 291.948438 104.1264 
-L 187.323438 104.1264 
+    <path d="M 186.718047 133.5096 
+L 291.343047 133.5096 
+L 291.343047 104.1264 
+L 186.718047 104.1264 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.948438 133.5096 
-L 396.573438 133.5096 
-L 396.573438 104.1264 
-L 291.948438 104.1264 
+    <path d="M 291.343047 133.5096 
+L 395.968047 133.5096 
+L 395.968047 104.1264 
+L 291.343047 104.1264 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.573438 133.5096 
-L 501.198438 133.5096 
-L 501.198438 104.1264 
-L 396.573438 104.1264 
+    <path d="M 395.968047 133.5096 
+L 500.593047 133.5096 
+L 500.593047 104.1264 
+L 395.968047 104.1264 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.323438 162.8928 
-L 291.948438 162.8928 
-L 291.948438 133.5096 
-L 187.323438 133.5096 
+    <path d="M 186.718047 162.8928 
+L 291.343047 162.8928 
+L 291.343047 133.5096 
+L 186.718047 133.5096 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.948438 162.8928 
-L 396.573438 162.8928 
-L 396.573438 133.5096 
-L 291.948438 133.5096 
+    <path d="M 291.343047 162.8928 
+L 395.968047 162.8928 
+L 395.968047 133.5096 
+L 291.343047 133.5096 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.573438 162.8928 
-L 501.198438 162.8928 
-L 501.198438 133.5096 
-L 396.573438 133.5096 
+    <path d="M 395.968047 162.8928 
+L 500.593047 162.8928 
+L 500.593047 133.5096 
+L 395.968047 133.5096 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.323438 192.276 
-L 291.948438 192.276 
-L 291.948438 162.8928 
-L 187.323438 162.8928 
+    <path d="M 186.718047 192.276 
+L 291.343047 192.276 
+L 291.343047 162.8928 
+L 186.718047 162.8928 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.948438 192.276 
-L 396.573438 192.276 
-L 396.573438 162.8928 
-L 291.948438 162.8928 
+    <path d="M 291.343047 192.276 
+L 395.968047 192.276 
+L 395.968047 162.8928 
+L 291.343047 162.8928 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.573438 192.276 
-L 501.198438 192.276 
-L 501.198438 162.8928 
-L 396.573438 162.8928 
+    <path d="M 395.968047 192.276 
+L 500.593047 192.276 
+L 500.593047 162.8928 
+L 395.968047 162.8928 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.323438 221.6592 
-L 291.948438 221.6592 
-L 291.948438 192.276 
-L 187.323438 192.276 
+    <path d="M 186.718047 221.6592 
+L 291.343047 221.6592 
+L 291.343047 192.276 
+L 186.718047 192.276 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.948438 221.6592 
-L 396.573438 221.6592 
-L 396.573438 192.276 
-L 291.948438 192.276 
+    <path d="M 291.343047 221.6592 
+L 395.968047 221.6592 
+L 395.968047 192.276 
+L 291.343047 192.276 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.573438 221.6592 
-L 501.198438 221.6592 
-L 501.198438 192.276 
-L 396.573438 192.276 
+    <path d="M 395.968047 221.6592 
+L 500.593047 221.6592 
+L 500.593047 192.276 
+L 395.968047 192.276 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.323438 251.0424 
-L 291.948438 251.0424 
-L 291.948438 221.6592 
-L 187.323438 221.6592 
+    <path d="M 186.718047 251.0424 
+L 291.343047 251.0424 
+L 291.343047 221.6592 
+L 186.718047 221.6592 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.948438 251.0424 
-L 396.573438 251.0424 
-L 396.573438 221.6592 
-L 291.948438 221.6592 
+    <path d="M 291.343047 251.0424 
+L 395.968047 251.0424 
+L 395.968047 221.6592 
+L 291.343047 221.6592 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.573438 251.0424 
-L 501.198438 251.0424 
-L 501.198438 221.6592 
-L 396.573438 221.6592 
+    <path d="M 395.968047 251.0424 
+L 500.593047 251.0424 
+L 500.593047 221.6592 
+L 395.968047 221.6592 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.323438 280.4256 
-L 291.948438 280.4256 
-L 291.948438 251.0424 
-L 187.323438 251.0424 
+    <path d="M 186.718047 280.4256 
+L 291.343047 280.4256 
+L 291.343047 251.0424 
+L 186.718047 251.0424 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.948438 280.4256 
-L 396.573438 280.4256 
-L 396.573438 251.0424 
-L 291.948438 251.0424 
+    <path d="M 291.343047 280.4256 
+L 395.968047 280.4256 
+L 395.968047 251.0424 
+L 291.343047 251.0424 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.573438 280.4256 
-L 501.198438 280.4256 
-L 501.198438 251.0424 
-L 396.573438 251.0424 
+    <path d="M 395.968047 280.4256 
+L 500.593047 280.4256 
+L 500.593047 251.0424 
+L 395.968047 251.0424 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.323438 309.8088 
-L 291.948438 309.8088 
-L 291.948438 280.4256 
-L 187.323438 280.4256 
+    <path d="M 186.718047 309.8088 
+L 291.343047 309.8088 
+L 291.343047 280.4256 
+L 186.718047 280.4256 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.948438 309.8088 
-L 396.573438 309.8088 
-L 396.573438 280.4256 
-L 291.948438 280.4256 
+    <path d="M 291.343047 309.8088 
+L 395.968047 309.8088 
+L 395.968047 280.4256 
+L 291.343047 280.4256 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.573438 309.8088 
-L 501.198438 309.8088 
-L 501.198438 280.4256 
-L 396.573438 280.4256 
+    <path d="M 395.968047 309.8088 
+L 500.593047 309.8088 
+L 500.593047 280.4256 
+L 395.968047 280.4256 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.323438 339.192 
-L 291.948438 339.192 
-L 291.948438 309.8088 
-L 187.323438 309.8088 
+    <path d="M 186.718047 339.192 
+L 291.343047 339.192 
+L 291.343047 309.8088 
+L 186.718047 309.8088 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.948438 339.192 
-L 396.573438 339.192 
-L 396.573438 309.8088 
-L 291.948438 309.8088 
+    <path d="M 291.343047 339.192 
+L 395.968047 339.192 
+L 395.968047 309.8088 
+L 291.343047 309.8088 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.573438 339.192 
-L 501.198438 339.192 
-L 501.198438 309.8088 
-L 396.573438 309.8088 
+    <path d="M 395.968047 339.192 
+L 500.593047 339.192 
+L 500.593047 309.8088 
+L 395.968047 309.8088 
 z
-" clip-path="url(#pfef4d56b4b)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7818709b64)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.310703 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.594922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.167031 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.51875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.248438 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.184688 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.625938 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.250938 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.886563 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.184688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.170938 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.250938 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.149687 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.544297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.184688 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.170938 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.250938 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.455938 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.850547 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.184688 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.170938 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.250938 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.612188 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.006797 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.184688 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.170938 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,325 +1492,15 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.250938 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- lean-zip (native) -->
-    <g transform="translate(97.957813 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
-L 1656 4863 
-L 1656 0 
-L 538 0 
-L 538 4863 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
-L 4056 0 
-L 2931 0 
-L 2931 347 
-L 2931 1631 
-Q 2931 2084 2911 2256 
-Q 2891 2428 2841 2509 
-Q 2775 2619 2662 2680 
-Q 2550 2741 2406 2741 
-Q 2056 2741 1856 2470 
-Q 1656 2200 1656 1722 
-L 1656 0 
-L 538 0 
-L 538 3500 
-L 1656 3500 
-L 1656 2988 
-Q 1909 3294 2193 3439 
-Q 2478 3584 2822 3584 
-Q 3428 3584 3742 3212 
-Q 4056 2841 4056 2131 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
-L 2309 2297 
-L 2309 1388 
-L 347 1388 
-L 347 2297 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
-L 3419 3500 
-L 3419 2719 
-L 1575 800 
-L 3419 800 
-L 3419 0 
-L 288 0 
-L 288 781 
-L 2131 2700 
-L 366 2700 
-L 366 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
-L 1484 -844 
-Q 1006 -72 778 623 
-Q 550 1319 550 2003 
-Q 550 2688 779 3389 
-Q 1009 4091 1484 4856 
-L 2413 4856 
-Q 2013 4116 1813 3408 
-Q 1613 2700 1613 2009 
-Q 1613 1319 1811 609 
-Q 2009 -100 2413 -844 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-76" d="M 97 3500 
-L 1216 3500 
-L 2088 1081 
-L 2956 3500 
-L 4078 3500 
-L 2700 0 
-L 1472 0 
-L 97 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-29" d="M 513 -844 
-Q 913 -100 1113 609 
-Q 1313 1319 1313 2009 
-Q 1313 2700 1113 3408 
-Q 913 4116 513 4856 
-L 1441 4856 
-Q 1916 4091 2145 3389 
-Q 2375 2688 2375 2003 
-Q 2375 1319 2147 623 
-Q 1919 -72 1441 -844 
-L 513 -844 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-6c"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.304 -->
-    <g transform="translate(226.984063 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
-Q 2944 3213 2780 3570 
-Q 2616 3928 2228 3928 
-Q 1841 3928 1675 3570 
-Q 1509 3213 1509 2338 
-Q 1509 1453 1675 1090 
-Q 1841 728 2228 728 
-Q 2613 728 2778 1090 
-Q 2944 1453 2944 2338 
-z
-M 4147 2328 
-Q 4147 1169 3647 539 
-Q 3147 -91 2228 -91 
-Q 1306 -91 806 539 
-Q 306 1169 306 2328 
-Q 306 3491 806 4120 
-Q 1306 4750 2228 4750 
-Q 3147 4750 3647 4120 
-Q 4147 3491 4147 2328 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
-L 1778 1209 
-L 1778 0 
-L 653 0 
-L 653 1209 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 26 -->
-    <g transform="translate(338.694687 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 208 -->
-    <g transform="translate(440.536563 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.072813 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.467422 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1937,9 +1627,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.184688 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1947,24 +1637,24 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_31">
+   <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.170938 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_32">
+   <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(441.250938 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
-   <g id="text_33">
+   <g id="text_29">
     <!-- Go compress/flate -->
-    <g transform="translate(98.579688 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.974297 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2018,9 +1708,9 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
     </g>
    </g>
-   <g id="text_34">
+   <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(228.184688 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2028,23 +1718,304 @@ z
      <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_35">
+   <g id="text_31">
     <!-- 18 -->
-    <g transform="translate(339.170938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_36">
+   <g id="text_32">
     <!-- 88 -->
-    <g transform="translate(443.795938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.190547 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
+   <g id="text_33">
+    <!-- lean-zip (native) -->
+    <g transform="translate(97.352422 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
+L 2309 2297 
+L 2309 1388 
+L 347 1388 
+L 347 2297 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-6c"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 0.298 -->
+    <g transform="translate(226.378672 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 17 -->
+    <g transform="translate(338.089297 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 208 -->
+    <g transform="translate(439.931172 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.294063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2055,7 +2026,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.184688 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2065,13 +2036,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.715937 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.885938 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2087,7 +2058,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.707188 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.101797 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2226,6 +2197,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2270,7 +2271,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2412,13 +2413,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2457,110 +2458,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfef4d56b4b">
-   <rect x="82.698438" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p7818709b64">
+   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc4cca4aa6e)">
+   <g clip-path="url(#p9a109575d5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3Yv46cZx2GYc/OeI0dRzjEOAIkiwaoQIqgouEMKDgMSlp6Smpaek6ACkSFhBB0oSMKKcARf0Ica3dnd5YjoLLe+7f+dF1H8Iy+eee9v9md/vnL23tbdryYXsDrOF1PL1hrdza9YK3rq+kFaz16Mr1grcuX0wvW2p9PL+B1bP37ef5oesFSG7/9AAC4awQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpwx+PH05vWOpwtp+esNTp9nZ6wlLP3n42PWGpD//7t+kJa238FfebX3gyPWGp44Pz6QlL/enFB9MTlvrO029MT1jq8vw0PWGp3e7V9ISlNn49AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTh+dtfn96w1JMHz6YnLPXJxcfTE5b66qttvyM9fvfb0xOW2u8O0xOWOt07TU9Y6sv3nk5PWOr66dX0hKXee/R8esJSx9O2n99bV9v+fdn27Q4AwJ0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB12u2036GfHf01PWOrh/vH0hKVu3v3S9ISl/v7pn6cnLPXy6mJ6wlLffed70xOWutpPL1jr8+Nn0xN4Df+5fDE9Ya0Hz6YXLLXt+gQA4M4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHY3v/vJ7fSIpU6n6QXw/515B3yj+X15s239/G39++n5vdE2/vQAALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDe3/4y/SGpc4O227sFx98Mj1hqV/8+P3pCUv97Pf/mJ6w1A+ef3F6wlK/+u1fpycs9dMffWt6wlI//81H0xOW+uH7X5mesNRHn15OT1jq+197a3rCUtuuMwAA7hwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaHW9+fTs9YqX99fX0hLXODtML1rq+mF6w1vmj6QVr7Tb+jnt7ml6w1tH5e6PdbPv+O+62ff7ub7xfNn47AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh4ubV9Mblnp4//H0hKVuTtfTE5a6f/FyesJSn+9P0xOWenjY9vk7u9n2+bu38c/378sX0xOWemf/ZHrCUvf359MT1rq5mF6wlH9AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A7yZgLa2ceZGAAAAAElFTkSuQmCC" id="image6dd5fa2257" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ70lEQVR4nO3XvY6dVxmGYe+ZzRhsRziJ4wiQrDSBCqQIKhrOgILDSJmWnpI6bfqcQCpQqkgIQZdUJEoiFGxA+THBnj2zhyOgstb9jj9d1xE80vez7rU7/uudqxtbdngyvYBncbyYXrDW7mR6wVoX59ML1rp1d3rBWk8fTy9Y6/RsegHPYuvv59mt6QVLbfz0AwDguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9n8+fDK9Yan9yen0hKWOV1fTE5a6/8L96QlLffL1Z9MT1tr4FffH3707PWGpw82z6QlL/eXhh9MTlvrZvdenJyz19Ow4PWGp3e7b6QlLbfx4AADguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9gxdem96w1N2b96cnLPXoyefTE5b64bfbviPdefmn0xOWOt3tpycsdbxxnJ6w1Cs37k1PWOri3vn0hKVevfVgesJSh+O2n9/t823/X7Z9ugMAcO0IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvdbtsN+s3h39MTlvre6Z3pCUtdvvzS9ISlvvjqr9MTlnp8/mR6wlI/f/EX0xOWOj+dXrDWfw7fTE/gGXz59OH0hLVu3p9esNS26xMAgGtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNpdvv/W1fSIpY7H6QXw/524Az7X/F+eb1v//rb+fnp+z7WNPz0AAK4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr/6p8+mt6w1Ml+24398MNH0xOWevvNN6YnLPW7D/4xPWGpXz34/vSEpd7948fTE5b67W9+Mj1hqd//4dPpCUv9+o0fTE9Y6tOvnk5PWOqXP7o9PWGpbdcZAADXjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0Ol+9dTY9Y6fTiYnrCWif76QVrXTyZXrDW2a3pBWvtNn7HvTpOL1jr4Pt7rl1u+/w77Lb9/X1n4/2y8dMBAIDrRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDan14epzes9ehv0wvWuv3S9IK1Hv9zesFaN+9ML1jrZON33K0/vy//Pr1grXuvTS9Y679fTy9Yav/Fx9MT1nrxlekFS238dAAA4LoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApP4H+sh5n1658IwAAAAASUVORK5CYII=" id="image501fcf60be" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m23a1a32520" d="M 0 0 
+       <path id="m16c00044bc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m23a1a32520" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m23a1a32520" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m23a1a32520" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m23a1a32520" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m23a1a32520" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m23a1a32520" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m23a1a32520" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m23a1a32520" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m23a1a32520" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m23a1a32520" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m23a1a32520" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m23a1a32520" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c00044bc" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="ma7106b914c" d="M 0 0 
+       <path id="ma274cb65a1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma7106b914c" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma274cb65a1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,268 +1138,8 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +17 -->
-    <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- +3 -->
-    <g transform="translate(151.301137 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +8 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -30 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +17 -->
-    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +5 -->
-    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -8 -->
-    <g transform="translate(354.238989 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -18 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +28 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
     <!-- -9 -->
-    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(112.574598 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1436,24 +1176,126 @@ z
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- +1 -->
-    <g transform="translate(513.797724 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -18 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -52 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -29 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -53 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -39 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -36 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1483,6 +1325,128 @@ Q 447 3434 972 4092
 Q 1497 4750 2381 4750 
 Q 2619 4750 2861 4703 
 Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -24 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -54 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -15 -->
+    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -33 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -73 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -47 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1592,6 +1556,29 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -1610,6 +1597,47 @@ z
    <g id="text_49">
     <!-- +238 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
@@ -1810,27 +1838,6 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2191,18 +2198,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2dccb08e1b" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image32d9f5842e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md81d9db3c6" d="M 0 0 
+       <path id="m4e4493e31b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2232,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2246,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2260,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2273,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2286,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2299,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#md81d9db3c6" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e4493e31b" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2915,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.001562 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,13 +3008,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3046,109 +3053,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc4cca4aa6e">
+  <clipPath id="p9a109575d5">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mdf2377db75" d="M 0 0 
+       <path id="me7ce4edff6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdf2377db75" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdf2377db75" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mdf2377db75" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mdf2377db75" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mdf2377db75" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mdf2377db75" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdf2377db75" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7ce4edff6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m4e8f14d759" d="M 0 0 
+       <path id="m65dd581b63" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4e8f14d759" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m65dd581b63" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4e8f14d759" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m65dd581b63" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4e8f14d759" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m65dd581b63" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m208af1114a" d="M 0 0 
+       <path id="m0bcfde6d37" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m208af1114a" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0bcfde6d37" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m7aace1751b" d="M -2.5 2.5 
+     <path id="m9243d9e984" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#m7aace1751b" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7aace1751b" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m9243d9e984" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9243d9e984" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="me4c8bb8640" d="M 0 -2.5 
+     <path id="m54a7e200ff" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#me4c8bb8640" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4c8bb8640" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m54a7e200ff" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54a7e200ff" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="md9e20a57c2" d="M -0 3.535534 
+     <path id="m1dc411d95f" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#md9e20a57c2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md9e20a57c2" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m1dc411d95f" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1dc411d95f" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="ma63a97c6e1" d="M -0 2.5 
+     <path id="m33d2ec03b9" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#ma63a97c6e1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m33d2ec03b9" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mdac4e8324c" d="M -0.833333 2.5 
+     <path id="m167b397267" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#mdac4e8324c" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac4e8324c" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m167b397267" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m167b397267" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m8878730467" d="M -1.25 2.5 
+     <path id="m9aa0d425c0" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#m8878730467" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8878730467" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m9aa0d425c0" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9aa0d425c0" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m0a02d5c586" d="M 0 -2.5 
+     <path id="mfc94265a71" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a02d5c586" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#mfc94265a71" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mfc94265a71" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m61084a9ed4" d="M 0 -2.5 
+     <path id="me99c880a60" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#m61084a9ed4" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61084a9ed4" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#me99c880a60" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me99c880a60" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="md71ea08d68" d="M 0 3.5 
+      <path id="m22462678e4" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md71ea08d68" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m22462678e4" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m7aace1751b" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9243d9e984" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#me4c8bb8640" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m54a7e200ff" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#md9e20a57c2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1dc411d95f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#ma63a97c6e1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m33d2ec03b9" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mdac4e8324c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m167b397267" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m8878730467" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9aa0d425c0" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m0a02d5c586" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mfc94265a71" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m61084a9ed4" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me99c880a60" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,17 +5370,17 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pb9bf2d5554)">
-     <use xlink:href="#md71ea08d68" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="210.483065" y="166.559544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="208.196568" y="168.292731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="197.379782" y="173.102943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="187.620351" y="187.562061" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="157.246106" y="244.18749" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="128.707405" y="299.638966" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md71ea08d68" x="99.149529" y="328.932112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p89c096f61a)">
+     <use xlink:href="#m22462678e4" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="199.905291" y="168.655914" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="190.316224" y="181.598644" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="165.455859" y="201.108991" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="159.141659" y="209.528698" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="157.246106" y="231.9046" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="128.707405" y="299.638966" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m22462678e4" x="99.149529" y="328.932112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
@@ -5433,7 +5433,7 @@ L 272.28703 149.213953
 L 271.234673 149.476182 
 L 270.182316 149.737147 
 L 269.129958 149.996859 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
     <path d="M 269.129958 149.996859 
@@ -5485,319 +5485,319 @@ L 248.807714 154.373471
 L 248.356109 154.466819 
 L 247.904503 154.560007 
 L 247.452898 154.653035 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
     <path d="M 247.452898 154.653035 
-L 246.682693 154.929781 
-L 245.912488 155.20512 
-L 245.142283 155.479065 
-L 244.372079 155.751629 
-L 243.601874 156.022829 
-L 242.831669 156.292675 
-L 242.061464 156.561183 
-L 241.291259 156.828366 
-L 240.521054 157.094235 
-L 239.750849 157.358805 
-L 238.980645 157.622088 
-L 238.21044 157.884096 
-L 237.440235 158.144842 
-L 236.67003 158.404338 
-L 235.899825 158.662595 
-L 235.12962 158.919626 
-L 234.359415 159.175441 
-L 233.589211 159.430053 
-L 232.819006 159.683473 
-L 232.048801 159.935712 
-L 231.278596 160.186781 
-L 230.508391 160.43669 
-L 229.738186 160.68545 
-L 228.967981 160.933072 
-L 228.197777 161.179567 
-L 227.427572 161.424943 
-L 226.657367 161.669212 
-L 225.887162 161.912384 
-L 225.116957 162.154468 
-L 224.346752 162.395474 
-L 223.576547 162.635411 
-L 222.806343 162.874289 
-L 222.036138 163.112117 
-L 221.265933 163.348905 
-L 220.495728 163.584662 
-L 219.725523 163.819395 
-L 218.955318 164.053115 
-L 218.185113 164.28583 
-L 217.414909 164.517549 
-L 216.644704 164.748279 
-L 215.874499 164.978031 
-L 215.104294 165.20681 
-L 214.334089 165.434627 
-L 213.563884 165.661489 
-L 212.793679 165.887404 
-L 212.023475 166.112379 
-L 211.25327 166.336424 
-L 210.483065 166.559544 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+L 246.462323 154.98496 
+L 245.471748 155.314862 
+L 244.481173 155.642765 
+L 243.490597 155.968693 
+L 242.500022 156.29267 
+L 241.509447 156.614719 
+L 240.518872 156.934862 
+L 239.528297 157.253123 
+L 238.537722 157.569524 
+L 237.547147 157.884085 
+L 236.556571 158.196829 
+L 235.565996 158.507775 
+L 234.575421 158.816946 
+L 233.584846 159.12436 
+L 232.594271 159.430037 
+L 231.603696 159.733998 
+L 230.613121 160.036261 
+L 229.622545 160.336845 
+L 228.63197 160.635769 
+L 227.641395 160.933051 
+L 226.65082 161.228709 
+L 225.660245 161.52276 
+L 224.66967 161.815223 
+L 223.679095 162.106113 
+L 222.688519 162.395448 
+L 221.697944 162.683244 
+L 220.707369 162.969519 
+L 219.716794 163.254286 
+L 218.726219 163.537563 
+L 217.735644 163.819365 
+L 216.745069 164.099708 
+L 215.754493 164.378605 
+L 214.763918 164.656073 
+L 213.773343 164.932125 
+L 212.782768 165.206776 
+L 211.792193 165.480041 
+L 210.801618 165.751932 
+L 209.811043 166.022465 
+L 208.820467 166.291652 
+L 207.829892 166.559506 
+L 206.839317 166.826041 
+L 205.848742 167.091271 
+L 204.858167 167.355206 
+L 203.867592 167.617861 
+L 202.877017 167.879247 
+L 201.886441 168.139376 
+L 200.895866 168.398261 
+L 199.905291 168.655914 
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 210.483065 166.559544 
-L 210.43543 166.596224 
-L 210.387794 166.632879 
-L 210.340159 166.66951 
-L 210.292523 166.706115 
-L 210.244888 166.742696 
-L 210.197253 166.779252 
-L 210.149617 166.815784 
-L 210.101982 166.852291 
-L 210.054347 166.888773 
-L 210.006711 166.925231 
-L 209.959076 166.961664 
-L 209.911441 166.998072 
-L 209.863805 167.034456 
-L 209.81617 167.070816 
-L 209.768535 167.107151 
-L 209.720899 167.143462 
-L 209.673264 167.179749 
-L 209.625628 167.216011 
-L 209.577993 167.252249 
-L 209.530358 167.288463 
-L 209.482722 167.324652 
-L 209.435087 167.360817 
-L 209.387452 167.396959 
-L 209.339816 167.433076 
-L 209.292181 167.469169 
-L 209.244546 167.505237 
-L 209.19691 167.541282 
-L 209.149275 167.577303 
-L 209.10164 167.6133 
-L 209.054004 167.649273 
-L 209.006369 167.685222 
-L 208.958734 167.721147 
-L 208.911098 167.757049 
-L 208.863463 167.792926 
-L 208.815827 167.82878 
-L 208.768192 167.86461 
-L 208.720557 167.900417 
-L 208.672921 167.936199 
-L 208.625286 167.971958 
-L 208.577651 168.007694 
-L 208.530015 168.043406 
-L 208.48238 168.079094 
-L 208.434745 168.114759 
-L 208.387109 168.1504 
-L 208.339474 168.186018 
-L 208.291839 168.221612 
-L 208.244203 168.257183 
-L 208.196568 168.292731 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 168.655914 
+L 199.705519 168.959675 
+L 199.505747 169.26174 
+L 199.305974 169.562129 
+L 199.106202 169.860859 
+L 198.90643 170.15795 
+L 198.706658 170.453418 
+L 198.506885 170.747282 
+L 198.307113 171.03956 
+L 198.107341 171.330267 
+L 197.907569 171.61942 
+L 197.707797 171.907038 
+L 197.508024 172.193134 
+L 197.308252 172.477726 
+L 197.10848 172.76083 
+L 196.908708 173.04246 
+L 196.708935 173.322632 
+L 196.509163 173.601361 
+L 196.309391 173.878662 
+L 196.109619 174.154549 
+L 195.909846 174.429037 
+L 195.710074 174.70214 
+L 195.510302 174.973872 
+L 195.31053 175.244246 
+L 195.110758 175.513276 
+L 194.910985 175.780975 
+L 194.711213 176.047356 
+L 194.511441 176.312433 
+L 194.311669 176.576218 
+L 194.111896 176.838723 
+L 193.912124 177.099961 
+L 193.712352 177.359944 
+L 193.51258 177.618684 
+L 193.312807 177.876193 
+L 193.113035 178.132482 
+L 192.913263 178.387564 
+L 192.713491 178.641448 
+L 192.513719 178.894148 
+L 192.313946 179.145673 
+L 192.114174 179.396034 
+L 191.914402 179.645242 
+L 191.71463 179.893308 
+L 191.514857 180.140242 
+L 191.315085 180.386055 
+L 191.115313 180.630756 
+L 190.915541 180.874356 
+L 190.715768 181.116864 
+L 190.515996 181.35829 
+L 190.316224 181.598644 
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 208.196568 168.292731 
-L 207.971218 168.397431 
-L 207.745868 168.501929 
-L 207.520519 168.606225 
-L 207.295169 168.710321 
-L 207.069819 168.814217 
-L 206.84447 168.917914 
-L 206.61912 169.021412 
-L 206.39377 169.124713 
-L 206.168421 169.227817 
-L 205.943071 169.330726 
-L 205.717721 169.433438 
-L 205.492371 169.535957 
-L 205.267022 169.638281 
-L 205.041672 169.740412 
-L 204.816322 169.842351 
-L 204.590973 169.944099 
-L 204.365623 170.045655 
-L 204.140273 170.147021 
-L 203.914924 170.248198 
-L 203.689574 170.349185 
-L 203.464224 170.449985 
-L 203.238874 170.550597 
-L 203.013525 170.651023 
-L 202.788175 170.751263 
-L 202.562825 170.851317 
-L 202.337476 170.951187 
-L 202.112126 171.050872 
-L 201.886776 171.150375 
-L 201.661427 171.249695 
-L 201.436077 171.348832 
-L 201.210727 171.447789 
-L 200.985377 171.546565 
-L 200.760028 171.645161 
-L 200.534678 171.743578 
-L 200.309328 171.841816 
-L 200.083979 171.939876 
-L 199.858629 172.037758 
-L 199.633279 172.135464 
-L 199.40793 172.232994 
-L 199.18258 172.330349 
-L 198.95723 172.427528 
-L 198.73188 172.524534 
-L 198.506531 172.621366 
-L 198.281181 172.718025 
-L 198.055831 172.814511 
-L 197.830482 172.910826 
-L 197.605132 173.00697 
-L 197.379782 173.102943 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 181.598644 
+L 189.7983 182.085837 
+L 189.280375 182.568683 
+L 188.762451 183.047259 
+L 188.244527 183.52164 
+L 187.726603 183.991899 
+L 187.208678 184.458107 
+L 186.690754 184.920333 
+L 186.17283 185.378644 
+L 185.654906 185.833107 
+L 185.136981 186.283785 
+L 184.619057 186.730741 
+L 184.101133 187.174036 
+L 183.583208 187.613729 
+L 183.065284 188.049879 
+L 182.54736 188.482542 
+L 182.029436 188.911773 
+L 181.511511 189.337627 
+L 180.993587 189.760155 
+L 180.475663 190.179411 
+L 179.957739 190.595443 
+L 179.439814 191.008302 
+L 178.92189 191.418035 
+L 178.403966 191.824689 
+L 177.886041 192.22831 
+L 177.368117 192.628943 
+L 176.850193 193.026632 
+L 176.332269 193.42142 
+L 175.814344 193.813349 
+L 175.29642 194.20246 
+L 174.778496 194.588793 
+L 174.260572 194.972388 
+L 173.742647 195.353283 
+L 173.224723 195.731516 
+L 172.706799 196.107124 
+L 172.188874 196.480142 
+L 171.67095 196.850608 
+L 171.153026 197.218554 
+L 170.635102 197.584016 
+L 170.117177 197.947027 
+L 169.599253 198.307618 
+L 169.081329 198.665823 
+L 168.563404 199.021673 
+L 168.04548 199.375198 
+L 167.527556 199.726429 
+L 167.009632 200.075395 
+L 166.491707 200.422125 
+L 165.973783 200.766648 
+L 165.455859 201.108991 
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 197.379782 173.102943 
-L 197.176461 173.447155 
-L 196.973139 173.789192 
-L 196.769818 174.12908 
-L 196.566496 174.466847 
-L 196.363175 174.802519 
-L 196.159853 175.136122 
-L 195.956532 175.467681 
-L 195.75321 175.797221 
-L 195.549889 176.124766 
-L 195.346567 176.450341 
-L 195.143246 176.773969 
-L 194.939924 177.095674 
-L 194.736603 177.415477 
-L 194.533281 177.733401 
-L 194.32996 178.049469 
-L 194.126638 178.363702 
-L 193.923317 178.67612 
-L 193.719995 178.986745 
-L 193.516674 179.295598 
-L 193.313353 179.602698 
-L 193.110031 179.908065 
-L 192.90671 180.211719 
-L 192.703388 180.513678 
-L 192.500067 180.813962 
-L 192.296745 181.112589 
-L 192.093424 181.409577 
-L 191.890102 181.704945 
-L 191.686781 181.998709 
-L 191.483459 182.290887 
-L 191.280138 182.581496 
-L 191.076816 182.870553 
-L 190.873495 183.158074 
-L 190.670173 183.444076 
-L 190.466852 183.728574 
-L 190.26353 184.011584 
-L 190.060209 184.293122 
-L 189.856887 184.573203 
-L 189.653566 184.851842 
-L 189.450244 185.129054 
-L 189.246923 185.404853 
-L 189.043601 185.679254 
-L 188.84028 185.95227 
-L 188.636958 186.223916 
-L 188.433637 186.494205 
-L 188.230315 186.763151 
-L 188.026994 187.030767 
-L 187.823672 187.297066 
-L 187.620351 187.562061 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 201.108991 
+L 165.324313 201.298451 
+L 165.192767 201.487249 
+L 165.061221 201.675392 
+L 164.929675 201.862882 
+L 164.79813 202.049726 
+L 164.666584 202.235926 
+L 164.535038 202.421488 
+L 164.403492 202.606416 
+L 164.271946 202.790714 
+L 164.1404 202.974387 
+L 164.008855 203.157438 
+L 163.877309 203.339872 
+L 163.745763 203.521694 
+L 163.614217 203.702906 
+L 163.482671 203.883514 
+L 163.351125 204.063521 
+L 163.21958 204.242931 
+L 163.088034 204.421749 
+L 162.956488 204.599977 
+L 162.824942 204.777621 
+L 162.693396 204.954683 
+L 162.56185 205.131168 
+L 162.430305 205.30708 
+L 162.298759 205.482421 
+L 162.167213 205.657196 
+L 162.035667 205.831408 
+L 161.904121 206.005062 
+L 161.772575 206.17816 
+L 161.64103 206.350706 
+L 161.509484 206.522704 
+L 161.377938 206.694157 
+L 161.246392 206.865068 
+L 161.114846 207.035441 
+L 160.9833 207.20528 
+L 160.851754 207.374587 
+L 160.720209 207.543367 
+L 160.588663 207.711621 
+L 160.457117 207.879354 
+L 160.325571 208.046569 
+L 160.194025 208.213269 
+L 160.062479 208.379457 
+L 159.930934 208.545136 
+L 159.799388 208.710309 
+L 159.667842 208.87498 
+L 159.536296 209.039152 
+L 159.40475 209.202826 
+L 159.273204 209.366008 
+L 159.141659 209.528698 
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 187.620351 187.562061 
-L 186.987554 189.605606 
-L 186.354757 191.574785 
-L 185.721961 193.474821 
-L 185.089164 195.310405 
-L 184.456367 197.085768 
-L 183.82357 198.804734 
-L 183.190774 200.470778 
-L 182.557977 202.087061 
-L 181.92518 203.656469 
-L 181.292383 205.181644 
-L 180.659587 206.665013 
-L 180.02679 208.108805 
-L 179.393993 209.515078 
-L 178.761196 210.885732 
-L 178.1284 212.222528 
-L 177.495603 213.527098 
-L 176.862806 214.800959 
-L 176.230009 216.045523 
-L 175.597212 217.262109 
-L 174.964416 218.451946 
-L 174.331619 219.616185 
-L 173.698822 220.755905 
-L 173.066025 221.872117 
-L 172.433229 222.965771 
-L 171.800432 224.037761 
-L 171.167635 225.088928 
-L 170.534838 226.120067 
-L 169.902042 227.131926 
-L 169.269245 228.125213 
-L 168.636448 229.100597 
-L 168.003651 230.058712 
-L 167.370855 231.00016 
-L 166.738058 231.92551 
-L 166.105261 232.835303 
-L 165.472464 233.730055 
-L 164.839668 234.610253 
-L 164.206871 235.476364 
-L 163.574074 236.328833 
-L 162.941277 237.168081 
-L 162.30848 237.994513 
-L 161.675684 238.808514 
-L 161.042887 239.610453 
-L 160.41009 240.400682 
-L 159.777293 241.179539 
-L 159.144497 241.947345 
-L 158.5117 242.70441 
-L 157.878903 243.45103 
-L 157.246106 244.18749 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 209.528698 
+L 159.102168 210.102952 
+L 159.062677 210.671177 
+L 159.023187 211.233497 
+L 158.983696 211.790035 
+L 158.944205 212.340907 
+L 158.904715 212.886229 
+L 158.865224 213.42611 
+L 158.825733 213.960659 
+L 158.786243 214.48998 
+L 158.746752 215.014173 
+L 158.707261 215.533338 
+L 158.667771 216.04757 
+L 158.62828 216.556961 
+L 158.588789 217.061603 
+L 158.549299 217.561582 
+L 158.509808 218.056984 
+L 158.470317 218.547893 
+L 158.430827 219.034388 
+L 158.391336 219.516549 
+L 158.351845 219.994453 
+L 158.312355 220.468173 
+L 158.272864 220.937782 
+L 158.233373 221.403351 
+L 158.193882 221.86495 
+L 158.154392 222.322644 
+L 158.114901 222.7765 
+L 158.07541 223.226582 
+L 158.03592 223.672951 
+L 157.996429 224.115668 
+L 157.956938 224.554794 
+L 157.917448 224.990385 
+L 157.877957 225.422497 
+L 157.838466 225.851187 
+L 157.798976 226.276508 
+L 157.759485 226.698512 
+L 157.719994 227.117251 
+L 157.680504 227.532775 
+L 157.641013 227.945133 
+L 157.601522 228.354372 
+L 157.562032 228.760541 
+L 157.522541 229.163683 
+L 157.48305 229.563845 
+L 157.44356 229.961069 
+L 157.404069 230.355399 
+L 157.364578 230.746876 
+L 157.325088 231.135543 
+L 157.285597 231.521437 
+L 157.246106 231.9046 
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 244.18749 
-L 156.65155 246.164662 
-L 156.056994 248.072139 
-L 155.462438 249.914667 
-L 154.867881 251.696524 
-L 154.273325 253.421579 
-L 153.678769 255.093341 
-L 153.084212 256.715004 
-L 152.489656 258.289485 
-L 151.8951 259.819452 
-L 151.300544 261.307351 
-L 150.705987 262.755436 
-L 150.111431 264.16578 
-L 149.516875 265.540303 
-L 148.922318 266.880777 
-L 148.327762 268.188851 
-L 147.733206 269.466052 
-L 147.13865 270.713804 
-L 146.544093 271.933436 
-L 145.949537 273.126186 
-L 145.354981 274.293215 
-L 144.760424 275.435607 
-L 144.165868 276.554383 
-L 143.571312 277.650498 
-L 142.976756 278.724852 
-L 142.382199 279.778293 
-L 141.787643 280.81162 
-L 141.193087 281.825585 
-L 140.598531 282.820901 
-L 140.003974 283.798242 
-L 139.409418 284.758246 
-L 138.814862 285.701517 
-L 138.220305 286.628628 
-L 137.625749 287.540124 
-L 137.031193 288.436521 
-L 136.436637 289.318313 
-L 135.84208 290.185967 
-L 135.247524 291.03993 
-L 134.652968 291.880627 
-L 134.058411 292.708463 
-L 133.463855 293.523827 
-L 132.869299 294.327089 
-L 132.274743 295.118602 
-L 131.680186 295.898705 
-L 131.08563 296.667723 
-L 130.491074 297.425967 
-L 129.896517 298.173733 
-L 129.301961 298.911308 
+    <path d="M 157.246106 231.9046 
+L 156.65155 234.647937 
+L 156.056994 237.258894 
+L 155.462438 239.749662 
+L 154.867881 242.13082 
+L 154.273325 244.411611 
+L 153.678769 246.600153 
+L 153.084212 248.70362 
+L 152.489656 250.72838 
+L 151.8951 252.680111 
+L 151.300544 254.563898 
+L 150.705987 256.384313 
+L 150.111431 258.145481 
+L 149.516875 259.851137 
+L 148.922318 261.504675 
+L 148.327762 263.109184 
+L 147.733206 264.66749 
+L 147.13865 266.182178 
+L 146.544093 267.655625 
+L 145.949537 269.090016 
+L 145.354981 270.487368 
+L 144.760424 271.849547 
+L 144.165868 273.178279 
+L 143.571312 274.475169 
+L 142.976756 275.741706 
+L 142.382199 276.979278 
+L 141.787643 278.189182 
+L 141.193087 279.372626 
+L 140.598531 280.530745 
+L 140.003974 281.664598 
+L 139.409418 282.775183 
+L 138.814862 283.863434 
+L 138.220305 284.930233 
+L 137.625749 285.976408 
+L 137.031193 287.002743 
+L 136.436637 288.009975 
+L 135.84208 288.998804 
+L 135.247524 289.969888 
+L 134.652968 290.923854 
+L 134.058411 291.861296 
+L 133.463855 292.782775 
+L 132.869299 293.688826 
+L 132.274743 294.579958 
+L 131.680186 295.456653 
+L 131.08563 296.319373 
+L 130.491074 297.168555 
+L 129.896517 298.004618 
+L 129.301961 298.827961 
 L 128.707405 299.638966 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
     <path d="M 128.707405 299.638966 
@@ -5849,7 +5849,7 @@ L 100.996896 327.499484
 L 100.381107 327.981253 
 L 99.765318 328.458771 
 L 99.149529 328.932112 
-" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.001562 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,31 +6201,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6326,13 +6301,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6371,109 +6346,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb9bf2d5554">
+  <clipPath id="p89c096f61a">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me3d7810ba7" d="M 0 0 
+       <path id="mee70dc716c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me3d7810ba7" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me3d7810ba7" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me3d7810ba7" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me3d7810ba7" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me3d7810ba7" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me3d7810ba7" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me3d7810ba7" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee70dc716c" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m81ba0308e4" d="M 0 0 
+       <path id="mc34e0aa2c5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m81ba0308e4" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m81ba0308e4" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m81ba0308e4" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="me3a9f50beb" d="M 0 0 
+       <path id="mc4a980db70" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#me3a9f50beb" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc4a980db70" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p3bba1e6869)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m8ddb55214d" d="M -2.5 2.5 
+     <path id="mbe8d11b38a" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m8ddb55214d" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8ddb55214d" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#mbe8d11b38a" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe8d11b38a" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mcbf383a595" d="M 0 -2.5 
+     <path id="m2d004b8ac0" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#mcbf383a595" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbf383a595" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#m2d004b8ac0" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2d004b8ac0" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m4d8e3b0c73" d="M -0 3.535534 
+     <path id="mbc94892416" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m4d8e3b0c73" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8e3b0c73" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#mbc94892416" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc94892416" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m8488fd6fe9" d="M -0.833333 2.5 
+     <path id="mb3b8af1d88" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m8488fd6fe9" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8488fd6fe9" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#mb3b8af1d88" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb3b8af1d88" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m7e6bcd8302" d="M -1.25 2.5 
+     <path id="m0fefece0e8" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m7e6bcd8302" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e6bcd8302" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#m0fefece0e8" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fefece0e8" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m03f1766d82" d="M 0 -2.5 
+     <path id="mf3d55a56cc" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m03f1766d82" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m03f1766d82" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#mf3d55a56cc" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf3d55a56cc" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m868fd11540" d="M 0 -2.5 
+     <path id="m88c3ebe006" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m868fd11540" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m868fd11540" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#m88c3ebe006" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m88c3ebe006" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m06a46da345" d="M 0 3.5 
+      <path id="m780377906b" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m06a46da345" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m780377906b" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m8ddb55214d" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbe8d11b38a" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mcbf383a595" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2d004b8ac0" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m4d8e3b0c73" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbc94892416" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m8488fd6fe9" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb3b8af1d88" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m7e6bcd8302" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0fefece0e8" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m03f1766d82" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf3d55a56cc" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m868fd11540" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m88c3ebe006" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pfc36f9d8d9)">
-     <use xlink:href="#m06a46da345" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m06a46da345" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3bba1e6869)">
+     <use xlink:href="#m780377906b" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m780377906b" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pfc36f9d8d9">
+  <clipPath id="p3bba1e6869">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m166dc9d3ec" d="M 0 0 
+       <path id="m4cc47e3ffb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m166dc9d3ec" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc47e3ffb" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m166dc9d3ec" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cc47e3ffb" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="me2628a614b" d="M 0 0 
+       <path id="m2e33ed48b0" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#me2628a614b" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me2628a614b" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me2628a614b" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me2628a614b" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me2628a614b" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me2628a614b" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me2628a614b" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me2628a614b" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me2628a614b" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me2628a614b" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me2628a614b" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me2628a614b" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#me2628a614b" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#me2628a614b" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#me2628a614b" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#me2628a614b" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me2628a614b" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me2628a614b" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me2628a614b" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#me2628a614b" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2e33ed48b0" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m9de5e9f3e7" d="M 0 0 
+       <path id="me807060126" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me807060126" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#pbce84ea252)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pfc348b4c56)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m71160f0dc3" d="M 0 3 
+     <path id="m9cc4472b6c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m71160f0dc3" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m9cc4472b6c" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m565731d7f1" d="M 0 3 
+     <path id="m0ee5c74d9d" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m565731d7f1" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m0ee5c74d9d" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m8f7d887760" d="M 0 3 
+     <path id="m3f078d146a" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m8f7d887760" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m3f078d146a" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m34262db8b6" d="M 0 5 
+     <path id="mb8f570a8ad" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m34262db8b6" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#mb8f570a8ad" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m9d403304f0" d="M 0 3 
+     <path id="mf4d2bd27d8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m9d403304f0" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#mf4d2bd27d8" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m3ad6408a59" d="M 0 3 
+     <path id="m8f6f0807e0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m3ad6408a59" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m8f6f0807e0" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="mf0ee440873" d="M 0 3 
+     <path id="m48aa16f746" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#mf0ee440873" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m48aa16f746" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m1f0010e8bc" d="M 0 3 
+     <path id="m2c60072d5a" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pbce84ea252)">
-     <use xlink:href="#m1f0010e8bc" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pfc348b4c56)">
+     <use xlink:href="#m2c60072d5a" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pbce84ea252">
+  <clipPath id="pfc348b4c56">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc3a7eadb8d)">
+   <g clip-path="url(#p8961c73747)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAklEQVR4nO3Yv6ueZx3H8fPknDQxJ81JgtZiFdEUl1oFF4mgU0EQHdwdRP8CFycncXJ1UEcXt1KcJEM7CvG3dbJYf+APQmxMGkuanpycx7/gPUi5+MrD6/UXfOC+ue73fW1Ob/1wu7eDjn98Y3rCEmdfeH56wjKbpz4wPWGJ7W9/Nz1hic0nnpuesMT2wf3pCcvc/uZL0xOWeOo7X5yesMTm6vunJ6xx/GB6wTKnP9/N8/7M9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLmP8cvbadHrHD479vTE5Z449KF6QnLvH3y1vSEJT705vH0hCXefN/T0xOWON2eTk9Y5srB1ekJa9z5y/SCJe5f2c3n9eSf/zA9YZntxz49PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSDwzu3pjesceHy9IIlttvj6QnLfPCVX05PWOOFL0wvWOLojX9OT1jj9GR6wTqHO3p+nLs4vWCJS//aze/z3Q9fm56wzJW/vTo9YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaPHp8Yzs9YoX923+anrDErSefmJ6wzFuP7k1PWOLaX+9NT1ji5OOfmZ6wxIOT+9MTljnavzw9YYnt67+YnrDEw48+Pz1hifOv3pyesMw7n7w+PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vzk9W9sp0escPX84fSEJV67d2d6wjJf/96vpycs8Ztvf2l6whJH546mJyzxrZ/9anrCMp975vz0hCW+fO369IQlXvn7zekJS1w8u5vv4d7e3t6Lf7w7PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2jx6fGM7PWKFu+/cnp6wxOHBpekJy7x27/fTE5Z49vJz0xOW2G5PpycscfFkd/+h/3G6m+fiM4fPTk9Y4uHjB9MTltjVs2Nvb29v/8zB9IQldvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrY3xxMb1jivftXpyessf/E9IJljs4dTU9Y4vDg0vSEJR5vT6YnLHF6dnf/oZ/eXpiewP9gV7/Px9uH0xOWuf/O7ekJS+zuqQgAwLsmFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASJvT05e30yNWePT9H0xPWOLs174yPWGdMwfTC5bY3nx5esISm+ufn56wxtv3phcs8/C7P5qesMS5r352esISpx/51PSEJc789MXpCetceM/0giXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAADpvx9umTWu9YozAAAAAElFTkSuQmCC" id="image0e7ef49e9b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="imagefdeb789502" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5ab8d8ecfc" d="M 0 0 
+       <path id="m52736d8c06" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5ab8d8ecfc" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52736d8c06" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md541e250a5" d="M 0 0 
+       <path id="md63a601b9b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md541e250a5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md63a601b9b" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1183,27 +1183,8 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- +7 -->
-    <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
     <!-- +1 -->
-    <g transform="translate(188.414476 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1224,39 +1205,51 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- +1 -->
-    <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +4 -->
-    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -2 -->
+    <g transform="translate(189.965336 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -1 -->
+    <g transform="translate(228.97711 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +2 -->
+    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1267,58 +1260,17 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- +8 -->
-    <g transform="translate(383.473351 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(385.02421 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1370,44 +1322,38 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- +5 -->
+    <!-- +4 -->
     <g transform="translate(500.508675 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- +5 -->
+    <!-- +0 -->
     <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1434,32 +1380,6 @@ z
    <g id="text_36">
     <!-- -2 -->
     <g transform="translate(228.97711 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
@@ -1607,6 +1527,33 @@ z
    <g id="text_57">
     <!-- -5 -->
     <g transform="translate(111.941786 180.060583) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -2015,6 +1962,18 @@ z
    <g id="text_106">
     <!-- +7 -->
     <g transform="translate(149.402701 327.403714) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2101,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee241b7f2e6" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image657f2a2ec9" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma27107b62b" d="M 0 0 
+       <path id="mda9bbca44c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma27107b62b" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda9bbca44c" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma27107b62b" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda9bbca44c" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma27107b62b" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda9bbca44c" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma27107b62b" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda9bbca44c" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma27107b62b" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda9bbca44c" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.001562 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2845,6 +2804,45 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2873,13 +2871,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc3a7eadb8d">
+  <clipPath id="p8961c73747">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.396875pt" height="386.202469pt" viewBox="0 0 570.396875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.396875 386.202469 
-L 570.396875 0 
+L 569.186094 386.202469 
+L 569.186094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.323438 104.1264 
-L 291.948438 104.1264 
-L 291.948438 74.7432 
-L 187.323438 74.7432 
+    <path d="M 186.718047 104.1264 
+L 291.343047 104.1264 
+L 291.343047 74.7432 
+L 186.718047 74.7432 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.948438 104.1264 
-L 396.573438 104.1264 
-L 396.573438 74.7432 
-L 291.948438 74.7432 
+    <path d="M 291.343047 104.1264 
+L 395.968047 104.1264 
+L 395.968047 74.7432 
+L 291.343047 74.7432 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.573438 104.1264 
-L 501.198438 104.1264 
-L 501.198438 74.7432 
-L 396.573438 74.7432 
+    <path d="M 395.968047 104.1264 
+L 500.593047 104.1264 
+L 500.593047 74.7432 
+L 395.968047 74.7432 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.323438 133.5096 
-L 291.948438 133.5096 
-L 291.948438 104.1264 
-L 187.323438 104.1264 
+    <path d="M 186.718047 133.5096 
+L 291.343047 133.5096 
+L 291.343047 104.1264 
+L 186.718047 104.1264 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.948438 133.5096 
-L 396.573438 133.5096 
-L 396.573438 104.1264 
-L 291.948438 104.1264 
+    <path d="M 291.343047 133.5096 
+L 395.968047 133.5096 
+L 395.968047 104.1264 
+L 291.343047 104.1264 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.573438 133.5096 
-L 501.198438 133.5096 
-L 501.198438 104.1264 
-L 396.573438 104.1264 
+    <path d="M 395.968047 133.5096 
+L 500.593047 133.5096 
+L 500.593047 104.1264 
+L 395.968047 104.1264 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.323438 162.8928 
-L 291.948438 162.8928 
-L 291.948438 133.5096 
-L 187.323438 133.5096 
+    <path d="M 186.718047 162.8928 
+L 291.343047 162.8928 
+L 291.343047 133.5096 
+L 186.718047 133.5096 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.948438 162.8928 
-L 396.573438 162.8928 
-L 396.573438 133.5096 
-L 291.948438 133.5096 
+    <path d="M 291.343047 162.8928 
+L 395.968047 162.8928 
+L 395.968047 133.5096 
+L 291.343047 133.5096 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.573438 162.8928 
-L 501.198438 162.8928 
-L 501.198438 133.5096 
-L 396.573438 133.5096 
+    <path d="M 395.968047 162.8928 
+L 500.593047 162.8928 
+L 500.593047 133.5096 
+L 395.968047 133.5096 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.323438 192.276 
-L 291.948438 192.276 
-L 291.948438 162.8928 
-L 187.323438 162.8928 
+    <path d="M 186.718047 192.276 
+L 291.343047 192.276 
+L 291.343047 162.8928 
+L 186.718047 162.8928 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.948438 192.276 
-L 396.573438 192.276 
-L 396.573438 162.8928 
-L 291.948438 162.8928 
+    <path d="M 291.343047 192.276 
+L 395.968047 192.276 
+L 395.968047 162.8928 
+L 291.343047 162.8928 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.573438 192.276 
-L 501.198438 192.276 
-L 501.198438 162.8928 
-L 396.573438 162.8928 
+    <path d="M 395.968047 192.276 
+L 500.593047 192.276 
+L 500.593047 162.8928 
+L 395.968047 162.8928 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.323438 221.6592 
-L 291.948438 221.6592 
-L 291.948438 192.276 
-L 187.323438 192.276 
+    <path d="M 186.718047 221.6592 
+L 291.343047 221.6592 
+L 291.343047 192.276 
+L 186.718047 192.276 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.948438 221.6592 
-L 396.573438 221.6592 
-L 396.573438 192.276 
-L 291.948438 192.276 
+    <path d="M 291.343047 221.6592 
+L 395.968047 221.6592 
+L 395.968047 192.276 
+L 291.343047 192.276 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.573438 221.6592 
-L 501.198438 221.6592 
-L 501.198438 192.276 
-L 396.573438 192.276 
+    <path d="M 395.968047 221.6592 
+L 500.593047 221.6592 
+L 500.593047 192.276 
+L 395.968047 192.276 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.323438 251.0424 
-L 291.948438 251.0424 
-L 291.948438 221.6592 
-L 187.323438 221.6592 
+    <path d="M 186.718047 251.0424 
+L 291.343047 251.0424 
+L 291.343047 221.6592 
+L 186.718047 221.6592 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.948438 251.0424 
-L 396.573438 251.0424 
-L 396.573438 221.6592 
-L 291.948438 221.6592 
+    <path d="M 291.343047 251.0424 
+L 395.968047 251.0424 
+L 395.968047 221.6592 
+L 291.343047 221.6592 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.573438 251.0424 
-L 501.198438 251.0424 
-L 501.198438 221.6592 
-L 396.573438 221.6592 
+    <path d="M 395.968047 251.0424 
+L 500.593047 251.0424 
+L 500.593047 221.6592 
+L 395.968047 221.6592 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.323438 280.4256 
-L 291.948438 280.4256 
-L 291.948438 251.0424 
-L 187.323438 251.0424 
+    <path d="M 186.718047 280.4256 
+L 291.343047 280.4256 
+L 291.343047 251.0424 
+L 186.718047 251.0424 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.948438 280.4256 
-L 396.573438 280.4256 
-L 396.573438 251.0424 
-L 291.948438 251.0424 
+    <path d="M 291.343047 280.4256 
+L 395.968047 280.4256 
+L 395.968047 251.0424 
+L 291.343047 251.0424 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fba05b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.573438 280.4256 
-L 501.198438 280.4256 
-L 501.198438 251.0424 
-L 396.573438 251.0424 
+    <path d="M 395.968047 280.4256 
+L 500.593047 280.4256 
+L 500.593047 251.0424 
+L 395.968047 251.0424 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.323438 309.8088 
-L 291.948438 309.8088 
-L 291.948438 280.4256 
-L 187.323438 280.4256 
+    <path d="M 186.718047 309.8088 
+L 291.343047 309.8088 
+L 291.343047 280.4256 
+L 186.718047 280.4256 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.948438 309.8088 
-L 396.573438 309.8088 
-L 396.573438 280.4256 
-L 291.948438 280.4256 
+    <path d="M 291.343047 309.8088 
+L 395.968047 309.8088 
+L 395.968047 280.4256 
+L 291.343047 280.4256 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.573438 309.8088 
-L 501.198438 309.8088 
-L 501.198438 280.4256 
-L 396.573438 280.4256 
+    <path d="M 395.968047 309.8088 
+L 500.593047 309.8088 
+L 500.593047 280.4256 
+L 395.968047 280.4256 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.323438 339.192 
-L 291.948438 339.192 
-L 291.948438 309.8088 
-L 187.323438 309.8088 
+    <path d="M 186.718047 339.192 
+L 291.343047 339.192 
+L 291.343047 309.8088 
+L 186.718047 309.8088 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.948438 339.192 
-L 396.573438 339.192 
-L 396.573438 309.8088 
-L 291.948438 309.8088 
+    <path d="M 291.343047 339.192 
+L 395.968047 339.192 
+L 395.968047 309.8088 
+L 291.343047 309.8088 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.573438 339.192 
-L 501.198438 339.192 
-L 501.198438 309.8088 
-L 396.573438 309.8088 
+    <path d="M 395.968047 339.192 
+L 500.593047 339.192 
+L 500.593047 309.8088 
+L 395.968047 309.8088 
 z
-" clip-path="url(#pf55c1d862f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc63a3693a8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.310703 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.594922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.167031 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.51875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.248438 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.184688 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.625938 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.250938 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.886563 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.184688 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.170938 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.250938 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.579688 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.974297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.184688 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.170938 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.250938 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.612188 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.006797 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.184688 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.170938 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.250938 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.149687 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.544297 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.184688 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,22 +1552,106 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.170938 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.250938 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
+    <!-- miniz_oxide -->
+    <g transform="translate(110.850547 238.44705) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 0.322 -->
+    <g transform="translate(227.579297 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 36 -->
+    <g transform="translate(338.565547 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 532 -->
+    <g transform="translate(440.645547 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.957813 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.352422 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1674,9 +1758,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- 0.332 -->
-    <g transform="translate(226.984063 238.5583) scale(0.08 -0.08)">
+   <g id="text_30">
+    <!-- 0.325 -->
+    <g transform="translate(226.378672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1760,37 +1844,6 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 37 -->
-    <g transform="translate(338.694687 238.5583) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 258 -->
-    <g transform="translate(440.536563 238.5583) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
 L 3669 3781 
@@ -1816,138 +1869,78 @@ Q 1016 2181 678 2041
 L 678 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 22 -->
+    <g transform="translate(338.089297 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 261 -->
+    <g transform="translate(439.931172 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- miniz_oxide -->
-    <g transform="translate(111.455938 267.83025) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.322 -->
-    <g transform="translate(228.184688 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 36 -->
-    <g transform="translate(339.170938 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 532 -->
-    <g transform="translate(441.250938 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.072813 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.467422 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2012,7 +2005,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.184688 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2022,21 +2015,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.170938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.795938 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.190547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.294063 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2047,7 +2040,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.184688 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2057,13 +2050,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.715937 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.885938 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2079,7 +2072,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.800156 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.194766 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2152,36 +2145,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2223,7 +2186,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2365,13 +2328,13 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2410,110 +2373,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf55c1d862f">
-   <rect x="82.698438" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc63a3693a8">
+   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,17491 +1,17491 @@
 {
-  "meta": {
-    "date": "2026-07-03T00:31:25Z",
-    "machine": "Linux chungus x86_64",
-    "git_commit": "0d41c6ad",
-    "toolchain": "leanprover/lean4:v4.30.0-rc2",
-    "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+ "meta": {
+  "date": "2026-07-03T03:26:41Z",
+  "machine": "Linux chungus x86_64",
+  "git_commit": "f46604b4",
+  "toolchain": "leanprover/lean4:v4.30.0-rc2",
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+ },
+ "results": [
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 60455,
+   "ratio": 0.3975,
+   "compress_mbps": 54.97,
+   "decompress_mbps": 187.38
   },
-  "results": [
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 60455,
-      "ratio": 0.3975,
-      "compress_mbps": 54.97,
-      "decompress_mbps": 187.38
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 56316,
-      "ratio": 0.3703,
-      "compress_mbps": 42.23,
-      "decompress_mbps": 213.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 55646,
-      "ratio": 0.3659,
-      "compress_mbps": 38.03,
-      "decompress_mbps": 233.09
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 54782,
-      "ratio": 0.3602,
-      "compress_mbps": 29.85,
-      "decompress_mbps": 235.95
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 54700,
-      "ratio": 0.3597,
-      "compress_mbps": 28.77,
-      "decompress_mbps": 238.04
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54535,
-      "ratio": 0.3586,
-      "compress_mbps": 26.45,
-      "decompress_mbps": 244.69
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 54385,
-      "ratio": 0.3576,
-      "compress_mbps": 21.24,
-      "decompress_mbps": 245.06
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 54127,
-      "ratio": 0.3559,
-      "compress_mbps": 9.54,
-      "decompress_mbps": 245.55
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 53082,
-      "ratio": 0.349,
-      "compress_mbps": 3.23,
-      "decompress_mbps": 242.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 53135,
-      "ratio": 0.4245,
-      "compress_mbps": 49.96,
-      "decompress_mbps": 180.32
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 50187,
-      "ratio": 0.4009,
-      "compress_mbps": 38.94,
-      "decompress_mbps": 196.51
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 49810,
-      "ratio": 0.3979,
-      "compress_mbps": 35.79,
-      "decompress_mbps": 214.24
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 49036,
-      "ratio": 0.3917,
-      "compress_mbps": 27.82,
-      "decompress_mbps": 218.14
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 48994,
-      "ratio": 0.3914,
-      "compress_mbps": 26.92,
-      "decompress_mbps": 219.56
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48934,
-      "ratio": 0.3909,
-      "compress_mbps": 25.58,
-      "decompress_mbps": 223.98
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48874,
-      "ratio": 0.3904,
-      "compress_mbps": 22.82,
-      "decompress_mbps": 224.04
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 48634,
-      "ratio": 0.3885,
-      "compress_mbps": 9.34,
-      "decompress_mbps": 223.94
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 47620,
-      "ratio": 0.3804,
-      "compress_mbps": 3.41,
-      "decompress_mbps": 224.53
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 8476,
-      "ratio": 0.3445,
-      "compress_mbps": 39.89,
-      "decompress_mbps": 217.23
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8271,
-      "ratio": 0.3362,
-      "compress_mbps": 35.22,
-      "decompress_mbps": 224.64
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8158,
-      "ratio": 0.3316,
-      "compress_mbps": 34.4,
-      "decompress_mbps": 229.75
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 7991,
-      "ratio": 0.3248,
-      "compress_mbps": 31.43,
-      "decompress_mbps": 238.21
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 7984,
-      "ratio": 0.3245,
-      "compress_mbps": 30.95,
-      "decompress_mbps": 244.99
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7949,
-      "ratio": 0.3231,
-      "compress_mbps": 29.76,
-      "decompress_mbps": 246.58
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7929,
-      "ratio": 0.3223,
-      "compress_mbps": 25.95,
-      "decompress_mbps": 248.55
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7929,
-      "ratio": 0.3223,
-      "compress_mbps": 9.94,
-      "decompress_mbps": 249.94
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7806,
-      "ratio": 0.3173,
-      "compress_mbps": 4.14,
-      "decompress_mbps": 249.31
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3509,
-      "ratio": 0.3147,
-      "compress_mbps": 26.08,
-      "decompress_mbps": 151.57
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3269,
-      "ratio": 0.2932,
-      "compress_mbps": 24.14,
-      "decompress_mbps": 153.81
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3208,
-      "ratio": 0.2877,
-      "compress_mbps": 23.41,
-      "decompress_mbps": 157.24
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3147,
-      "ratio": 0.2822,
-      "compress_mbps": 21.89,
-      "decompress_mbps": 159.6
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3141,
-      "ratio": 0.2817,
-      "compress_mbps": 21.61,
-      "decompress_mbps": 161.54
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3133,
-      "ratio": 0.281,
-      "compress_mbps": 21.34,
-      "decompress_mbps": 161.88
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3128,
-      "ratio": 0.2805,
-      "compress_mbps": 19.27,
-      "decompress_mbps": 162.27
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3128,
-      "ratio": 0.2805,
-      "compress_mbps": 7.18,
-      "decompress_mbps": 162.33
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3057,
-      "ratio": 0.2742,
-      "compress_mbps": 4.15,
-      "decompress_mbps": 162.59
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1282,
-      "ratio": 0.3445,
-      "compress_mbps": 12.51,
-      "decompress_mbps": 71.4
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1225,
-      "ratio": 0.3292,
-      "compress_mbps": 11.95,
-      "decompress_mbps": 72.06
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1220,
-      "ratio": 0.3279,
-      "compress_mbps": 11.84,
-      "decompress_mbps": 71.99
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1213,
-      "ratio": 0.326,
-      "compress_mbps": 11.56,
-      "decompress_mbps": 72.48
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1213,
-      "ratio": 0.326,
-      "compress_mbps": 11.56,
-      "decompress_mbps": 72.47
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1213,
-      "ratio": 0.326,
-      "compress_mbps": 11.54,
-      "decompress_mbps": 72.81
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1209,
-      "ratio": 0.3249,
-      "compress_mbps": 11.28,
-      "decompress_mbps": 72.93
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1209,
-      "ratio": 0.3249,
-      "compress_mbps": 3.89,
-      "decompress_mbps": 72.82
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1205,
-      "ratio": 0.3238,
-      "compress_mbps": 3.41,
-      "decompress_mbps": 72.8
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 251793,
-      "ratio": 0.2445,
-      "compress_mbps": 104.94,
-      "decompress_mbps": 342.73
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 242565,
-      "ratio": 0.2356,
-      "compress_mbps": 78.17,
-      "decompress_mbps": 371.99
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 242532,
-      "ratio": 0.2355,
-      "compress_mbps": 65.23,
-      "decompress_mbps": 393.88
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 239898,
-      "ratio": 0.233,
-      "compress_mbps": 60.31,
-      "decompress_mbps": 413.35
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 239804,
-      "ratio": 0.2329,
-      "compress_mbps": 59.44,
-      "decompress_mbps": 399.75
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 239606,
-      "ratio": 0.2327,
-      "compress_mbps": 54.76,
-      "decompress_mbps": 413.34
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 214282,
-      "ratio": 0.2081,
-      "compress_mbps": 19.77,
-      "decompress_mbps": 416.68
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 200719,
-      "ratio": 0.1949,
-      "compress_mbps": 7.22,
-      "decompress_mbps": 423.75
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 183445,
-      "ratio": 0.1781,
-      "compress_mbps": 2.51,
-      "decompress_mbps": 425.93
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 160674,
-      "ratio": 0.3765,
-      "compress_mbps": 61.26,
-      "decompress_mbps": 198.55
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 149787,
-      "ratio": 0.351,
-      "compress_mbps": 46.35,
-      "decompress_mbps": 214.99
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 148055,
-      "ratio": 0.3469,
-      "compress_mbps": 41.66,
-      "decompress_mbps": 239.44
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 145888,
-      "ratio": 0.3419,
-      "compress_mbps": 32.45,
-      "decompress_mbps": 243.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 145758,
-      "ratio": 0.3416,
-      "compress_mbps": 31.54,
-      "decompress_mbps": 245.89
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 145454,
-      "ratio": 0.3408,
-      "compress_mbps": 28.96,
-      "decompress_mbps": 250.68
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 145077,
-      "ratio": 0.34,
-      "compress_mbps": 23.62,
-      "decompress_mbps": 251.84
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 144540,
-      "ratio": 0.3387,
-      "compress_mbps": 10.43,
-      "decompress_mbps": 251.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 141031,
-      "ratio": 0.3305,
-      "compress_mbps": 3.23,
-      "decompress_mbps": 251.73
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 212588,
-      "ratio": 0.4412,
-      "compress_mbps": 52.3,
-      "decompress_mbps": 171.03
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 199981,
-      "ratio": 0.415,
-      "compress_mbps": 38.93,
-      "decompress_mbps": 190.63
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 198551,
-      "ratio": 0.4121,
-      "compress_mbps": 35.02,
-      "decompress_mbps": 210.44
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 195797,
-      "ratio": 0.4063,
-      "compress_mbps": 25.64,
-      "decompress_mbps": 213.72
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 195462,
-      "ratio": 0.4056,
-      "compress_mbps": 24.25,
-      "decompress_mbps": 212.05
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 194965,
-      "ratio": 0.4046,
-      "compress_mbps": 22.38,
-      "decompress_mbps": 216.14
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 194724,
-      "ratio": 0.4041,
-      "compress_mbps": 19.43,
-      "decompress_mbps": 216.49
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 194380,
-      "ratio": 0.4034,
-      "compress_mbps": 8.84,
-      "decompress_mbps": 216.66
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 190711,
-      "ratio": 0.3958,
-      "compress_mbps": 2.98,
-      "decompress_mbps": 216.38
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 60161,
-      "ratio": 0.1172,
-      "compress_mbps": 160.01,
-      "decompress_mbps": 465.04
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 58873,
-      "ratio": 0.1147,
-      "compress_mbps": 123.86,
-      "decompress_mbps": 497.18
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 58327,
-      "ratio": 0.1137,
-      "compress_mbps": 108.63,
-      "decompress_mbps": 536.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 56347,
-      "ratio": 0.1098,
-      "compress_mbps": 85.54,
-      "decompress_mbps": 451.63
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 56324,
-      "ratio": 0.1097,
-      "compress_mbps": 83.2,
-      "decompress_mbps": 479.66
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 55811,
-      "ratio": 0.1087,
-      "compress_mbps": 71.72,
-      "decompress_mbps": 525.26
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 53748,
-      "ratio": 0.1047,
-      "compress_mbps": 38.11,
-      "decompress_mbps": 564.25
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 52897,
-      "ratio": 0.1031,
-      "compress_mbps": 16.52,
-      "decompress_mbps": 608.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 52729,
-      "ratio": 0.1027,
-      "compress_mbps": 4.73,
-      "decompress_mbps": 628.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 14249,
-      "ratio": 0.3726,
-      "compress_mbps": 29.56,
-      "decompress_mbps": 183.43
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 13825,
-      "ratio": 0.3615,
-      "compress_mbps": 27.04,
-      "decompress_mbps": 188.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13751,
-      "ratio": 0.3596,
-      "compress_mbps": 26.18,
-      "decompress_mbps": 191.71
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13379,
-      "ratio": 0.3499,
-      "compress_mbps": 23.81,
-      "decompress_mbps": 197.48
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13375,
-      "ratio": 0.3498,
-      "compress_mbps": 23.39,
-      "decompress_mbps": 208.8
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 13368,
-      "ratio": 0.3496,
-      "compress_mbps": 21.9,
-      "decompress_mbps": 213.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 13344,
-      "ratio": 0.349,
-      "compress_mbps": 17.53,
-      "decompress_mbps": 214.82
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 13028,
-      "ratio": 0.3407,
-      "compress_mbps": 5.34,
-      "decompress_mbps": 217.38
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 12522,
-      "ratio": 0.3275,
-      "compress_mbps": 3.54,
-      "decompress_mbps": 217.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1800,
-      "ratio": 0.4258,
-      "compress_mbps": 13.91,
-      "decompress_mbps": 77.53
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1750,
-      "ratio": 0.414,
-      "compress_mbps": 13.36,
-      "decompress_mbps": 76.84
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1742,
-      "ratio": 0.4121,
-      "compress_mbps": 13.31,
-      "decompress_mbps": 77.6
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1732,
-      "ratio": 0.4097,
-      "compress_mbps": 13.12,
-      "decompress_mbps": 78.13
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1732,
-      "ratio": 0.4097,
-      "compress_mbps": 13.14,
-      "decompress_mbps": 78.25
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1732,
-      "ratio": 0.4097,
-      "compress_mbps": 13.12,
-      "decompress_mbps": 78.28
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1729,
-      "ratio": 0.409,
-      "compress_mbps": 12.95,
-      "decompress_mbps": 78.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1729,
-      "ratio": 0.409,
-      "compress_mbps": 4.29,
-      "decompress_mbps": 78.52
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1708,
-      "ratio": 0.4041,
-      "compress_mbps": 3.9,
-      "decompress_mbps": 78.24
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 65130,
-      "ratio": 0.4282,
-      "compress_mbps": 118.84,
-      "decompress_mbps": 399.29
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 62270,
-      "ratio": 0.4094,
-      "compress_mbps": 101.78,
-      "decompress_mbps": 418.8
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 59488,
-      "ratio": 0.3911,
-      "compress_mbps": 67.0,
-      "decompress_mbps": 435.28
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 57679,
-      "ratio": 0.3792,
-      "compress_mbps": 71.67,
-      "decompress_mbps": 414.35
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 55616,
-      "ratio": 0.3657,
-      "compress_mbps": 41.81,
-      "decompress_mbps": 408.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54398,
-      "ratio": 0.3577,
-      "compress_mbps": 25.53,
-      "decompress_mbps": 421.51
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 54253,
-      "ratio": 0.3567,
-      "compress_mbps": 21.45,
-      "decompress_mbps": 423.73
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 54164,
-      "ratio": 0.3561,
-      "compress_mbps": 16.99,
-      "decompress_mbps": 425.54
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 54164,
-      "ratio": 0.3561,
-      "compress_mbps": 16.98,
-      "decompress_mbps": 423.92
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 56791,
-      "ratio": 0.4537,
-      "compress_mbps": 115.6,
-      "decompress_mbps": 394.7
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 54652,
-      "ratio": 0.4366,
-      "compress_mbps": 97.78,
-      "decompress_mbps": 407.38
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 52663,
-      "ratio": 0.4207,
-      "compress_mbps": 62.36,
-      "decompress_mbps": 428.67
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 51266,
-      "ratio": 0.4095,
-      "compress_mbps": 67.4,
-      "decompress_mbps": 398.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 49622,
-      "ratio": 0.3964,
-      "compress_mbps": 37.32,
-      "decompress_mbps": 386.08
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48891,
-      "ratio": 0.3906,
-      "compress_mbps": 22.81,
-      "decompress_mbps": 395.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48801,
-      "ratio": 0.3898,
-      "compress_mbps": 20.02,
-      "decompress_mbps": 397.56
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 48772,
-      "ratio": 0.3896,
-      "compress_mbps": 18.15,
-      "decompress_mbps": 395.81
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 48772,
-      "ratio": 0.3896,
-      "compress_mbps": 18.14,
-      "decompress_mbps": 399.23
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 9028,
-      "ratio": 0.3669,
-      "compress_mbps": 414.75,
-      "decompress_mbps": 1058.33
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8811,
-      "ratio": 0.3581,
-      "compress_mbps": 218.08,
-      "decompress_mbps": 1085.71
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8616,
-      "ratio": 0.3502,
-      "compress_mbps": 163.26,
-      "decompress_mbps": 1104.41
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8219,
-      "ratio": 0.3341,
-      "compress_mbps": 116.35,
-      "decompress_mbps": 1113.96
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 8001,
-      "ratio": 0.3252,
-      "compress_mbps": 84.93,
-      "decompress_mbps": 1146.67
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7955,
-      "ratio": 0.3233,
-      "compress_mbps": 68.91,
-      "decompress_mbps": 1156.51
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7933,
-      "ratio": 0.3224,
-      "compress_mbps": 62.88,
-      "decompress_mbps": 1159.42
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7934,
-      "ratio": 0.3225,
-      "compress_mbps": 58.08,
-      "decompress_mbps": 1161.26
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7934,
-      "ratio": 0.3225,
-      "compress_mbps": 58.09,
-      "decompress_mbps": 1160.11
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3647,
-      "ratio": 0.3271,
-      "compress_mbps": 426.79,
-      "decompress_mbps": 1073.55
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3501,
-      "ratio": 0.314,
-      "compress_mbps": 408.84,
-      "decompress_mbps": 1117.67
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3393,
-      "ratio": 0.3043,
-      "compress_mbps": 338.35,
-      "decompress_mbps": 1147.08
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3215,
-      "ratio": 0.2883,
-      "compress_mbps": 271.93,
-      "decompress_mbps": 1175.75
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3140,
-      "ratio": 0.2816,
-      "compress_mbps": 205.2,
-      "decompress_mbps": 1205.2
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3116,
-      "ratio": 0.2795,
-      "compress_mbps": 154.1,
-      "decompress_mbps": 1215.53
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 131.87,
-      "decompress_mbps": 1216.78
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3109,
-      "ratio": 0.2788,
-      "compress_mbps": 111.18,
-      "decompress_mbps": 1216.5
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3109,
-      "ratio": 0.2788,
-      "compress_mbps": 110.92,
-      "decompress_mbps": 1220.83
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1326,
-      "ratio": 0.3564,
-      "compress_mbps": 317.29,
-      "decompress_mbps": 787.88
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1306,
-      "ratio": 0.351,
-      "compress_mbps": 310.71,
-      "decompress_mbps": 796.73
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1301,
-      "ratio": 0.3496,
-      "compress_mbps": 291.04,
-      "decompress_mbps": 799.42
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1228,
-      "ratio": 0.33,
-      "compress_mbps": 233.69,
-      "decompress_mbps": 825.26
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 198.9,
-      "decompress_mbps": 831.06
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 177.77,
-      "decompress_mbps": 832.23
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 170.71,
-      "decompress_mbps": 821.82
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 167.8,
-      "decompress_mbps": 826.61
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 168.26,
-      "decompress_mbps": 828.73
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 242293,
-      "ratio": 0.2353,
-      "compress_mbps": 261.91,
-      "decompress_mbps": 834.71
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 233553,
-      "ratio": 0.2268,
-      "compress_mbps": 248.46,
-      "decompress_mbps": 990.64
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 228222,
-      "ratio": 0.2216,
-      "compress_mbps": 195.71,
-      "decompress_mbps": 1047.56
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 223668,
-      "ratio": 0.2172,
-      "compress_mbps": 177.25,
-      "decompress_mbps": 1079.08
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 205994,
-      "ratio": 0.2,
-      "compress_mbps": 110.7,
-      "decompress_mbps": 1038.46
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 203986,
-      "ratio": 0.1981,
-      "compress_mbps": 50.06,
-      "decompress_mbps": 1033.64
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 207681,
-      "ratio": 0.2017,
-      "compress_mbps": 37.08,
-      "decompress_mbps": 1027.99
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 206827,
-      "ratio": 0.2009,
-      "compress_mbps": 7.29,
-      "decompress_mbps": 1001.69
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 207023,
-      "ratio": 0.201,
-      "compress_mbps": 3.43,
-      "decompress_mbps": 1007.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 174124,
-      "ratio": 0.408,
-      "compress_mbps": 124.52,
-      "decompress_mbps": 403.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 166150,
-      "ratio": 0.3893,
-      "compress_mbps": 105.75,
-      "decompress_mbps": 410.83
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 158784,
-      "ratio": 0.3721,
-      "compress_mbps": 70.62,
-      "decompress_mbps": 431.19
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 152782,
-      "ratio": 0.358,
-      "compress_mbps": 74.37,
-      "decompress_mbps": 417.63
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 147196,
-      "ratio": 0.3449,
-      "compress_mbps": 43.69,
-      "decompress_mbps": 412.43
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 144898,
-      "ratio": 0.3395,
-      "compress_mbps": 26.54,
-      "decompress_mbps": 422.22
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 144589,
-      "ratio": 0.3388,
-      "compress_mbps": 23.0,
-      "decompress_mbps": 422.54
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 144436,
-      "ratio": 0.3385,
-      "compress_mbps": 19.77,
-      "decompress_mbps": 426.62
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 144433,
-      "ratio": 0.3384,
-      "compress_mbps": 19.7,
-      "decompress_mbps": 427.06
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 228883,
-      "ratio": 0.475,
-      "compress_mbps": 108.85,
-      "decompress_mbps": 379.18
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 219047,
-      "ratio": 0.4546,
-      "compress_mbps": 91.35,
-      "decompress_mbps": 396.75
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 209408,
-      "ratio": 0.4346,
-      "compress_mbps": 55.73,
-      "decompress_mbps": 408.77
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 205916,
-      "ratio": 0.4273,
-      "compress_mbps": 62.79,
-      "decompress_mbps": 384.06
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 199188,
-      "ratio": 0.4134,
-      "compress_mbps": 33.23,
-      "decompress_mbps": 365.25
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 195255,
-      "ratio": 0.4052,
-      "compress_mbps": 19.51,
-      "decompress_mbps": 371.54
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 194657,
-      "ratio": 0.404,
-      "compress_mbps": 16.52,
-      "decompress_mbps": 368.04
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 194326,
-      "ratio": 0.4033,
-      "compress_mbps": 13.04,
-      "decompress_mbps": 372.62
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 194326,
-      "ratio": 0.4033,
-      "compress_mbps": 13.03,
-      "decompress_mbps": 376.86
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 65553,
-      "ratio": 0.1277,
-      "compress_mbps": 277.05,
-      "decompress_mbps": 898.35
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 63891,
-      "ratio": 0.1245,
-      "compress_mbps": 249.81,
-      "decompress_mbps": 925.37
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 62515,
-      "ratio": 0.1218,
-      "compress_mbps": 196.22,
-      "decompress_mbps": 996.47
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 58451,
-      "ratio": 0.1139,
-      "compress_mbps": 170.56,
-      "decompress_mbps": 705.74
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 57410,
-      "ratio": 0.1119,
-      "compress_mbps": 131.27,
-      "decompress_mbps": 733.83
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 56459,
-      "ratio": 0.11,
-      "compress_mbps": 77.73,
-      "decompress_mbps": 785.69
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 55358,
-      "ratio": 0.1079,
-      "compress_mbps": 60.89,
-      "decompress_mbps": 824.41
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 52991,
-      "ratio": 0.1033,
-      "compress_mbps": 27.8,
-      "decompress_mbps": 878.92
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 52215,
-      "ratio": 0.1017,
-      "compress_mbps": 9.91,
-      "decompress_mbps": 892.75
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 14112,
-      "ratio": 0.369,
-      "compress_mbps": 130.36,
-      "decompress_mbps": 944.12
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 13815,
-      "ratio": 0.3613,
-      "compress_mbps": 110.11,
-      "decompress_mbps": 978.68
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13795,
-      "ratio": 0.3607,
-      "compress_mbps": 79.64,
-      "decompress_mbps": 1014.48
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13375,
-      "ratio": 0.3498,
-      "compress_mbps": 81.09,
-      "decompress_mbps": 997.82
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13062,
-      "ratio": 0.3416,
-      "compress_mbps": 56.15,
-      "decompress_mbps": 1040.2
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 12984,
-      "ratio": 0.3395,
-      "compress_mbps": 33.24,
-      "decompress_mbps": 1062.14
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 12949,
-      "ratio": 0.3386,
-      "compress_mbps": 25.62,
-      "decompress_mbps": 1070.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 12894,
-      "ratio": 0.3372,
-      "compress_mbps": 11.1,
-      "decompress_mbps": 1080.36
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 12832,
-      "ratio": 0.3356,
-      "compress_mbps": 5.1,
-      "decompress_mbps": 1081.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1846,
-      "ratio": 0.4367,
-      "compress_mbps": 290.31,
-      "decompress_mbps": 710.34
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1820,
-      "ratio": 0.4306,
-      "compress_mbps": 284.39,
-      "decompress_mbps": 723.73
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1808,
-      "ratio": 0.4277,
-      "compress_mbps": 272.54,
-      "decompress_mbps": 726.34
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1749,
-      "ratio": 0.4138,
-      "compress_mbps": 226.28,
-      "decompress_mbps": 749.43
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 202.59,
-      "decompress_mbps": 753.91
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 199.81,
-      "decompress_mbps": 754.2
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 196.62,
-      "decompress_mbps": 753.91
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 197.1,
-      "decompress_mbps": 754.2
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 197.89,
-      "decompress_mbps": 752.93
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 76470,
-      "ratio": 0.5028,
-      "compress_mbps": 156.81,
-      "decompress_mbps": 442.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 62765,
-      "ratio": 0.4127,
-      "compress_mbps": 133.14,
-      "decompress_mbps": 491.57
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 57162,
-      "ratio": 0.3758,
-      "compress_mbps": 72.46,
-      "decompress_mbps": 549.38
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 56826,
-      "ratio": 0.3736,
-      "compress_mbps": 64.54,
-      "decompress_mbps": 540.99
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 55696,
-      "ratio": 0.3662,
-      "compress_mbps": 46.93,
-      "decompress_mbps": 528.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54440,
-      "ratio": 0.3579,
-      "compress_mbps": 26.59,
-      "decompress_mbps": 545.39
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 54283,
-      "ratio": 0.3569,
-      "compress_mbps": 22.46,
-      "decompress_mbps": 546.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 54221,
-      "ratio": 0.3565,
-      "compress_mbps": 19.77,
-      "decompress_mbps": 546.31
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 54217,
-      "ratio": 0.3565,
-      "compress_mbps": 19.52,
-      "decompress_mbps": 546.07
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 64926,
-      "ratio": 0.5187,
-      "compress_mbps": 150.76,
-      "decompress_mbps": 420.61
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 54985,
-      "ratio": 0.4393,
-      "compress_mbps": 124.87,
-      "decompress_mbps": 468.91
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 51148,
-      "ratio": 0.4086,
-      "compress_mbps": 67.28,
-      "decompress_mbps": 536.64
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 50599,
-      "ratio": 0.4042,
-      "compress_mbps": 59.25,
-      "decompress_mbps": 526.29
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 49775,
-      "ratio": 0.3976,
-      "compress_mbps": 42.72,
-      "decompress_mbps": 513.76
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48967,
-      "ratio": 0.3912,
-      "compress_mbps": 25.03,
-      "decompress_mbps": 524.3
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48870,
-      "ratio": 0.3904,
-      "compress_mbps": 22.21,
-      "decompress_mbps": 523.8
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 48845,
-      "ratio": 0.3902,
-      "compress_mbps": 20.95,
-      "decompress_mbps": 522.13
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 48845,
-      "ratio": 0.3902,
-      "compress_mbps": 20.95,
-      "decompress_mbps": 524.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 10024,
-      "ratio": 0.4074,
-      "compress_mbps": 568.72,
-      "decompress_mbps": 906.86
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8577,
-      "ratio": 0.3486,
-      "compress_mbps": 269.07,
-      "decompress_mbps": 929.83
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8168,
-      "ratio": 0.332,
-      "compress_mbps": 155.49,
-      "decompress_mbps": 951.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8069,
-      "ratio": 0.328,
-      "compress_mbps": 116.17,
-      "decompress_mbps": 969.68
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 7997,
-      "ratio": 0.325,
-      "compress_mbps": 100.13,
-      "decompress_mbps": 1001.46
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7952,
-      "ratio": 0.3232,
-      "compress_mbps": 74.99,
-      "decompress_mbps": 1003.47
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7947,
-      "ratio": 0.323,
-      "compress_mbps": 72.24,
-      "decompress_mbps": 1009.09
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7947,
-      "ratio": 0.323,
-      "compress_mbps": 71.2,
-      "decompress_mbps": 1009.52
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7947,
-      "ratio": 0.323,
-      "compress_mbps": 70.94,
-      "decompress_mbps": 1010.39
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 4061,
-      "ratio": 0.3642,
-      "compress_mbps": 505.27,
-      "decompress_mbps": 857.33
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3446,
-      "ratio": 0.3091,
-      "compress_mbps": 303.09,
-      "decompress_mbps": 902.14
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3201,
-      "ratio": 0.2871,
-      "compress_mbps": 235.32,
-      "decompress_mbps": 933.5
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3168,
-      "ratio": 0.2841,
-      "compress_mbps": 196.56,
-      "decompress_mbps": 955.13
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3139,
-      "ratio": 0.2815,
-      "compress_mbps": 162.35,
-      "decompress_mbps": 979.95
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3115,
-      "ratio": 0.2794,
-      "compress_mbps": 116.87,
-      "decompress_mbps": 990.27
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 106.87,
-      "decompress_mbps": 991.47
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 103.44,
-      "decompress_mbps": 992.11
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 103.35,
-      "decompress_mbps": 992.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1410,
-      "ratio": 0.3789,
-      "compress_mbps": 365.35,
-      "decompress_mbps": 595.71
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1262,
-      "ratio": 0.3392,
-      "compress_mbps": 234.59,
-      "decompress_mbps": 602.38
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1238,
-      "ratio": 0.3327,
-      "compress_mbps": 206.3,
-      "decompress_mbps": 606.19
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1219,
-      "ratio": 0.3276,
-      "compress_mbps": 178.27,
-      "decompress_mbps": 624.32
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 163.31,
-      "decompress_mbps": 633.68
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 147.91,
-      "decompress_mbps": 631.88
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 147.05,
-      "decompress_mbps": 632.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 147.52,
-      "decompress_mbps": 634.82
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1216,
-      "ratio": 0.3268,
-      "compress_mbps": 147.39,
-      "decompress_mbps": 634.93
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 274412,
-      "ratio": 0.2665,
-      "compress_mbps": 452.12,
-      "decompress_mbps": 796.51
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 213239,
-      "ratio": 0.2071,
-      "compress_mbps": 274.72,
-      "decompress_mbps": 895.56
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 232107,
-      "ratio": 0.2254,
-      "compress_mbps": 137.22,
-      "decompress_mbps": 936.66
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 202733,
-      "ratio": 0.1969,
-      "compress_mbps": 130.42,
-      "decompress_mbps": 942.52
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 207803,
-      "ratio": 0.2018,
-      "compress_mbps": 84.44,
-      "decompress_mbps": 954.1
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 205270,
-      "ratio": 0.1993,
-      "compress_mbps": 27.28,
-      "decompress_mbps": 981.19
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 209951,
-      "ratio": 0.2039,
-      "compress_mbps": 19.33,
-      "decompress_mbps": 997.67
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 209656,
-      "ratio": 0.2036,
-      "compress_mbps": 12.25,
-      "decompress_mbps": 1008.86
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 209189,
-      "ratio": 0.2031,
-      "compress_mbps": 8.96,
-      "decompress_mbps": 1009.49
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 208640,
-      "ratio": 0.4889,
-      "compress_mbps": 157.34,
-      "decompress_mbps": 424.83
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 167329,
-      "ratio": 0.3921,
-      "compress_mbps": 138.54,
-      "decompress_mbps": 464.58
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 151097,
-      "ratio": 0.3541,
-      "compress_mbps": 73.57,
-      "decompress_mbps": 510.84
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 150035,
-      "ratio": 0.3516,
-      "compress_mbps": 66.59,
-      "decompress_mbps": 511.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 147375,
-      "ratio": 0.3453,
-      "compress_mbps": 48.11,
-      "decompress_mbps": 508.07
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 144908,
-      "ratio": 0.3396,
-      "compress_mbps": 28.06,
-      "decompress_mbps": 519.16
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 144562,
-      "ratio": 0.3387,
-      "compress_mbps": 24.64,
-      "decompress_mbps": 517.99
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 144449,
-      "ratio": 0.3385,
-      "compress_mbps": 22.41,
-      "decompress_mbps": 518.6
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 144438,
-      "ratio": 0.3385,
-      "compress_mbps": 22.31,
-      "decompress_mbps": 518.95
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 264549,
-      "ratio": 0.549,
-      "compress_mbps": 135.43,
-      "decompress_mbps": 376.95
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 223724,
-      "ratio": 0.4643,
-      "compress_mbps": 118.93,
-      "decompress_mbps": 422.83
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 204825,
-      "ratio": 0.4251,
-      "compress_mbps": 60.63,
-      "decompress_mbps": 478.39
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 203945,
-      "ratio": 0.4232,
-      "compress_mbps": 53.94,
-      "decompress_mbps": 474.47
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 199780,
-      "ratio": 0.4146,
-      "compress_mbps": 37.91,
-      "decompress_mbps": 457.62
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 195417,
-      "ratio": 0.4055,
-      "compress_mbps": 21.2,
-      "decompress_mbps": 468.93
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 194796,
-      "ratio": 0.4043,
-      "compress_mbps": 17.9,
-      "decompress_mbps": 467.61
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 194543,
-      "ratio": 0.4037,
-      "compress_mbps": 15.72,
-      "decompress_mbps": 467.24
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 194460,
-      "ratio": 0.4036,
-      "compress_mbps": 15.05,
-      "decompress_mbps": 468.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 67436,
-      "ratio": 0.1314,
-      "compress_mbps": 627.54,
-      "decompress_mbps": 1004.41
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 59257,
-      "ratio": 0.1155,
-      "compress_mbps": 278.61,
-      "decompress_mbps": 1060.4
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 58316,
-      "ratio": 0.1136,
-      "compress_mbps": 181.72,
-      "decompress_mbps": 1145.04
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 56291,
-      "ratio": 0.1097,
-      "compress_mbps": 185.03,
-      "decompress_mbps": 1154.82
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 56220,
-      "ratio": 0.1095,
-      "compress_mbps": 146.23,
-      "decompress_mbps": 1207.72
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 55972,
-      "ratio": 0.1091,
-      "compress_mbps": 74.5,
-      "decompress_mbps": 1263.85
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 55121,
-      "ratio": 0.1074,
-      "compress_mbps": 52.14,
-      "decompress_mbps": 1305.51
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 54124,
-      "ratio": 0.1055,
-      "compress_mbps": 36.7,
-      "decompress_mbps": 1378.02
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 53699,
-      "ratio": 0.1046,
-      "compress_mbps": 28.66,
-      "decompress_mbps": 1411.67
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 15612,
-      "ratio": 0.4083,
-      "compress_mbps": 502.51,
-      "decompress_mbps": 850.6
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 14133,
-      "ratio": 0.3696,
-      "compress_mbps": 145.19,
-      "decompress_mbps": 890.56
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13341,
-      "ratio": 0.3489,
-      "compress_mbps": 88.72,
-      "decompress_mbps": 911.51
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13289,
-      "ratio": 0.3475,
-      "compress_mbps": 83.64,
-      "decompress_mbps": 941.29
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13052,
-      "ratio": 0.3413,
-      "compress_mbps": 66.83,
-      "decompress_mbps": 973.4
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 12996,
-      "ratio": 0.3399,
-      "compress_mbps": 37.14,
-      "decompress_mbps": 986.7
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 12972,
-      "ratio": 0.3392,
-      "compress_mbps": 27.2,
-      "decompress_mbps": 990.88
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 12951,
-      "ratio": 0.3387,
-      "compress_mbps": 19.04,
-      "decompress_mbps": 996.63
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 12933,
-      "ratio": 0.3382,
-      "compress_mbps": 14.86,
-      "decompress_mbps": 1010.18
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1988,
-      "ratio": 0.4703,
-      "compress_mbps": 340.18,
-      "decompress_mbps": 548.09
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1802,
-      "ratio": 0.4263,
-      "compress_mbps": 218.94,
-      "decompress_mbps": 554.27
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 205.58,
-      "decompress_mbps": 558.57
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1732,
-      "ratio": 0.4097,
-      "compress_mbps": 171.81,
-      "decompress_mbps": 573.34
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 167.66,
-      "decompress_mbps": 582.37
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 166.66,
-      "decompress_mbps": 582.62
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 166.44,
-      "decompress_mbps": 580.03
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 167.1,
-      "decompress_mbps": 579.86
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1730,
-      "ratio": 0.4093,
-      "compress_mbps": 166.8,
-      "decompress_mbps": 579.36
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 59790,
-      "ratio": 0.3931,
-      "compress_mbps": 262.72,
-      "decompress_mbps": 1002.92
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 57173,
-      "ratio": 0.3759,
-      "compress_mbps": 181.24,
-      "decompress_mbps": 1076.37
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 56189,
-      "ratio": 0.3694,
-      "compress_mbps": 150.83,
-      "decompress_mbps": 1150.52
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 55816,
-      "ratio": 0.367,
-      "compress_mbps": 138.22,
-      "decompress_mbps": 1189.04
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 54758,
-      "ratio": 0.36,
-      "compress_mbps": 109.12,
-      "decompress_mbps": 1241.07
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54220,
-      "ratio": 0.3565,
-      "compress_mbps": 84.01,
-      "decompress_mbps": 1281.1
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 53801,
-      "ratio": 0.3537,
-      "compress_mbps": 61.34,
-      "decompress_mbps": 1284.1
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 53573,
-      "ratio": 0.3522,
-      "compress_mbps": 38.99,
-      "decompress_mbps": 1281.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 53546,
-      "ratio": 0.3521,
-      "compress_mbps": 34.49,
-      "decompress_mbps": 1286.38
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 52276,
-      "ratio": 0.4176,
-      "compress_mbps": 244.27,
-      "decompress_mbps": 941.62
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 50534,
-      "ratio": 0.4037,
-      "compress_mbps": 169.26,
-      "decompress_mbps": 994.53
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 49919,
-      "ratio": 0.3988,
-      "compress_mbps": 142.29,
-      "decompress_mbps": 1056.87
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 49715,
-      "ratio": 0.3972,
-      "compress_mbps": 131.62,
-      "decompress_mbps": 1092.43
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 48735,
-      "ratio": 0.3893,
-      "compress_mbps": 101.28,
-      "decompress_mbps": 1138.39
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48422,
-      "ratio": 0.3868,
-      "compress_mbps": 79.56,
-      "decompress_mbps": 1159.77
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48249,
-      "ratio": 0.3854,
-      "compress_mbps": 61.42,
-      "decompress_mbps": 1167.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 47977,
-      "ratio": 0.3833,
-      "compress_mbps": 43.01,
-      "decompress_mbps": 1163.26
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 47971,
-      "ratio": 0.3832,
-      "compress_mbps": 41.05,
-      "decompress_mbps": 1168.97
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 8385,
-      "ratio": 0.3408,
-      "compress_mbps": 694.12,
-      "decompress_mbps": 956.86
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8380,
-      "ratio": 0.3406,
-      "compress_mbps": 439.72,
-      "decompress_mbps": 974.59
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8286,
-      "ratio": 0.3368,
-      "compress_mbps": 403.73,
-      "decompress_mbps": 993.24
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8163,
-      "ratio": 0.3318,
-      "compress_mbps": 378.68,
-      "decompress_mbps": 1003.78
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 8053,
-      "ratio": 0.3273,
-      "compress_mbps": 335.07,
-      "decompress_mbps": 1027.69
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7986,
-      "ratio": 0.3246,
-      "compress_mbps": 277.67,
-      "decompress_mbps": 1035.81
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7954,
-      "ratio": 0.3233,
-      "compress_mbps": 191.05,
-      "decompress_mbps": 1026.12
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7916,
-      "ratio": 0.3217,
-      "compress_mbps": 129.56,
-      "decompress_mbps": 1035.17
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7916,
-      "ratio": 0.3217,
-      "compress_mbps": 125.42,
-      "decompress_mbps": 1013.27
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3401,
-      "ratio": 0.305,
-      "compress_mbps": 586.93,
-      "decompress_mbps": 768.98
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3307,
-      "ratio": 0.2966,
-      "compress_mbps": 398.24,
-      "decompress_mbps": 792.95
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3242,
-      "ratio": 0.2908,
-      "compress_mbps": 371.5,
-      "decompress_mbps": 810.66
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3205,
-      "ratio": 0.2874,
-      "compress_mbps": 349.62,
-      "decompress_mbps": 821.62
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3150,
-      "ratio": 0.2825,
-      "compress_mbps": 313.81,
-      "decompress_mbps": 837.48
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3126,
-      "ratio": 0.2804,
-      "compress_mbps": 267.83,
-      "decompress_mbps": 842.46
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3106,
-      "ratio": 0.2786,
-      "compress_mbps": 206.71,
-      "decompress_mbps": 846.01
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3102,
-      "ratio": 0.2782,
-      "compress_mbps": 147.91,
-      "decompress_mbps": 842.39
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3102,
-      "ratio": 0.2782,
-      "compress_mbps": 140.39,
-      "decompress_mbps": 846.34
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1251,
-      "ratio": 0.3362,
-      "compress_mbps": 377.39,
-      "decompress_mbps": 426.98
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1228,
-      "ratio": 0.33,
-      "compress_mbps": 267.66,
-      "decompress_mbps": 433.76
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1219,
-      "ratio": 0.3276,
-      "compress_mbps": 258.72,
-      "decompress_mbps": 433.23
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1220,
-      "ratio": 0.3279,
-      "compress_mbps": 253.94,
-      "decompress_mbps": 439.29
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 240.44,
-      "decompress_mbps": 443.8
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 222.65,
-      "decompress_mbps": 441.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 203.53,
-      "decompress_mbps": 438.86
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1204,
-      "ratio": 0.3236,
-      "compress_mbps": 169.68,
-      "decompress_mbps": 444.08
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1204,
-      "ratio": 0.3236,
-      "compress_mbps": 169.88,
-      "decompress_mbps": 438.1
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 221813,
-      "ratio": 0.2154,
-      "compress_mbps": 593.83,
-      "decompress_mbps": 1009.94
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 199825,
-      "ratio": 0.1941,
-      "compress_mbps": 409.25,
-      "decompress_mbps": 1460.57
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 195675,
-      "ratio": 0.19,
-      "compress_mbps": 283.23,
-      "decompress_mbps": 1526.64
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 195664,
-      "ratio": 0.19,
-      "compress_mbps": 279.77,
-      "decompress_mbps": 1536.83
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 198900,
-      "ratio": 0.1932,
-      "compress_mbps": 239.94,
-      "decompress_mbps": 1127.82
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 199347,
-      "ratio": 0.1936,
-      "compress_mbps": 204.69,
-      "decompress_mbps": 1130.61
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 199777,
-      "ratio": 0.194,
-      "compress_mbps": 123.53,
-      "decompress_mbps": 1190.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 182094,
-      "ratio": 0.1768,
-      "compress_mbps": 25.66,
-      "decompress_mbps": 1169.78
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 181451,
-      "ratio": 0.1762,
-      "compress_mbps": 13.61,
-      "decompress_mbps": 1173.47
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 159063,
-      "ratio": 0.3727,
-      "compress_mbps": 263.86,
-      "decompress_mbps": 1029.34
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 152115,
-      "ratio": 0.3564,
-      "compress_mbps": 187.44,
-      "decompress_mbps": 1105.52
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 149162,
-      "ratio": 0.3495,
-      "compress_mbps": 156.82,
-      "decompress_mbps": 1189.07
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 148359,
-      "ratio": 0.3476,
-      "compress_mbps": 142.61,
-      "decompress_mbps": 1033.04
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 145353,
-      "ratio": 0.3406,
-      "compress_mbps": 113.35,
-      "decompress_mbps": 997.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 144209,
-      "ratio": 0.3379,
-      "compress_mbps": 87.48,
-      "decompress_mbps": 1037.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 143604,
-      "ratio": 0.3365,
-      "compress_mbps": 66.64,
-      "decompress_mbps": 1039.31
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 142086,
-      "ratio": 0.3329,
-      "compress_mbps": 44.24,
-      "decompress_mbps": 1035.21
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 142027,
-      "ratio": 0.3328,
-      "compress_mbps": 40.46,
-      "decompress_mbps": 1038.75
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 210662,
-      "ratio": 0.4372,
-      "compress_mbps": 228.71,
-      "decompress_mbps": 869.83
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 202881,
-      "ratio": 0.421,
-      "compress_mbps": 158.66,
-      "decompress_mbps": 939.95
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 200409,
-      "ratio": 0.4159,
-      "compress_mbps": 132.96,
-      "decompress_mbps": 1019.12
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 199678,
-      "ratio": 0.4144,
-      "compress_mbps": 122.96,
-      "decompress_mbps": 839.63
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 195798,
-      "ratio": 0.4063,
-      "compress_mbps": 93.4,
-      "decompress_mbps": 789.36
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 194029,
-      "ratio": 0.4027,
-      "compress_mbps": 71.6,
-      "decompress_mbps": 813.1
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 192773,
-      "ratio": 0.4001,
-      "compress_mbps": 50.41,
-      "decompress_mbps": 835.88
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 191739,
-      "ratio": 0.3979,
-      "compress_mbps": 33.69,
-      "decompress_mbps": 841.06
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 191676,
-      "ratio": 0.3978,
-      "compress_mbps": 31.1,
-      "decompress_mbps": 839.65
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 58079,
-      "ratio": 0.1132,
-      "compress_mbps": 373.38,
-      "decompress_mbps": 1687.98
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 57838,
-      "ratio": 0.1127,
-      "compress_mbps": 413.69,
-      "decompress_mbps": 1800.72
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 57554,
-      "ratio": 0.1121,
-      "compress_mbps": 394.76,
-      "decompress_mbps": 1899.42
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 57064,
-      "ratio": 0.1112,
-      "compress_mbps": 374.05,
-      "decompress_mbps": 1741.26
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 55743,
-      "ratio": 0.1086,
-      "compress_mbps": 343.45,
-      "decompress_mbps": 1793.36
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 55102,
-      "ratio": 0.1074,
-      "compress_mbps": 285.08,
-      "decompress_mbps": 1869.89
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 54742,
-      "ratio": 0.1067,
-      "compress_mbps": 193.03,
-      "decompress_mbps": 1929.26
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 53133,
-      "ratio": 0.1035,
-      "compress_mbps": 102.77,
-      "decompress_mbps": 1996.36
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 52186,
-      "ratio": 0.1017,
-      "compress_mbps": 72.32,
-      "decompress_mbps": 2031.74
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 14122,
-      "ratio": 0.3693,
-      "compress_mbps": 648.66,
-      "decompress_mbps": 823.66
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 13374,
-      "ratio": 0.3497,
-      "compress_mbps": 338.62,
-      "decompress_mbps": 879.23
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13293,
-      "ratio": 0.3476,
-      "compress_mbps": 257.73,
-      "decompress_mbps": 960.76
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13259,
-      "ratio": 0.3467,
-      "compress_mbps": 263.83,
-      "decompress_mbps": 960.86
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 12641,
-      "ratio": 0.3306,
-      "compress_mbps": 190.13,
-      "decompress_mbps": 990.29
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 12432,
-      "ratio": 0.3251,
-      "compress_mbps": 164.05,
-      "decompress_mbps": 1006.67
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 12439,
-      "ratio": 0.3253,
-      "compress_mbps": 122.43,
-      "decompress_mbps": 1013.21
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 12579,
-      "ratio": 0.3289,
-      "compress_mbps": 67.61,
-      "decompress_mbps": 1025.92
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 12574,
-      "ratio": 0.3288,
-      "compress_mbps": 47.47,
-      "decompress_mbps": 1031.58
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1777,
-      "ratio": 0.4204,
-      "compress_mbps": 386.35,
-      "decompress_mbps": 403.24
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1756,
-      "ratio": 0.4154,
-      "compress_mbps": 260.77,
-      "decompress_mbps": 408.51
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1746,
-      "ratio": 0.4131,
-      "compress_mbps": 257.14,
-      "decompress_mbps": 410.93
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1740,
-      "ratio": 0.4116,
-      "compress_mbps": 254.99,
-      "decompress_mbps": 414.73
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1722,
-      "ratio": 0.4074,
-      "compress_mbps": 240.47,
-      "decompress_mbps": 415.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1721,
-      "ratio": 0.4071,
-      "compress_mbps": 235.91,
-      "decompress_mbps": 415.29
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 234.75,
-      "decompress_mbps": 415.41
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1717,
-      "ratio": 0.4062,
-      "compress_mbps": 217.57,
-      "decompress_mbps": 417.83
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1717,
-      "ratio": 0.4062,
-      "compress_mbps": 216.75,
-      "decompress_mbps": 416.19
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 4259644,
-      "ratio": 0.4179,
-      "compress_mbps": 55.48,
-      "decompress_mbps": 175.13
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 3977395,
-      "ratio": 0.3902,
-      "compress_mbps": 41.33,
-      "decompress_mbps": 190.42
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 3945296,
-      "ratio": 0.3871,
-      "compress_mbps": 36.93,
-      "decompress_mbps": 209.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 3888037,
-      "ratio": 0.3815,
-      "compress_mbps": 27.75,
-      "decompress_mbps": 213.35
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3882328,
-      "ratio": 0.3809,
-      "compress_mbps": 27.19,
-      "decompress_mbps": 212.35
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3873339,
-      "ratio": 0.38,
-      "compress_mbps": 24.92,
-      "decompress_mbps": 218.0
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3866648,
-      "ratio": 0.3794,
-      "compress_mbps": 20.84,
-      "decompress_mbps": 217.98
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3864805,
-      "ratio": 0.3792,
-      "compress_mbps": 9.49,
-      "decompress_mbps": 226.2
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3790404,
-      "ratio": 0.3719,
-      "compress_mbps": 3.13,
-      "decompress_mbps": 219.59
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 21267086,
-      "ratio": 0.4152,
-      "compress_mbps": 70.17,
-      "decompress_mbps": 192.7
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 20802983,
-      "ratio": 0.4061,
-      "compress_mbps": 56.03,
-      "decompress_mbps": 200.74
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 20665485,
-      "ratio": 0.4035,
-      "compress_mbps": 52.53,
-      "decompress_mbps": 200.3
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 20427823,
-      "ratio": 0.3988,
-      "compress_mbps": 41.38,
-      "decompress_mbps": 210.97
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 20413947,
-      "ratio": 0.3986,
-      "compress_mbps": 39.25,
-      "decompress_mbps": 224.27
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 20373541,
-      "ratio": 0.3978,
-      "compress_mbps": 34.33,
-      "decompress_mbps": 224.75
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 20251873,
-      "ratio": 0.3954,
-      "compress_mbps": 22.16,
-      "decompress_mbps": 225.66
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19172591,
-      "ratio": 0.3743,
-      "compress_mbps": 6.94,
-      "decompress_mbps": 226.33
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 18723512,
-      "ratio": 0.3655,
-      "compress_mbps": 3.21,
-      "decompress_mbps": 224.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3864163,
-      "ratio": 0.3876,
-      "compress_mbps": 68.39,
-      "decompress_mbps": 205.5
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3734957,
-      "ratio": 0.3746,
-      "compress_mbps": 53.45,
-      "decompress_mbps": 214.49
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3708443,
-      "ratio": 0.3719,
-      "compress_mbps": 46.13,
-      "decompress_mbps": 224.58
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3712990,
-      "ratio": 0.3724,
-      "compress_mbps": 32.72,
-      "decompress_mbps": 208.12
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3707399,
-      "ratio": 0.3718,
-      "compress_mbps": 31.1,
-      "decompress_mbps": 203.21
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3701112,
-      "ratio": 0.3712,
-      "compress_mbps": 28.43,
-      "decompress_mbps": 196.91
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3704320,
-      "ratio": 0.3715,
-      "compress_mbps": 22.54,
-      "decompress_mbps": 212.23
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3609490,
-      "ratio": 0.362,
-      "compress_mbps": 8.27,
-      "decompress_mbps": 228.1
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3598941,
-      "ratio": 0.361,
-      "compress_mbps": 3.58,
-      "decompress_mbps": 227.82
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 3785443,
-      "ratio": 0.1128,
-      "compress_mbps": 200.7,
-      "decompress_mbps": 597.03
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 3761560,
-      "ratio": 0.1121,
-      "compress_mbps": 129.81,
-      "decompress_mbps": 670.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3606997,
-      "ratio": 0.1075,
-      "compress_mbps": 113.5,
-      "decompress_mbps": 745.87
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3340261,
-      "ratio": 0.0996,
-      "compress_mbps": 95.64,
-      "decompress_mbps": 742.09
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3336190,
-      "ratio": 0.0994,
-      "compress_mbps": 93.91,
-      "decompress_mbps": 830.01
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3217453,
-      "ratio": 0.0959,
-      "compress_mbps": 79.07,
-      "decompress_mbps": 839.94
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3126259,
-      "ratio": 0.0932,
-      "compress_mbps": 42.73,
-      "decompress_mbps": 903.26
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 3112207,
-      "ratio": 0.0928,
-      "compress_mbps": 22.47,
-      "decompress_mbps": 892.73
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 3083394,
-      "ratio": 0.0919,
-      "compress_mbps": 3.08,
-      "decompress_mbps": 908.14
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3357083,
-      "ratio": 0.5457,
-      "compress_mbps": 48.27,
-      "decompress_mbps": 128.85
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3285077,
-      "ratio": 0.534,
-      "compress_mbps": 41.14,
-      "decompress_mbps": 132.57
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3272746,
-      "ratio": 0.532,
-      "compress_mbps": 39.54,
-      "decompress_mbps": 137.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3238986,
-      "ratio": 0.5265,
-      "compress_mbps": 32.38,
-      "decompress_mbps": 145.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3237944,
-      "ratio": 0.5263,
-      "compress_mbps": 32.14,
-      "decompress_mbps": 150.52
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3235767,
-      "ratio": 0.526,
-      "compress_mbps": 30.8,
-      "decompress_mbps": 153.53
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3232738,
-      "ratio": 0.5255,
-      "compress_mbps": 26.88,
-      "decompress_mbps": 154.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3165909,
-      "ratio": 0.5146,
-      "compress_mbps": 7.02,
-      "decompress_mbps": 156.75
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3055775,
-      "ratio": 0.4967,
-      "compress_mbps": 3.72,
-      "decompress_mbps": 156.25
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 3838828,
-      "ratio": 0.3806,
-      "compress_mbps": 78.07,
-      "decompress_mbps": 230.29
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3792520,
-      "ratio": 0.376,
-      "compress_mbps": 59.51,
-      "decompress_mbps": 238.0
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3783171,
-      "ratio": 0.3751,
-      "compress_mbps": 57.57,
-      "decompress_mbps": 242.95
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3709091,
-      "ratio": 0.3678,
-      "compress_mbps": 51.26,
-      "decompress_mbps": 242.19
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3708716,
-      "ratio": 0.3677,
-      "compress_mbps": 51.45,
-      "decompress_mbps": 242.31
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3707113,
-      "ratio": 0.3676,
-      "compress_mbps": 51.47,
-      "decompress_mbps": 251.84
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3706769,
-      "ratio": 0.3675,
-      "compress_mbps": 47.47,
-      "decompress_mbps": 254.69
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3706769,
-      "ratio": 0.3675,
-      "compress_mbps": 12.78,
-      "decompress_mbps": 263.77
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3693258,
-      "ratio": 0.3662,
-      "compress_mbps": 4.84,
-      "decompress_mbps": 269.3
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2254442,
-      "ratio": 0.3402,
-      "compress_mbps": 69.34,
-      "decompress_mbps": 222.38
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2044843,
-      "ratio": 0.3086,
-      "compress_mbps": 48.71,
-      "decompress_mbps": 233.42
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 1992105,
-      "ratio": 0.3006,
-      "compress_mbps": 39.96,
-      "decompress_mbps": 254.89
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 1911755,
-      "ratio": 0.2885,
-      "compress_mbps": 27.89,
-      "decompress_mbps": 257.69
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1901448,
-      "ratio": 0.2869,
-      "compress_mbps": 25.9,
-      "decompress_mbps": 260.08
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1883344,
-      "ratio": 0.2842,
-      "compress_mbps": 21.06,
-      "decompress_mbps": 271.62
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1868258,
-      "ratio": 0.2819,
-      "compress_mbps": 13.38,
-      "decompress_mbps": 276.33
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1841388,
-      "ratio": 0.2779,
-      "compress_mbps": 7.82,
-      "decompress_mbps": 284.02
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1794155,
-      "ratio": 0.2707,
-      "compress_mbps": 2.47,
-      "decompress_mbps": 290.71
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 6406301,
-      "ratio": 0.2965,
-      "compress_mbps": 95.14,
-      "decompress_mbps": 293.3
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 6102377,
-      "ratio": 0.2824,
-      "compress_mbps": 72.18,
-      "decompress_mbps": 313.32
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 6022184,
-      "ratio": 0.2787,
-      "compress_mbps": 66.12,
-      "decompress_mbps": 325.67
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5904034,
-      "ratio": 0.2733,
-      "compress_mbps": 52.53,
-      "decompress_mbps": 336.24
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5899862,
-      "ratio": 0.2731,
-      "compress_mbps": 50.36,
-      "decompress_mbps": 342.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5881527,
-      "ratio": 0.2722,
-      "compress_mbps": 46.19,
-      "decompress_mbps": 351.91
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5830453,
-      "ratio": 0.2698,
-      "compress_mbps": 33.41,
-      "decompress_mbps": 352.37
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5407066,
-      "ratio": 0.2503,
-      "compress_mbps": 12.96,
-      "decompress_mbps": 327.8
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5257833,
-      "ratio": 0.2433,
-      "compress_mbps": 3.99,
-      "decompress_mbps": 355.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5612204,
-      "ratio": 0.7739,
-      "compress_mbps": 41.24,
-      "decompress_mbps": 129.07
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5533875,
-      "ratio": 0.7631,
-      "compress_mbps": 35.17,
-      "decompress_mbps": 132.08
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5522436,
-      "ratio": 0.7615,
-      "compress_mbps": 33.18,
-      "decompress_mbps": 136.64
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5500073,
-      "ratio": 0.7584,
-      "compress_mbps": 27.91,
-      "decompress_mbps": 139.09
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5498823,
-      "ratio": 0.7583,
-      "compress_mbps": 26.89,
-      "decompress_mbps": 136.43
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5497402,
-      "ratio": 0.7581,
-      "compress_mbps": 26.32,
-      "decompress_mbps": 138.94
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5496371,
-      "ratio": 0.7579,
-      "compress_mbps": 25.01,
-      "decompress_mbps": 138.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5429363,
-      "ratio": 0.7487,
-      "compress_mbps": 6.35,
-      "decompress_mbps": 141.33
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5301868,
-      "ratio": 0.7311,
-      "compress_mbps": 3.62,
-      "decompress_mbps": 141.55
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 13727247,
-      "ratio": 0.3311,
-      "compress_mbps": 71.12,
-      "decompress_mbps": 223.0
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 12940398,
-      "ratio": 0.3121,
-      "compress_mbps": 54.34,
-      "decompress_mbps": 241.35
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 12703756,
-      "ratio": 0.3064,
-      "compress_mbps": 50.41,
-      "decompress_mbps": 262.78
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12294598,
-      "ratio": 0.2966,
-      "compress_mbps": 39.65,
-      "decompress_mbps": 267.14
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12269076,
-      "ratio": 0.2959,
-      "compress_mbps": 37.96,
-      "decompress_mbps": 272.69
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12184584,
-      "ratio": 0.2939,
-      "compress_mbps": 33.32,
-      "decompress_mbps": 269.98
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12109369,
-      "ratio": 0.2921,
-      "compress_mbps": 25.31,
-      "decompress_mbps": 281.5
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12106058,
-      "ratio": 0.292,
-      "compress_mbps": 11.79,
-      "decompress_mbps": 282.72
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 11868997,
-      "ratio": 0.2863,
-      "compress_mbps": 3.24,
-      "decompress_mbps": 282.41
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6438176,
-      "ratio": 0.7597,
-      "compress_mbps": 39.06,
-      "decompress_mbps": 126.15
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6392101,
-      "ratio": 0.7543,
-      "compress_mbps": 37.61,
-      "decompress_mbps": 126.96
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6392124,
-      "ratio": 0.7543,
-      "compress_mbps": 37.91,
-      "decompress_mbps": 128.38
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6368722,
-      "ratio": 0.7515,
-      "compress_mbps": 35.88,
-      "decompress_mbps": 116.53
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6368719,
-      "ratio": 0.7515,
-      "compress_mbps": 35.44,
-      "decompress_mbps": 117.83
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 6368719,
-      "ratio": 0.7515,
-      "compress_mbps": 35.43,
-      "decompress_mbps": 118.63
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 6368717,
-      "ratio": 0.7515,
-      "compress_mbps": 35.68,
-      "decompress_mbps": 118.83
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 6278507,
-      "ratio": 0.7409,
-      "compress_mbps": 4.9,
-      "decompress_mbps": 120.21
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 5949045,
-      "ratio": 0.702,
-      "compress_mbps": 4.32,
-      "decompress_mbps": 121.14
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 858525,
-      "ratio": 0.1606,
-      "compress_mbps": 151.44,
-      "decompress_mbps": 419.29
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 846807,
-      "ratio": 0.1584,
-      "compress_mbps": 101.03,
-      "decompress_mbps": 455.3
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 806798,
-      "ratio": 0.1509,
-      "compress_mbps": 92.34,
-      "decompress_mbps": 503.3
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 746239,
-      "ratio": 0.1396,
-      "compress_mbps": 73.56,
-      "decompress_mbps": 547.92
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 743257,
-      "ratio": 0.139,
-      "compress_mbps": 71.46,
-      "decompress_mbps": 596.7
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 721315,
-      "ratio": 0.1349,
-      "compress_mbps": 64.91,
-      "decompress_mbps": 648.89
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 703742,
-      "ratio": 0.1317,
-      "compress_mbps": 42.29,
-      "decompress_mbps": 664.81
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 674362,
-      "ratio": 0.1262,
-      "compress_mbps": 20.92,
-      "decompress_mbps": 676.13
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 669438,
-      "ratio": 0.1252,
-      "compress_mbps": 3.92,
-      "decompress_mbps": 664.14
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 4585612,
-      "ratio": 0.4499,
-      "compress_mbps": 113.67,
-      "decompress_mbps": 354.82
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4389474,
-      "ratio": 0.4307,
-      "compress_mbps": 96.07,
-      "decompress_mbps": 375.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 4192079,
-      "ratio": 0.4113,
-      "compress_mbps": 59.36,
-      "decompress_mbps": 412.28
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 4095021,
-      "ratio": 0.4018,
-      "compress_mbps": 66.19,
-      "decompress_mbps": 389.42
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3949169,
-      "ratio": 0.3875,
-      "compress_mbps": 35.97,
-      "decompress_mbps": 376.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3871628,
-      "ratio": 0.3799,
-      "compress_mbps": 21.24,
-      "decompress_mbps": 384.89
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3858876,
-      "ratio": 0.3786,
-      "compress_mbps": 17.58,
-      "decompress_mbps": 387.13
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3854729,
-      "ratio": 0.3782,
-      "compress_mbps": 15.07,
-      "decompress_mbps": 385.46
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3854729,
-      "ratio": 0.3782,
-      "compress_mbps": 15.07,
-      "decompress_mbps": 391.3
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 20577220,
-      "ratio": 0.4017,
-      "compress_mbps": 113.25,
-      "decompress_mbps": 364.49
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 20247697,
-      "ratio": 0.3953,
-      "compress_mbps": 100.51,
-      "decompress_mbps": 370.0
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 19987880,
-      "ratio": 0.3902,
-      "compress_mbps": 75.64,
-      "decompress_mbps": 340.24
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19512665,
-      "ratio": 0.381,
-      "compress_mbps": 71.76,
-      "decompress_mbps": 363.34
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 19213507,
-      "ratio": 0.3751,
-      "compress_mbps": 51.35,
-      "decompress_mbps": 370.37
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 19089118,
-      "ratio": 0.3727,
-      "compress_mbps": 33.44,
-      "decompress_mbps": 376.59
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 19061204,
-      "ratio": 0.3721,
-      "compress_mbps": 27.31,
-      "decompress_mbps": 380.14
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19040998,
-      "ratio": 0.3717,
-      "compress_mbps": 15.24,
-      "decompress_mbps": 379.76
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 19044390,
-      "ratio": 0.3718,
-      "compress_mbps": 9.54,
-      "decompress_mbps": 385.45
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3828360,
-      "ratio": 0.384,
-      "compress_mbps": 144.91,
-      "decompress_mbps": 453.29
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3798539,
-      "ratio": 0.381,
-      "compress_mbps": 128.29,
-      "decompress_mbps": 497.36
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3674568,
-      "ratio": 0.3685,
-      "compress_mbps": 80.47,
-      "decompress_mbps": 515.99
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3680923,
-      "ratio": 0.3692,
-      "compress_mbps": 89.36,
-      "decompress_mbps": 457.6
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3698707,
-      "ratio": 0.371,
-      "compress_mbps": 48.13,
-      "decompress_mbps": 427.63
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3675935,
-      "ratio": 0.3687,
-      "compress_mbps": 26.41,
-      "decompress_mbps": 437.75
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3670281,
-      "ratio": 0.3681,
-      "compress_mbps": 20.84,
-      "decompress_mbps": 444.31
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3661103,
-      "ratio": 0.3672,
-      "compress_mbps": 10.94,
-      "decompress_mbps": 458.18
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3660788,
-      "ratio": 0.3672,
-      "compress_mbps": 9.47,
-      "decompress_mbps": 459.79
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 4624591,
-      "ratio": 0.1378,
-      "compress_mbps": 332.0,
-      "decompress_mbps": 831.27
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 4303176,
-      "ratio": 0.1282,
-      "compress_mbps": 310.37,
-      "decompress_mbps": 841.9
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 4010156,
-      "ratio": 0.1195,
-      "compress_mbps": 257.47,
-      "decompress_mbps": 926.52
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3713866,
-      "ratio": 0.1107,
-      "compress_mbps": 212.08,
-      "decompress_mbps": 896.37
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3378136,
-      "ratio": 0.1007,
-      "compress_mbps": 166.1,
-      "decompress_mbps": 954.98
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3200182,
-      "ratio": 0.0954,
-      "compress_mbps": 113.17,
-      "decompress_mbps": 986.8
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3141278,
-      "ratio": 0.0936,
-      "compress_mbps": 90.33,
-      "decompress_mbps": 999.02
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 3031199,
-      "ratio": 0.0903,
-      "compress_mbps": 39.16,
-      "decompress_mbps": 1017.12
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 2987995,
-      "ratio": 0.0891,
-      "compress_mbps": 21.44,
-      "decompress_mbps": 1033.52
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3290526,
-      "ratio": 0.5349,
-      "compress_mbps": 79.06,
-      "decompress_mbps": 257.16
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3238282,
-      "ratio": 0.5264,
-      "compress_mbps": 72.38,
-      "decompress_mbps": 263.21
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3193366,
-      "ratio": 0.5191,
-      "compress_mbps": 57.0,
-      "decompress_mbps": 265.33
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3158012,
-      "ratio": 0.5133,
-      "compress_mbps": 55.65,
-      "decompress_mbps": 268.5
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3115309,
-      "ratio": 0.5064,
-      "compress_mbps": 39.25,
-      "decompress_mbps": 269.0
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3097288,
-      "ratio": 0.5034,
-      "compress_mbps": 26.28,
-      "decompress_mbps": 264.86
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3094363,
-      "ratio": 0.503,
-      "compress_mbps": 21.86,
-      "decompress_mbps": 268.09
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3093026,
-      "ratio": 0.5028,
-      "compress_mbps": 16.97,
-      "decompress_mbps": 270.33
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3092920,
-      "ratio": 0.5027,
-      "compress_mbps": 15.53,
-      "decompress_mbps": 269.1
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 4076385,
-      "ratio": 0.4042,
-      "compress_mbps": 125.81,
-      "decompress_mbps": 474.99
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3991014,
-      "ratio": 0.3957,
-      "compress_mbps": 117.17,
-      "decompress_mbps": 494.44
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3934055,
-      "ratio": 0.3901,
-      "compress_mbps": 93.6,
-      "decompress_mbps": 511.59
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3825092,
-      "ratio": 0.3793,
-      "compress_mbps": 85.49,
-      "decompress_mbps": 513.7
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3752932,
-      "ratio": 0.3721,
-      "compress_mbps": 64.41,
-      "decompress_mbps": 496.1
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3695164,
-      "ratio": 0.3664,
-      "compress_mbps": 49.22,
-      "decompress_mbps": 507.36
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3676881,
-      "ratio": 0.3646,
-      "compress_mbps": 38.17,
-      "decompress_mbps": 515.91
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3673171,
-      "ratio": 0.3642,
-      "compress_mbps": 31.92,
-      "decompress_mbps": 519.6
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3673171,
-      "ratio": 0.3642,
-      "compress_mbps": 31.92,
-      "decompress_mbps": 519.23
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2376424,
-      "ratio": 0.3586,
-      "compress_mbps": 130.38,
-      "decompress_mbps": 393.75
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2259060,
-      "ratio": 0.3409,
-      "compress_mbps": 112.03,
-      "decompress_mbps": 411.76
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2135664,
-      "ratio": 0.3223,
-      "compress_mbps": 72.25,
-      "decompress_mbps": 435.29
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 2052793,
-      "ratio": 0.3098,
-      "compress_mbps": 81.67,
-      "decompress_mbps": 430.73
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1932127,
-      "ratio": 0.2915,
-      "compress_mbps": 45.23,
-      "decompress_mbps": 432.43
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1860865,
-      "ratio": 0.2808,
-      "compress_mbps": 22.82,
-      "decompress_mbps": 440.25
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1838671,
-      "ratio": 0.2774,
-      "compress_mbps": 15.96,
-      "decompress_mbps": 441.72
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1823235,
-      "ratio": 0.2751,
-      "compress_mbps": 8.12,
-      "decompress_mbps": 436.13
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1823190,
-      "ratio": 0.2751,
-      "compress_mbps": 8.15,
-      "decompress_mbps": 439.5
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 6329449,
-      "ratio": 0.2929,
-      "compress_mbps": 169.74,
-      "decompress_mbps": 460.79
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 6128866,
-      "ratio": 0.2837,
-      "compress_mbps": 155.55,
-      "decompress_mbps": 557.06
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5982546,
-      "ratio": 0.2769,
-      "compress_mbps": 125.39,
-      "decompress_mbps": 581.02
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5656400,
-      "ratio": 0.2618,
-      "compress_mbps": 116.92,
-      "decompress_mbps": 576.69
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5511352,
-      "ratio": 0.2551,
-      "compress_mbps": 82.58,
-      "decompress_mbps": 587.65
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5451399,
-      "ratio": 0.2523,
-      "compress_mbps": 56.59,
-      "decompress_mbps": 593.88
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5417123,
-      "ratio": 0.2507,
-      "compress_mbps": 46.71,
-      "decompress_mbps": 596.81
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5404364,
-      "ratio": 0.2501,
-      "compress_mbps": 32.73,
-      "decompress_mbps": 602.78
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5402704,
-      "ratio": 0.2501,
-      "compress_mbps": 29.69,
-      "decompress_mbps": 390.04
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5567768,
-      "ratio": 0.7678,
-      "compress_mbps": 32.89,
-      "decompress_mbps": 211.48
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5504009,
-      "ratio": 0.759,
-      "compress_mbps": 38.32,
-      "decompress_mbps": 168.63
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5439339,
-      "ratio": 0.7501,
-      "compress_mbps": 29.43,
-      "decompress_mbps": 230.72
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5394604,
-      "ratio": 0.7439,
-      "compress_mbps": 32.68,
-      "decompress_mbps": 256.53
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5370116,
-      "ratio": 0.7405,
-      "compress_mbps": 28.44,
-      "decompress_mbps": 312.67
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5331793,
-      "ratio": 0.7352,
-      "compress_mbps": 20.53,
-      "decompress_mbps": 329.4
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5327677,
-      "ratio": 0.7347,
-      "compress_mbps": 21.16,
-      "decompress_mbps": 348.44
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5325914,
-      "ratio": 0.7344,
-      "compress_mbps": 18.96,
-      "decompress_mbps": 349.29
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5325914,
-      "ratio": 0.7344,
-      "compress_mbps": 18.95,
-      "decompress_mbps": 346.98
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 14991236,
-      "ratio": 0.3616,
-      "compress_mbps": 136.65,
-      "decompress_mbps": 380.3
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 14249692,
-      "ratio": 0.3437,
-      "compress_mbps": 120.34,
-      "decompress_mbps": 401.81
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 13627761,
-      "ratio": 0.3287,
-      "compress_mbps": 87.73,
-      "decompress_mbps": 414.55
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 13001990,
-      "ratio": 0.3136,
-      "compress_mbps": 85.4,
-      "decompress_mbps": 395.8
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12445991,
-      "ratio": 0.3002,
-      "compress_mbps": 55.03,
-      "decompress_mbps": 392.94
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12213941,
-      "ratio": 0.2946,
-      "compress_mbps": 36.53,
-      "decompress_mbps": 400.31
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12130416,
-      "ratio": 0.2926,
-      "compress_mbps": 29.65,
-      "decompress_mbps": 401.43
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12073697,
-      "ratio": 0.2912,
-      "compress_mbps": 21.5,
-      "decompress_mbps": 403.07
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 12073469,
-      "ratio": 0.2912,
-      "compress_mbps": 21.33,
-      "decompress_mbps": 403.44
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6033926,
-      "ratio": 0.712,
-      "compress_mbps": 75.49,
-      "decompress_mbps": 294.33
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 5997474,
-      "ratio": 0.7077,
-      "compress_mbps": 68.78,
-      "decompress_mbps": 305.32
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 5966621,
-      "ratio": 0.7041,
-      "compress_mbps": 55.63,
-      "decompress_mbps": 312.38
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6091108,
-      "ratio": 0.7188,
-      "compress_mbps": 46.09,
-      "decompress_mbps": 267.15
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6053566,
-      "ratio": 0.7143,
-      "compress_mbps": 37.26,
-      "decompress_mbps": 274.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 6045111,
-      "ratio": 0.7134,
-      "compress_mbps": 34.97,
-      "decompress_mbps": 276.79
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 6045034,
-      "ratio": 0.7133,
-      "compress_mbps": 34.92,
-      "decompress_mbps": 278.07
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 6045032,
-      "ratio": 0.7133,
-      "compress_mbps": 34.97,
-      "decompress_mbps": 277.28
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 6045032,
-      "ratio": 0.7133,
-      "compress_mbps": 34.94,
-      "decompress_mbps": 277.39
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 965242,
-      "ratio": 0.1806,
-      "compress_mbps": 264.31,
-      "decompress_mbps": 697.56
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 887265,
-      "ratio": 0.166,
-      "compress_mbps": 246.22,
-      "decompress_mbps": 752.4
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 822167,
-      "ratio": 0.1538,
-      "compress_mbps": 191.48,
-      "decompress_mbps": 797.39
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 807518,
-      "ratio": 0.1511,
-      "compress_mbps": 169.01,
-      "decompress_mbps": 768.34
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 730574,
-      "ratio": 0.1367,
-      "compress_mbps": 121.75,
-      "decompress_mbps": 815.59
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 687991,
-      "ratio": 0.1287,
-      "compress_mbps": 79.31,
-      "decompress_mbps": 872.54
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 673933,
-      "ratio": 0.1261,
-      "compress_mbps": 64.99,
-      "decompress_mbps": 887.93
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 659518,
-      "ratio": 0.1234,
-      "compress_mbps": 43.0,
-      "decompress_mbps": 884.96
-    },
-    {
-      "compressor": "zlib",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 658899,
-      "ratio": 0.1233,
-      "compress_mbps": 39.85,
-      "decompress_mbps": 896.88
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 5363862,
-      "ratio": 0.5263,
-      "compress_mbps": 141.65,
-      "decompress_mbps": 389.91
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4438205,
-      "ratio": 0.4354,
-      "compress_mbps": 128.9,
-      "decompress_mbps": 428.47
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 4054333,
-      "ratio": 0.3978,
-      "compress_mbps": 63.86,
-      "decompress_mbps": 475.64
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 4038550,
-      "ratio": 0.3962,
-      "compress_mbps": 57.76,
-      "decompress_mbps": 469.09
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3954920,
-      "ratio": 0.388,
-      "compress_mbps": 40.27,
-      "decompress_mbps": 462.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3872874,
-      "ratio": 0.38,
-      "compress_mbps": 22.58,
-      "decompress_mbps": 470.25
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3859937,
-      "ratio": 0.3787,
-      "compress_mbps": 18.83,
-      "decompress_mbps": 472.38
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3855935,
-      "ratio": 0.3783,
-      "compress_mbps": 17.07,
-      "decompress_mbps": 469.47
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3855791,
-      "ratio": 0.3783,
-      "compress_mbps": 17.01,
-      "decompress_mbps": 470.52
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 22334882,
-      "ratio": 0.4361,
-      "compress_mbps": 233.89,
-      "decompress_mbps": 370.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 20150366,
-      "ratio": 0.3934,
-      "compress_mbps": 119.97,
-      "decompress_mbps": 375.66
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 19495014,
-      "ratio": 0.3806,
-      "compress_mbps": 70.13,
-      "decompress_mbps": 389.58
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19424978,
-      "ratio": 0.3792,
-      "compress_mbps": 71.02,
-      "decompress_mbps": 402.97
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 19298736,
-      "ratio": 0.3768,
-      "compress_mbps": 54.1,
-      "decompress_mbps": 393.93
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 19179167,
-      "ratio": 0.3744,
-      "compress_mbps": 29.69,
-      "decompress_mbps": 422.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 19151324,
-      "ratio": 0.3739,
-      "compress_mbps": 21.89,
-      "decompress_mbps": 422.25
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19144373,
-      "ratio": 0.3738,
-      "compress_mbps": 16.59,
-      "decompress_mbps": 407.62
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 19141383,
-      "ratio": 0.3737,
-      "compress_mbps": 14.17,
-      "decompress_mbps": 420.85
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 4249731,
-      "ratio": 0.4262,
-      "compress_mbps": 313.35,
-      "decompress_mbps": 528.94
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3775479,
-      "ratio": 0.3787,
-      "compress_mbps": 156.84,
-      "decompress_mbps": 517.84
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3656966,
-      "ratio": 0.3668,
-      "compress_mbps": 79.84,
-      "decompress_mbps": 574.15
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3740378,
-      "ratio": 0.3751,
-      "compress_mbps": 67.57,
-      "decompress_mbps": 534.79
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3713604,
-      "ratio": 0.3725,
-      "compress_mbps": 48.45,
-      "decompress_mbps": 501.84
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3683556,
-      "ratio": 0.3694,
-      "compress_mbps": 24.87,
-      "decompress_mbps": 515.42
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3683797,
-      "ratio": 0.3695,
-      "compress_mbps": 18.98,
-      "decompress_mbps": 521.98
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3684477,
-      "ratio": 0.3695,
-      "compress_mbps": 14.34,
-      "decompress_mbps": 540.16
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3679414,
-      "ratio": 0.369,
-      "compress_mbps": 12.34,
-      "decompress_mbps": 542.45
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 5594622,
-      "ratio": 0.1667,
-      "compress_mbps": 433.55,
-      "decompress_mbps": 834.3
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 4179532,
-      "ratio": 0.1246,
-      "compress_mbps": 327.38,
-      "decompress_mbps": 926.24
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3542329,
-      "ratio": 0.1056,
-      "compress_mbps": 211.33,
-      "decompress_mbps": 842.8
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3323363,
-      "ratio": 0.099,
-      "compress_mbps": 197.38,
-      "decompress_mbps": 872.41
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3230343,
-      "ratio": 0.0963,
-      "compress_mbps": 161.61,
-      "decompress_mbps": 952.97
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3123421,
-      "ratio": 0.0931,
-      "compress_mbps": 95.69,
-      "decompress_mbps": 997.1
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3093778,
-      "ratio": 0.0922,
-      "compress_mbps": 70.53,
-      "decompress_mbps": 972.37
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 3067318,
-      "ratio": 0.0914,
-      "compress_mbps": 50.06,
-      "decompress_mbps": 1013.07
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 3050695,
-      "ratio": 0.0909,
-      "compress_mbps": 41.98,
-      "decompress_mbps": 1022.82
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3543611,
-      "ratio": 0.576,
-      "compress_mbps": 169.2,
-      "decompress_mbps": 269.98
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3226818,
-      "ratio": 0.5245,
-      "compress_mbps": 86.03,
-      "decompress_mbps": 287.07
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3144140,
-      "ratio": 0.5111,
-      "compress_mbps": 52.6,
-      "decompress_mbps": 297.45
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3129833,
-      "ratio": 0.5087,
-      "compress_mbps": 51.39,
-      "decompress_mbps": 324.03
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3114809,
-      "ratio": 0.5063,
-      "compress_mbps": 40.29,
-      "decompress_mbps": 338.27
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3095705,
-      "ratio": 0.5032,
-      "compress_mbps": 25.04,
-      "decompress_mbps": 345.03
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3090055,
-      "ratio": 0.5023,
-      "compress_mbps": 20.39,
-      "decompress_mbps": 345.41
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3087665,
-      "ratio": 0.5019,
-      "compress_mbps": 17.41,
-      "decompress_mbps": 345.4
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3087158,
-      "ratio": 0.5018,
-      "compress_mbps": 16.29,
-      "decompress_mbps": 345.8
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 5419510,
-      "ratio": 0.5373,
-      "compress_mbps": 243.36,
-      "decompress_mbps": 535.63
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3982547,
-      "ratio": 0.3949,
-      "compress_mbps": 122.38,
-      "decompress_mbps": 550.66
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3806102,
-      "ratio": 0.3774,
-      "compress_mbps": 80.86,
-      "decompress_mbps": 568.24
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3761477,
-      "ratio": 0.373,
-      "compress_mbps": 78.11,
-      "decompress_mbps": 603.06
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3740298,
-      "ratio": 0.3709,
-      "compress_mbps": 67.07,
-      "decompress_mbps": 611.24
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3686116,
-      "ratio": 0.3655,
-      "compress_mbps": 49.52,
-      "decompress_mbps": 637.82
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3668442,
-      "ratio": 0.3637,
-      "compress_mbps": 38.85,
-      "decompress_mbps": 662.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3665072,
-      "ratio": 0.3634,
-      "compress_mbps": 33.15,
-      "decompress_mbps": 657.03
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3665057,
-      "ratio": 0.3634,
-      "compress_mbps": 32.94,
-      "decompress_mbps": 653.51
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2842321,
-      "ratio": 0.4289,
-      "compress_mbps": 193.08,
-      "decompress_mbps": 443.97
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2232180,
-      "ratio": 0.3368,
-      "compress_mbps": 151.04,
-      "decompress_mbps": 514.91
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2003056,
-      "ratio": 0.3022,
-      "compress_mbps": 81.92,
-      "decompress_mbps": 551.48
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 1985375,
-      "ratio": 0.2996,
-      "compress_mbps": 74.08,
-      "decompress_mbps": 566.46
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1933775,
-      "ratio": 0.2918,
-      "compress_mbps": 51.93,
-      "decompress_mbps": 538.73
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1858103,
-      "ratio": 0.2804,
-      "compress_mbps": 22.05,
-      "decompress_mbps": 541.6
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1840414,
-      "ratio": 0.2777,
-      "compress_mbps": 15.15,
-      "decompress_mbps": 550.69
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1831679,
-      "ratio": 0.2764,
-      "compress_mbps": 11.76,
-      "decompress_mbps": 543.82
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1827137,
-      "ratio": 0.2757,
-      "compress_mbps": 10.16,
-      "decompress_mbps": 544.36
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 7089759,
-      "ratio": 0.3281,
-      "compress_mbps": 290.79,
-      "decompress_mbps": 557.71
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 5966231,
-      "ratio": 0.2761,
-      "compress_mbps": 174.66,
-      "decompress_mbps": 619.46
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5611838,
-      "ratio": 0.2597,
-      "compress_mbps": 111.67,
-      "decompress_mbps": 648.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5535436,
-      "ratio": 0.2562,
-      "compress_mbps": 105.54,
-      "decompress_mbps": 672.27
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5480971,
-      "ratio": 0.2537,
-      "compress_mbps": 81.52,
-      "decompress_mbps": 680.77
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5437556,
-      "ratio": 0.2517,
-      "compress_mbps": 49.47,
-      "decompress_mbps": 697.31
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5432108,
-      "ratio": 0.2514,
-      "compress_mbps": 40.48,
-      "decompress_mbps": 694.27
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5428571,
-      "ratio": 0.2512,
-      "compress_mbps": 33.62,
-      "decompress_mbps": 700.3
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5425526,
-      "ratio": 0.2511,
-      "compress_mbps": 30.51,
-      "decompress_mbps": 703.33
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5900800,
-      "ratio": 0.8137,
-      "compress_mbps": 188.47,
-      "decompress_mbps": 324.35
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5523611,
-      "ratio": 0.7617,
-      "compress_mbps": 69.45,
-      "decompress_mbps": 340.66
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5393086,
-      "ratio": 0.7437,
-      "compress_mbps": 40.33,
-      "decompress_mbps": 351.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5401582,
-      "ratio": 0.7448,
-      "compress_mbps": 40.72,
-      "decompress_mbps": 367.5
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5371274,
-      "ratio": 0.7407,
-      "compress_mbps": 31.31,
-      "decompress_mbps": 358.37
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5330096,
-      "ratio": 0.735,
-      "compress_mbps": 20.8,
-      "decompress_mbps": 365.39
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5325437,
-      "ratio": 0.7343,
-      "compress_mbps": 18.98,
-      "decompress_mbps": 366.05
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5323934,
-      "ratio": 0.7341,
-      "compress_mbps": 18.05,
-      "decompress_mbps": 364.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5323621,
-      "ratio": 0.7341,
-      "compress_mbps": 17.67,
-      "decompress_mbps": 364.02
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 17587173,
-      "ratio": 0.4242,
-      "compress_mbps": 185.73,
-      "decompress_mbps": 379.13
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 14171707,
-      "ratio": 0.3418,
-      "compress_mbps": 149.15,
-      "decompress_mbps": 409.08
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 12774851,
-      "ratio": 0.3081,
-      "compress_mbps": 85.71,
-      "decompress_mbps": 440.79
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12612554,
-      "ratio": 0.3042,
-      "compress_mbps": 76.13,
-      "decompress_mbps": 444.75
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12392339,
-      "ratio": 0.2989,
-      "compress_mbps": 58.1,
-      "decompress_mbps": 457.17
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12158314,
-      "ratio": 0.2933,
-      "compress_mbps": 34.41,
-      "decompress_mbps": 463.08
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12107840,
-      "ratio": 0.292,
-      "compress_mbps": 27.64,
-      "decompress_mbps": 466.33
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12081311,
-      "ratio": 0.2914,
-      "compress_mbps": 22.88,
-      "decompress_mbps": 462.63
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 12081011,
-      "ratio": 0.2914,
-      "compress_mbps": 22.78,
-      "decompress_mbps": 460.01
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6527324,
-      "ratio": 0.7703,
-      "compress_mbps": 238.95,
-      "decompress_mbps": 330.7
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6051483,
-      "ratio": 0.7141,
-      "compress_mbps": 75.62,
-      "decompress_mbps": 332.39
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6010123,
-      "ratio": 0.7092,
-      "compress_mbps": 52.06,
-      "decompress_mbps": 334.45
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6024815,
-      "ratio": 0.711,
-      "compress_mbps": 44.63,
-      "decompress_mbps": 286.25
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6005181,
-      "ratio": 0.7086,
-      "compress_mbps": 40.44,
-      "decompress_mbps": 293.0
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 5997508,
-      "ratio": 0.7077,
-      "compress_mbps": 37.97,
-      "decompress_mbps": 295.42
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 5997403,
-      "ratio": 0.7077,
-      "compress_mbps": 37.87,
-      "decompress_mbps": 295.69
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 5997403,
-      "ratio": 0.7077,
-      "compress_mbps": 37.82,
-      "decompress_mbps": 295.45
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 5997403,
-      "ratio": 0.7077,
-      "compress_mbps": 37.76,
-      "decompress_mbps": 292.96
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 1147652,
-      "ratio": 0.2147,
-      "compress_mbps": 388.67,
-      "decompress_mbps": 761.65
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 919639,
-      "ratio": 0.172,
-      "compress_mbps": 262.86,
-      "decompress_mbps": 956.95
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 752341,
-      "ratio": 0.1407,
-      "compress_mbps": 167.46,
-      "decompress_mbps": 1057.51
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 735537,
-      "ratio": 0.1376,
-      "compress_mbps": 161.37,
-      "decompress_mbps": 1037.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 706789,
-      "ratio": 0.1322,
-      "compress_mbps": 123.5,
-      "decompress_mbps": 1129.34
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 676279,
-      "ratio": 0.1265,
-      "compress_mbps": 69.53,
-      "decompress_mbps": 1219.4
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 668772,
-      "ratio": 0.1251,
-      "compress_mbps": 55.97,
-      "decompress_mbps": 1208.21
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 665340,
-      "ratio": 0.1245,
-      "compress_mbps": 47.61,
-      "decompress_mbps": 1208.14
-    },
-    {
-      "compressor": "miniz_oxide",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 664273,
-      "ratio": 0.1243,
-      "compress_mbps": 45.85,
-      "decompress_mbps": 1218.11
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 4217525,
-      "ratio": 0.4138,
-      "compress_mbps": 243.85,
-      "decompress_mbps": 801.13
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4053259,
-      "ratio": 0.3977,
-      "compress_mbps": 170.19,
-      "decompress_mbps": 864.66
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 3989875,
-      "ratio": 0.3915,
-      "compress_mbps": 140.0,
-      "decompress_mbps": 934.98
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 3972869,
-      "ratio": 0.3898,
-      "compress_mbps": 127.83,
-      "decompress_mbps": 825.71
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3894026,
-      "ratio": 0.3821,
-      "compress_mbps": 99.29,
-      "decompress_mbps": 791.29
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3859436,
-      "ratio": 0.3787,
-      "compress_mbps": 75.65,
-      "decompress_mbps": 819.18
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3837515,
-      "ratio": 0.3765,
-      "compress_mbps": 55.71,
-      "decompress_mbps": 796.16
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3811467,
-      "ratio": 0.374,
-      "compress_mbps": 36.03,
-      "decompress_mbps": 816.32
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3810354,
-      "ratio": 0.3738,
-      "compress_mbps": 32.76,
-      "decompress_mbps": 816.68
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 20192961,
-      "ratio": 0.3942,
-      "compress_mbps": 242.16,
-      "decompress_mbps": 676.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 19374226,
-      "ratio": 0.3783,
-      "compress_mbps": 185.69,
-      "decompress_mbps": 710.78
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 19234937,
-      "ratio": 0.3755,
-      "compress_mbps": 173.04,
-      "decompress_mbps": 727.76
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19145385,
-      "ratio": 0.3738,
-      "compress_mbps": 162.62,
-      "decompress_mbps": 728.74
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 18878875,
-      "ratio": 0.3686,
-      "compress_mbps": 142.62,
-      "decompress_mbps": 741.83
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 18805391,
-      "ratio": 0.3671,
-      "compress_mbps": 117.71,
-      "decompress_mbps": 750.56
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 18749947,
-      "ratio": 0.3661,
-      "compress_mbps": 87.16,
-      "decompress_mbps": 759.3
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 18718540,
-      "ratio": 0.3655,
-      "compress_mbps": 47.56,
-      "decompress_mbps": 766.6
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 18713659,
-      "ratio": 0.3654,
-      "compress_mbps": 33.49,
-      "decompress_mbps": 676.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3740775,
-      "ratio": 0.3752,
-      "compress_mbps": 293.42,
-      "decompress_mbps": 755.42
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3707407,
-      "ratio": 0.3718,
-      "compress_mbps": 217.45,
-      "decompress_mbps": 768.84
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3672389,
-      "ratio": 0.3683,
-      "compress_mbps": 185.43,
-      "decompress_mbps": 809.7
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3660011,
-      "ratio": 0.3671,
-      "compress_mbps": 171.62,
-      "decompress_mbps": 751.11
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3664245,
-      "ratio": 0.3675,
-      "compress_mbps": 141.37,
-      "decompress_mbps": 712.85
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3648644,
-      "ratio": 0.3659,
-      "compress_mbps": 106.84,
-      "decompress_mbps": 739.26
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3635323,
-      "ratio": 0.3646,
-      "compress_mbps": 68.34,
-      "decompress_mbps": 735.43
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3624778,
-      "ratio": 0.3635,
-      "compress_mbps": 43.04,
-      "decompress_mbps": 773.18
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3625176,
-      "ratio": 0.3636,
-      "compress_mbps": 38.87,
-      "decompress_mbps": 757.44
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 3837577,
-      "ratio": 0.1144,
-      "compress_mbps": 609.02,
-      "decompress_mbps": 1491.69
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 3714632,
-      "ratio": 0.1107,
-      "compress_mbps": 462.85,
-      "decompress_mbps": 1747.31
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3599455,
-      "ratio": 0.1073,
-      "compress_mbps": 427.07,
-      "decompress_mbps": 1882.3
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3431843,
-      "ratio": 0.1023,
-      "compress_mbps": 388.74,
-      "decompress_mbps": 1763.39
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3268188,
-      "ratio": 0.0974,
-      "compress_mbps": 346.67,
-      "decompress_mbps": 1777.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3091741,
-      "ratio": 0.0921,
-      "compress_mbps": 264.16,
-      "decompress_mbps": 1787.13
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3032499,
-      "ratio": 0.0904,
-      "compress_mbps": 186.41,
-      "decompress_mbps": 1846.22
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 2949097,
-      "ratio": 0.0879,
-      "compress_mbps": 97.63,
-      "decompress_mbps": 1789.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 2925243,
-      "ratio": 0.0872,
-      "compress_mbps": 69.23,
-      "decompress_mbps": 1757.94
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3275124,
-      "ratio": 0.5324,
-      "compress_mbps": 166.26,
-      "decompress_mbps": 462.6
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3150806,
-      "ratio": 0.5121,
-      "compress_mbps": 128.39,
-      "decompress_mbps": 483.21
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3137061,
-      "ratio": 0.5099,
-      "compress_mbps": 120.82,
-      "decompress_mbps": 502.43
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3129676,
-      "ratio": 0.5087,
-      "compress_mbps": 116.89,
-      "decompress_mbps": 518.56
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3079277,
-      "ratio": 0.5005,
-      "compress_mbps": 99.99,
-      "decompress_mbps": 536.74
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3072378,
-      "ratio": 0.4994,
-      "compress_mbps": 88.82,
-      "decompress_mbps": 533.12
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3068123,
-      "ratio": 0.4987,
-      "compress_mbps": 76.38,
-      "decompress_mbps": 542.11
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3067299,
-      "ratio": 0.4986,
-      "compress_mbps": 55.33,
-      "decompress_mbps": 533.57
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3066968,
-      "ratio": 0.4985,
-      "compress_mbps": 49.23,
-      "decompress_mbps": 507.58
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 3868663,
-      "ratio": 0.3836,
-      "compress_mbps": 285.16,
-      "decompress_mbps": 772.78
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3839158,
-      "ratio": 0.3807,
-      "compress_mbps": 213.22,
-      "decompress_mbps": 914.82
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3818964,
-      "ratio": 0.3787,
-      "compress_mbps": 197.74,
-      "decompress_mbps": 936.61
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3789325,
-      "ratio": 0.3757,
-      "compress_mbps": 179.66,
-      "decompress_mbps": 954.8
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3666476,
-      "ratio": 0.3635,
-      "compress_mbps": 157.89,
-      "decompress_mbps": 942.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3660266,
-      "ratio": 0.3629,
-      "compress_mbps": 142.43,
-      "decompress_mbps": 987.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3659491,
-      "ratio": 0.3628,
-      "compress_mbps": 135.11,
-      "decompress_mbps": 999.79
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3654863,
-      "ratio": 0.3624,
-      "compress_mbps": 114.32,
-      "decompress_mbps": 1009.23
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3654860,
-      "ratio": 0.3624,
-      "compress_mbps": 114.27,
-      "decompress_mbps": 1001.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2197055,
-      "ratio": 0.3315,
-      "compress_mbps": 300.85,
-      "decompress_mbps": 858.37
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2082309,
-      "ratio": 0.3142,
-      "compress_mbps": 214.77,
-      "decompress_mbps": 1130.12
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2021047,
-      "ratio": 0.305,
-      "compress_mbps": 178.67,
-      "decompress_mbps": 1236.6
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 1990952,
-      "ratio": 0.3004,
-      "compress_mbps": 157.4,
-      "decompress_mbps": 1146.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1921113,
-      "ratio": 0.2899,
-      "compress_mbps": 127.99,
-      "decompress_mbps": 1093.81
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1876257,
-      "ratio": 0.2831,
-      "compress_mbps": 86.94,
-      "decompress_mbps": 1090.38
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1832695,
-      "ratio": 0.2765,
-      "compress_mbps": 46.02,
-      "decompress_mbps": 1103.5
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1809967,
-      "ratio": 0.2731,
-      "compress_mbps": 24.27,
-      "decompress_mbps": 1063.53
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1806374,
-      "ratio": 0.2726,
-      "compress_mbps": 19.83,
-      "decompress_mbps": 1054.62
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 5866517,
-      "ratio": 0.2715,
-      "compress_mbps": 338.52,
-      "decompress_mbps": 979.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 5695942,
-      "ratio": 0.2636,
-      "compress_mbps": 258.0,
-      "decompress_mbps": 1031.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5605878,
-      "ratio": 0.2595,
-      "compress_mbps": 233.32,
-      "decompress_mbps": 1100.86
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5553432,
-      "ratio": 0.257,
-      "compress_mbps": 216.59,
-      "decompress_mbps": 1079.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5416713,
-      "ratio": 0.2507,
-      "compress_mbps": 186.71,
-      "decompress_mbps": 1066.93
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5337149,
-      "ratio": 0.247,
-      "compress_mbps": 142.78,
-      "decompress_mbps": 1079.29
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5310181,
-      "ratio": 0.2458,
-      "compress_mbps": 100.23,
-      "decompress_mbps": 1069.71
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5272761,
-      "ratio": 0.244,
-      "compress_mbps": 62.39,
-      "decompress_mbps": 1089.17
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5270405,
-      "ratio": 0.2439,
-      "compress_mbps": 50.04,
-      "decompress_mbps": 1101.61
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5575128,
-      "ratio": 0.7688,
-      "compress_mbps": 162.23,
-      "decompress_mbps": 485.07
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5417142,
-      "ratio": 0.747,
-      "compress_mbps": 116.65,
-      "decompress_mbps": 518.27
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5397999,
-      "ratio": 0.7444,
-      "compress_mbps": 105.25,
-      "decompress_mbps": 528.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5391125,
-      "ratio": 0.7434,
-      "compress_mbps": 99.31,
-      "decompress_mbps": 542.53
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5352212,
-      "ratio": 0.738,
-      "compress_mbps": 87.58,
-      "decompress_mbps": 513.46
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5335405,
-      "ratio": 0.7357,
-      "compress_mbps": 73.79,
-      "decompress_mbps": 526.1
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5325697,
-      "ratio": 0.7344,
-      "compress_mbps": 63.45,
-      "decompress_mbps": 513.46
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5324004,
-      "ratio": 0.7341,
-      "compress_mbps": 52.34,
-      "decompress_mbps": 522.62
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5323197,
-      "ratio": 0.734,
-      "compress_mbps": 50.85,
-      "decompress_mbps": 511.04
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 13550569,
-      "ratio": 0.3268,
-      "compress_mbps": 266.06,
-      "decompress_mbps": 891.09
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 13130705,
-      "ratio": 0.3167,
-      "compress_mbps": 199.84,
-      "decompress_mbps": 973.65
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 12839361,
-      "ratio": 0.3097,
-      "compress_mbps": 176.74,
-      "decompress_mbps": 1015.15
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12601933,
-      "ratio": 0.304,
-      "compress_mbps": 161.98,
-      "decompress_mbps": 899.79
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12310776,
-      "ratio": 0.2969,
-      "compress_mbps": 131.58,
-      "decompress_mbps": 879.58
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12140474,
-      "ratio": 0.2928,
-      "compress_mbps": 104.62,
-      "decompress_mbps": 887.92
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12025296,
-      "ratio": 0.2901,
-      "compress_mbps": 75.01,
-      "decompress_mbps": 892.91
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 11893824,
-      "ratio": 0.2869,
-      "compress_mbps": 45.87,
-      "decompress_mbps": 886.31
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 11882496,
-      "ratio": 0.2866,
-      "compress_mbps": 39.46,
-      "decompress_mbps": 930.2
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6293390,
-      "ratio": 0.7426,
-      "compress_mbps": 145.39,
-      "decompress_mbps": 523.59
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6058412,
-      "ratio": 0.7149,
-      "compress_mbps": 120.35,
-      "decompress_mbps": 529.46
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6058381,
-      "ratio": 0.7149,
-      "compress_mbps": 120.3,
-      "decompress_mbps": 539.19
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6058363,
-      "ratio": 0.7149,
-      "compress_mbps": 120.03,
-      "decompress_mbps": 437.57
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 5998400,
-      "ratio": 0.7078,
-      "compress_mbps": 108.52,
-      "decompress_mbps": 459.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 5998438,
-      "ratio": 0.7078,
-      "compress_mbps": 108.55,
-      "decompress_mbps": 463.75
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 5998439,
-      "ratio": 0.7078,
-      "compress_mbps": 108.18,
-      "decompress_mbps": 462.69
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 5986859,
-      "ratio": 0.7065,
-      "compress_mbps": 90.15,
-      "decompress_mbps": 462.82
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 5986859,
-      "ratio": 0.7065,
-      "compress_mbps": 90.18,
-      "decompress_mbps": 454.72
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 887708,
-      "ratio": 0.1661,
-      "compress_mbps": 492.83,
-      "decompress_mbps": 1270.45
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 843475,
-      "ratio": 0.1578,
-      "compress_mbps": 363.79,
-      "decompress_mbps": 1801.54
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 793388,
-      "ratio": 0.1484,
-      "compress_mbps": 337.16,
-      "decompress_mbps": 1867.27
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 747602,
-      "ratio": 0.1399,
-      "compress_mbps": 304.24,
-      "decompress_mbps": 1819.5
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 718615,
-      "ratio": 0.1344,
-      "compress_mbps": 263.07,
-      "decompress_mbps": 1830.67
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 684405,
-      "ratio": 0.128,
-      "compress_mbps": 206.4,
-      "decompress_mbps": 1920.08
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 664859,
-      "ratio": 0.1244,
-      "compress_mbps": 142.72,
-      "decompress_mbps": 1906.99
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 650835,
-      "ratio": 0.1218,
-      "compress_mbps": 81.56,
-      "decompress_mbps": 1892.16
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 649494,
-      "ratio": 0.1215,
-      "compress_mbps": 68.13,
-      "decompress_mbps": 1902.14
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 65708,
-      "ratio": 0.432,
-      "compress_mbps": 42.56,
-      "decompress_mbps": 61.17
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 60259,
-      "ratio": 0.3962,
-      "compress_mbps": 26.21,
-      "decompress_mbps": 68.33
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 58544,
-      "ratio": 0.3849,
-      "compress_mbps": 21.92,
-      "decompress_mbps": 69.11
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 56238,
-      "ratio": 0.3698,
-      "compress_mbps": 21.46,
-      "decompress_mbps": 70.96
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 54764,
-      "ratio": 0.3601,
-      "compress_mbps": 16.16,
-      "decompress_mbps": 71.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54311,
-      "ratio": 0.3571,
-      "compress_mbps": 10.7,
-      "decompress_mbps": 71.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 54262,
-      "ratio": 0.3568,
-      "compress_mbps": 9.8,
-      "decompress_mbps": 72.02
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 54247,
-      "ratio": 0.3567,
-      "compress_mbps": 9.57,
-      "decompress_mbps": 72.02
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 54247,
-      "ratio": 0.3567,
-      "compress_mbps": 9.65,
-      "decompress_mbps": 72.57
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 56882,
-      "ratio": 0.4544,
-      "compress_mbps": 37.25,
-      "decompress_mbps": 55.92
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 52826,
-      "ratio": 0.422,
-      "compress_mbps": 23.05,
-      "decompress_mbps": 62.21
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 51625,
-      "ratio": 0.4124,
-      "compress_mbps": 22.69,
-      "decompress_mbps": 65.27
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 50034,
-      "ratio": 0.3997,
-      "compress_mbps": 22.5,
-      "decompress_mbps": 65.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 48912,
-      "ratio": 0.3907,
-      "compress_mbps": 12.62,
-      "decompress_mbps": 65.42
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48738,
-      "ratio": 0.3893,
-      "compress_mbps": 11.77,
-      "decompress_mbps": 65.61
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48719,
-      "ratio": 0.3892,
-      "compress_mbps": 9.97,
-      "decompress_mbps": 65.88
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 48716,
-      "ratio": 0.3892,
-      "compress_mbps": 9.9,
-      "decompress_mbps": 68.31
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 48716,
-      "ratio": 0.3892,
-      "compress_mbps": 12.58,
-      "decompress_mbps": 64.73
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 8988,
-      "ratio": 0.3653,
-      "compress_mbps": 36.94,
-      "decompress_mbps": 103.46
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8564,
-      "ratio": 0.3481,
-      "compress_mbps": 43.51,
-      "decompress_mbps": 102.54
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8390,
-      "ratio": 0.341,
-      "compress_mbps": 28.97,
-      "decompress_mbps": 97.31
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8167,
-      "ratio": 0.332,
-      "compress_mbps": 37.49,
-      "decompress_mbps": 98.37
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 7965,
-      "ratio": 0.3237,
-      "compress_mbps": 28.72,
-      "decompress_mbps": 88.78
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7916,
-      "ratio": 0.3217,
-      "compress_mbps": 22.76,
-      "decompress_mbps": 104.8
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7900,
-      "ratio": 0.3211,
-      "compress_mbps": 21.67,
-      "decompress_mbps": 85.25
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7900,
-      "ratio": 0.3211,
-      "compress_mbps": 20.13,
-      "decompress_mbps": 105.7
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7900,
-      "ratio": 0.3211,
-      "compress_mbps": 27.55,
-      "decompress_mbps": 92.8
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3731,
-      "ratio": 0.3346,
-      "compress_mbps": 18.9,
-      "decompress_mbps": 80.13
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3491,
-      "ratio": 0.3131,
-      "compress_mbps": 23.63,
-      "decompress_mbps": 84.66
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3384,
-      "ratio": 0.3035,
-      "compress_mbps": 22.04,
-      "decompress_mbps": 89.77
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3220,
-      "ratio": 0.2888,
-      "compress_mbps": 21.08,
-      "decompress_mbps": 86.53
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3138,
-      "ratio": 0.2814,
-      "compress_mbps": 17.11,
-      "decompress_mbps": 93.05
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3118,
-      "ratio": 0.2796,
-      "compress_mbps": 15.03,
-      "decompress_mbps": 100.03
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3116,
-      "ratio": 0.2795,
-      "compress_mbps": 14.26,
-      "decompress_mbps": 96.56
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3116,
-      "ratio": 0.2795,
-      "compress_mbps": 14.4,
-      "decompress_mbps": 104.06
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3116,
-      "ratio": 0.2795,
-      "compress_mbps": 15.81,
-      "decompress_mbps": 101.86
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1352,
-      "ratio": 0.3633,
-      "compress_mbps": 8.47,
-      "decompress_mbps": 63.54
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1287,
-      "ratio": 0.3459,
-      "compress_mbps": 11.63,
-      "decompress_mbps": 60.62
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1284,
-      "ratio": 0.3451,
-      "compress_mbps": 11.67,
-      "decompress_mbps": 62.5
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1226,
-      "ratio": 0.3295,
-      "compress_mbps": 11.31,
-      "decompress_mbps": 66.96
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1211,
-      "ratio": 0.3255,
-      "compress_mbps": 9.84,
-      "decompress_mbps": 63.24
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1211,
-      "ratio": 0.3255,
-      "compress_mbps": 10.84,
-      "decompress_mbps": 63.7
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1211,
-      "ratio": 0.3255,
-      "compress_mbps": 10.02,
-      "decompress_mbps": 64.11
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1211,
-      "ratio": 0.3255,
-      "compress_mbps": 10.74,
-      "decompress_mbps": 80.94
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1211,
-      "ratio": 0.3255,
-      "compress_mbps": 11.17,
-      "decompress_mbps": 63.88
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 245423,
-      "ratio": 0.2383,
-      "compress_mbps": 123.71,
-      "decompress_mbps": 127.4
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 229642,
-      "ratio": 0.223,
-      "compress_mbps": 92.84,
-      "decompress_mbps": 151.73
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 225678,
-      "ratio": 0.2192,
-      "compress_mbps": 109.83,
-      "decompress_mbps": 153.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 218218,
-      "ratio": 0.2119,
-      "compress_mbps": 99.82,
-      "decompress_mbps": 163.61
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 210550,
-      "ratio": 0.2045,
-      "compress_mbps": 48.7,
-      "decompress_mbps": 154.12
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 207949,
-      "ratio": 0.2019,
-      "compress_mbps": 27.88,
-      "decompress_mbps": 168.6
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 207413,
-      "ratio": 0.2014,
-      "compress_mbps": 18.82,
-      "decompress_mbps": 151.74
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 207478,
-      "ratio": 0.2015,
-      "compress_mbps": 6.77,
-      "decompress_mbps": 153.16
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 207482,
-      "ratio": 0.2015,
-      "compress_mbps": 3.56,
-      "decompress_mbps": 157.49
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 175980,
-      "ratio": 0.4124,
-      "compress_mbps": 43.31,
-      "decompress_mbps": 64.49
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 160455,
-      "ratio": 0.376,
-      "compress_mbps": 70.41,
-      "decompress_mbps": 72.33
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 156690,
-      "ratio": 0.3672,
-      "compress_mbps": 32.21,
-      "decompress_mbps": 74.1
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 149064,
-      "ratio": 0.3493,
-      "compress_mbps": 36.48,
-      "decompress_mbps": 75.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 145616,
-      "ratio": 0.3412,
-      "compress_mbps": 20.01,
-      "decompress_mbps": 76.95
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 144773,
-      "ratio": 0.3392,
-      "compress_mbps": 17.53,
-      "decompress_mbps": 76.34
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 144603,
-      "ratio": 0.3388,
-      "compress_mbps": 19.93,
-      "decompress_mbps": 75.91
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 144573,
-      "ratio": 0.3388,
-      "compress_mbps": 16.49,
-      "decompress_mbps": 80.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 144570,
-      "ratio": 0.3388,
-      "compress_mbps": 15.68,
-      "decompress_mbps": 75.93
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 228837,
-      "ratio": 0.4749,
-      "compress_mbps": 35.31,
-      "decompress_mbps": 54.63
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 211248,
-      "ratio": 0.4384,
-      "compress_mbps": 31.57,
-      "decompress_mbps": 61.56
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 205619,
-      "ratio": 0.4267,
-      "compress_mbps": 25.52,
-      "decompress_mbps": 67.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 200595,
-      "ratio": 0.4163,
-      "compress_mbps": 34.86,
-      "decompress_mbps": 66.46
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 195418,
-      "ratio": 0.4055,
-      "compress_mbps": 18.88,
-      "decompress_mbps": 65.35
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 194148,
-      "ratio": 0.4029,
-      "compress_mbps": 15.2,
-      "decompress_mbps": 66.36
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 193994,
-      "ratio": 0.4026,
-      "compress_mbps": 16.61,
-      "decompress_mbps": 66.46
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 193991,
-      "ratio": 0.4026,
-      "compress_mbps": 14.97,
-      "decompress_mbps": 65.37
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 193991,
-      "ratio": 0.4026,
-      "compress_mbps": 14.75,
-      "decompress_mbps": 80.17
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 60990,
-      "ratio": 0.1188,
-      "compress_mbps": 240.46,
-      "decompress_mbps": 173.43
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 61650,
-      "ratio": 0.1201,
-      "compress_mbps": 103.12,
-      "decompress_mbps": 188.54
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 60035,
-      "ratio": 0.117,
-      "compress_mbps": 90.48,
-      "decompress_mbps": 205.17
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 57005,
-      "ratio": 0.1111,
-      "compress_mbps": 91.56,
-      "decompress_mbps": 195.56
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 55779,
-      "ratio": 0.1087,
-      "compress_mbps": 81.64,
-      "decompress_mbps": 263.29
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 54970,
-      "ratio": 0.1071,
-      "compress_mbps": 69.16,
-      "decompress_mbps": 204.84
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 53922,
-      "ratio": 0.1051,
-      "compress_mbps": 76.91,
-      "decompress_mbps": 217.15
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 51977,
-      "ratio": 0.1013,
-      "compress_mbps": 17.63,
-      "decompress_mbps": 275.85
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 51474,
-      "ratio": 0.1003,
-      "compress_mbps": 6.71,
-      "decompress_mbps": 239.18
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 14783,
-      "ratio": 0.3866,
-      "compress_mbps": 32.71,
-      "decompress_mbps": 70.98
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 14101,
-      "ratio": 0.3688,
-      "compress_mbps": 33.16,
-      "decompress_mbps": 78.17
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13975,
-      "ratio": 0.3655,
-      "compress_mbps": 28.17,
-      "decompress_mbps": 75.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13632,
-      "ratio": 0.3565,
-      "compress_mbps": 30.93,
-      "decompress_mbps": 100.62
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13302,
-      "ratio": 0.3479,
-      "compress_mbps": 25.78,
-      "decompress_mbps": 79.98
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 13279,
-      "ratio": 0.3473,
-      "compress_mbps": 21.9,
-      "decompress_mbps": 77.99
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 13274,
-      "ratio": 0.3471,
-      "compress_mbps": 19.14,
-      "decompress_mbps": 84.74
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 13260,
-      "ratio": 0.3468,
-      "compress_mbps": 7.15,
-      "decompress_mbps": 80.47
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 13260,
-      "ratio": 0.3468,
-      "compress_mbps": 4.57,
-      "decompress_mbps": 79.18
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1862,
-      "ratio": 0.4405,
-      "compress_mbps": 9.05,
-      "decompress_mbps": 61.67
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1803,
-      "ratio": 0.4265,
-      "compress_mbps": 12.61,
-      "decompress_mbps": 58.6
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1791,
-      "ratio": 0.4237,
-      "compress_mbps": 12.87,
-      "decompress_mbps": 60.15
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1746,
-      "ratio": 0.4131,
-      "compress_mbps": 12.23,
-      "decompress_mbps": 60.76
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1725,
-      "ratio": 0.4081,
-      "compress_mbps": 10.95,
-      "decompress_mbps": 59.77
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1725,
-      "ratio": 0.4081,
-      "compress_mbps": 11.32,
-      "decompress_mbps": 59.78
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1725,
-      "ratio": 0.4081,
-      "compress_mbps": 10.98,
-      "decompress_mbps": 65.28
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1725,
-      "ratio": 0.4081,
-      "compress_mbps": 11.09,
-      "decompress_mbps": 61.29
-    },
-    {
-      "compressor": "go",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1725,
-      "ratio": 0.4081,
-      "compress_mbps": 11.55,
-      "decompress_mbps": 61.79
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 4623589,
-      "ratio": 0.4536,
-      "compress_mbps": 87.88,
-      "decompress_mbps": 121.47
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4241525,
-      "ratio": 0.4161,
-      "compress_mbps": 59.05,
-      "decompress_mbps": 124.77
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 4123202,
-      "ratio": 0.4045,
-      "compress_mbps": 61.06,
-      "decompress_mbps": 116.15
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 3985937,
-      "ratio": 0.3911,
-      "compress_mbps": 60.91,
-      "decompress_mbps": 204.23
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3883839,
-      "ratio": 0.3811,
-      "compress_mbps": 35.59,
-      "decompress_mbps": 119.76
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3860437,
-      "ratio": 0.3788,
-      "compress_mbps": 27.93,
-      "decompress_mbps": 202.6
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3857076,
-      "ratio": 0.3784,
-      "compress_mbps": 25.13,
-      "decompress_mbps": 126.89
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3856651,
-      "ratio": 0.3784,
-      "compress_mbps": 24.66,
-      "decompress_mbps": 202.36
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3856651,
-      "ratio": 0.3784,
-      "compress_mbps": 24.68,
-      "decompress_mbps": 116.01
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 21508211,
-      "ratio": 0.4199,
-      "compress_mbps": 143.1,
-      "decompress_mbps": 239.36
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 20538783,
-      "ratio": 0.401,
-      "compress_mbps": 103.18,
-      "decompress_mbps": 229.73
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 20334352,
-      "ratio": 0.397,
-      "compress_mbps": 88.51,
-      "decompress_mbps": 208.07
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19886937,
-      "ratio": 0.3883,
-      "compress_mbps": 86.76,
-      "decompress_mbps": 244.41
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 19582363,
-      "ratio": 0.3823,
-      "compress_mbps": 65.59,
-      "decompress_mbps": 239.15
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 19512479,
-      "ratio": 0.381,
-      "compress_mbps": 43.56,
-      "decompress_mbps": 220.01
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 19489160,
-      "ratio": 0.3805,
-      "compress_mbps": 32.93,
-      "decompress_mbps": 227.82
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19475109,
-      "ratio": 0.3802,
-      "compress_mbps": 18.63,
-      "decompress_mbps": 225.38
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 19476276,
-      "ratio": 0.3802,
-      "compress_mbps": 10.28,
-      "decompress_mbps": 247.36
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3967718,
-      "ratio": 0.3979,
-      "compress_mbps": 146.76,
-      "decompress_mbps": 172.01
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3773274,
-      "ratio": 0.3784,
-      "compress_mbps": 105.47,
-      "decompress_mbps": 124.64
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3670460,
-      "ratio": 0.3681,
-      "compress_mbps": 77.56,
-      "decompress_mbps": 182.34
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3655100,
-      "ratio": 0.3666,
-      "compress_mbps": 87.36,
-      "decompress_mbps": 107.18
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3620881,
-      "ratio": 0.3632,
-      "compress_mbps": 51.01,
-      "decompress_mbps": 125.34
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3606626,
-      "ratio": 0.3617,
-      "compress_mbps": 33.83,
-      "decompress_mbps": 183.58
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3605405,
-      "ratio": 0.3616,
-      "compress_mbps": 31.23,
-      "decompress_mbps": 130.79
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3601635,
-      "ratio": 0.3612,
-      "compress_mbps": 26.28,
-      "decompress_mbps": 133.31
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3601151,
-      "ratio": 0.3612,
-      "compress_mbps": 19.51,
-      "decompress_mbps": 120.72
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 4501482,
-      "ratio": 0.1342,
-      "compress_mbps": 294.72,
-      "decompress_mbps": 451.24
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 3875891,
-      "ratio": 0.1155,
-      "compress_mbps": 315.51,
-      "decompress_mbps": 356.45
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3731525,
-      "ratio": 0.1112,
-      "compress_mbps": 288.4,
-      "decompress_mbps": 372.55
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3542242,
-      "ratio": 0.1056,
-      "compress_mbps": 236.86,
-      "decompress_mbps": 484.44
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3239184,
-      "ratio": 0.0965,
-      "compress_mbps": 175.14,
-      "decompress_mbps": 539.55
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3113927,
-      "ratio": 0.0928,
-      "compress_mbps": 120.53,
-      "decompress_mbps": 330.65
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3063520,
-      "ratio": 0.0913,
-      "compress_mbps": 84.76,
-      "decompress_mbps": 331.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 2961320,
-      "ratio": 0.0883,
-      "compress_mbps": 29.61,
-      "decompress_mbps": 401.64
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 2940087,
-      "ratio": 0.0876,
-      "compress_mbps": 20.54,
-      "decompress_mbps": 474.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3462708,
-      "ratio": 0.5628,
-      "compress_mbps": 65.77,
-      "decompress_mbps": 109.92
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3327399,
-      "ratio": 0.5408,
-      "compress_mbps": 71.78,
-      "decompress_mbps": 84.48
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3297422,
-      "ratio": 0.536,
-      "compress_mbps": 66.06,
-      "decompress_mbps": 89.69
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3249485,
-      "ratio": 0.5282,
-      "compress_mbps": 64.02,
-      "decompress_mbps": 122.88
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3220046,
-      "ratio": 0.5234,
-      "compress_mbps": 49.81,
-      "decompress_mbps": 90.58
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3213239,
-      "ratio": 0.5223,
-      "compress_mbps": 43.12,
-      "decompress_mbps": 91.3
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3212009,
-      "ratio": 0.5221,
-      "compress_mbps": 39.44,
-      "decompress_mbps": 177.12
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3211575,
-      "ratio": 0.522,
-      "compress_mbps": 27.92,
-      "decompress_mbps": 92.84
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3211561,
-      "ratio": 0.522,
-      "compress_mbps": 29.68,
-      "decompress_mbps": 92.12
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 4334497,
-      "ratio": 0.4298,
-      "compress_mbps": 130.93,
-      "decompress_mbps": 133.29
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3900156,
-      "ratio": 0.3867,
-      "compress_mbps": 131.77,
-      "decompress_mbps": 116.9
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3876099,
-      "ratio": 0.3843,
-      "compress_mbps": 122.94,
-      "decompress_mbps": 133.81
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3782364,
-      "ratio": 0.375,
-      "compress_mbps": 110.84,
-      "decompress_mbps": 135.49
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3679310,
-      "ratio": 0.3648,
-      "compress_mbps": 89.42,
-      "decompress_mbps": 136.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3679424,
-      "ratio": 0.3648,
-      "compress_mbps": 87.41,
-      "decompress_mbps": 128.99
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3679163,
-      "ratio": 0.3648,
-      "compress_mbps": 83.39,
-      "decompress_mbps": 141.56
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3679169,
-      "ratio": 0.3648,
-      "compress_mbps": 82.21,
-      "decompress_mbps": 140.66
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3679169,
-      "ratio": 0.3648,
-      "compress_mbps": 81.84,
-      "decompress_mbps": 196.94
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2496363,
-      "ratio": 0.3767,
-      "compress_mbps": 96.93,
-      "decompress_mbps": 111.19
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2202601,
-      "ratio": 0.3324,
-      "compress_mbps": 92.65,
-      "decompress_mbps": 102.3
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2103089,
-      "ratio": 0.3173,
-      "compress_mbps": 49.73,
-      "decompress_mbps": 242.36
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 1999697,
-      "ratio": 0.3017,
-      "compress_mbps": 75.29,
-      "decompress_mbps": 121.18
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1892143,
-      "ratio": 0.2855,
-      "compress_mbps": 37.29,
-      "decompress_mbps": 108.65
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1838372,
-      "ratio": 0.2774,
-      "compress_mbps": 20.3,
-      "decompress_mbps": 108.77
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1828850,
-      "ratio": 0.276,
-      "compress_mbps": 15.87,
-      "decompress_mbps": 115.22
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1823159,
-      "ratio": 0.2751,
-      "compress_mbps": 12.46,
-      "decompress_mbps": 114.31
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1823159,
-      "ratio": 0.2751,
-      "compress_mbps": 12.53,
-      "decompress_mbps": 97.46
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 6447290,
-      "ratio": 0.2984,
-      "compress_mbps": 187.76,
-      "decompress_mbps": 292.5
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 6030257,
-      "ratio": 0.2791,
-      "compress_mbps": 147.85,
-      "decompress_mbps": 241.28
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5928121,
-      "ratio": 0.2744,
-      "compress_mbps": 128.5,
-      "decompress_mbps": 269.87
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5615804,
-      "ratio": 0.2599,
-      "compress_mbps": 121.57,
-      "decompress_mbps": 280.75
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5496738,
-      "ratio": 0.2544,
-      "compress_mbps": 80.22,
-      "decompress_mbps": 336.14
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5464184,
-      "ratio": 0.2529,
-      "compress_mbps": 62.73,
-      "decompress_mbps": 195.35
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5429645,
-      "ratio": 0.2513,
-      "compress_mbps": 47.93,
-      "decompress_mbps": 214.77
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5418135,
-      "ratio": 0.2508,
-      "compress_mbps": 36.65,
-      "decompress_mbps": 241.37
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5416628,
-      "ratio": 0.2507,
-      "compress_mbps": 33.67,
-      "decompress_mbps": 233.28
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5759187,
-      "ratio": 0.7942,
-      "compress_mbps": 91.27,
-      "decompress_mbps": 158.91
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5619390,
-      "ratio": 0.7749,
-      "compress_mbps": 49.54,
-      "decompress_mbps": 94.64
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5560914,
-      "ratio": 0.7668,
-      "compress_mbps": 43.81,
-      "decompress_mbps": 115.78
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5544069,
-      "ratio": 0.7645,
-      "compress_mbps": 44.58,
-      "decompress_mbps": 94.11
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5518257,
-      "ratio": 0.7609,
-      "compress_mbps": 36.73,
-      "decompress_mbps": 163.59
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5508662,
-      "ratio": 0.7596,
-      "compress_mbps": 33.77,
-      "decompress_mbps": 95.01
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5507534,
-      "ratio": 0.7595,
-      "compress_mbps": 35.09,
-      "decompress_mbps": 95.76
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5507183,
-      "ratio": 0.7594,
-      "compress_mbps": 32.41,
-      "decompress_mbps": 94.54
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5507183,
-      "ratio": 0.7594,
-      "compress_mbps": 32.5,
-      "decompress_mbps": 117.56
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 15230651,
-      "ratio": 0.3674,
-      "compress_mbps": 123.36,
-      "decompress_mbps": 184.33
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 13822040,
-      "ratio": 0.3334,
-      "compress_mbps": 96.36,
-      "decompress_mbps": 194.1
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 13397592,
-      "ratio": 0.3232,
-      "compress_mbps": 83.62,
-      "decompress_mbps": 202.34
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12759940,
-      "ratio": 0.3078,
-      "compress_mbps": 80.4,
-      "decompress_mbps": 223.21
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12274278,
-      "ratio": 0.2961,
-      "compress_mbps": 54.6,
-      "decompress_mbps": 216.16
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12131738,
-      "ratio": 0.2926,
-      "compress_mbps": 40.41,
-      "decompress_mbps": 218.2
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12060450,
-      "ratio": 0.2909,
-      "compress_mbps": 33.43,
-      "decompress_mbps": 203.45
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12036900,
-      "ratio": 0.2903,
-      "compress_mbps": 29.91,
-      "decompress_mbps": 206.04
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 12036900,
-      "ratio": 0.2903,
-      "compress_mbps": 30.01,
-      "decompress_mbps": 223.31
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6653052,
-      "ratio": 0.7851,
-      "compress_mbps": 124.38,
-      "decompress_mbps": 152.55
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6305035,
-      "ratio": 0.744,
-      "compress_mbps": 53.84,
-      "decompress_mbps": 154.18
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6302730,
-      "ratio": 0.7438,
-      "compress_mbps": 52.94,
-      "decompress_mbps": 119.64
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6299134,
-      "ratio": 0.7433,
-      "compress_mbps": 52.14,
-      "decompress_mbps": 156.45
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6289022,
-      "ratio": 0.7421,
-      "compress_mbps": 64.63,
-      "decompress_mbps": 159.21
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 6289013,
-      "ratio": 0.7421,
-      "compress_mbps": 50.64,
-      "decompress_mbps": 156.7
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 6289013,
-      "ratio": 0.7421,
-      "compress_mbps": 50.91,
-      "decompress_mbps": 165.38
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 6289012,
-      "ratio": 0.7421,
-      "compress_mbps": 64.4,
-      "decompress_mbps": 157.39
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 6289012,
-      "ratio": 0.7421,
-      "compress_mbps": 64.37,
-      "decompress_mbps": 98.54
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 989456,
-      "ratio": 0.1851,
-      "compress_mbps": 243.16,
-      "decompress_mbps": 153.25
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 839766,
-      "ratio": 0.1571,
-      "compress_mbps": 178.46,
-      "decompress_mbps": 169.75
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 800619,
-      "ratio": 0.1498,
-      "compress_mbps": 181.16,
-      "decompress_mbps": 178.28
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 776397,
-      "ratio": 0.1452,
-      "compress_mbps": 149.67,
-      "decompress_mbps": 185.03
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 712679,
-      "ratio": 0.1333,
-      "compress_mbps": 103.54,
-      "decompress_mbps": 199.06
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 683707,
-      "ratio": 0.1279,
-      "compress_mbps": 93.5,
-      "decompress_mbps": 512.66
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 668601,
-      "ratio": 0.1251,
-      "compress_mbps": 70.7,
-      "decompress_mbps": 209.33
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 659106,
-      "ratio": 0.1233,
-      "compress_mbps": 42.04,
-      "decompress_mbps": 216.57
-    },
-    {
-      "compressor": "go",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 658920,
-      "ratio": 0.1233,
-      "compress_mbps": 42.13,
-      "decompress_mbps": 256.07
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 62797,
-      "ratio": 0.4129,
-      "compress_mbps": 75.96,
-      "decompress_mbps": 132.29
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 59605,
-      "ratio": 0.3919,
-      "compress_mbps": 62.87,
-      "decompress_mbps": 131.77
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 57675,
-      "ratio": 0.3792,
-      "compress_mbps": 53.89,
-      "decompress_mbps": 124.29
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 56500,
-      "ratio": 0.3715,
-      "compress_mbps": 38.93,
-      "decompress_mbps": 131.16
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 56440,
-      "ratio": 0.3711,
-      "compress_mbps": 38.82,
-      "decompress_mbps": 130.65
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 55443,
-      "ratio": 0.3645,
-      "compress_mbps": 32.14,
-      "decompress_mbps": 146.84
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 55373,
-      "ratio": 0.3641,
-      "compress_mbps": 31.65,
-      "decompress_mbps": 130.38
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 55352,
-      "ratio": 0.3639,
-      "compress_mbps": 31.32,
-      "decompress_mbps": 136.96
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 55352,
-      "ratio": 0.3639,
-      "compress_mbps": 31.37,
-      "decompress_mbps": 135.72
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 55063,
-      "ratio": 0.4399,
-      "compress_mbps": 74.97,
-      "decompress_mbps": 117.68
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 52932,
-      "ratio": 0.4229,
-      "compress_mbps": 60.75,
-      "decompress_mbps": 116.27
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 51597,
-      "ratio": 0.4122,
-      "compress_mbps": 44.1,
-      "decompress_mbps": 116.24
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 50780,
-      "ratio": 0.4057,
-      "compress_mbps": 43.18,
-      "decompress_mbps": 120.67
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 50767,
-      "ratio": 0.4056,
-      "compress_mbps": 42.85,
-      "decompress_mbps": 122.05
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 50160,
-      "ratio": 0.4007,
-      "compress_mbps": 33.03,
-      "decompress_mbps": 128.52
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 50138,
-      "ratio": 0.4005,
-      "compress_mbps": 31.52,
-      "decompress_mbps": 124.51
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 50138,
-      "ratio": 0.4005,
-      "compress_mbps": 32.14,
-      "decompress_mbps": 125.83
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 50138,
-      "ratio": 0.4005,
-      "compress_mbps": 35.79,
-      "decompress_mbps": 124.35
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 8730,
-      "ratio": 0.3548,
-      "compress_mbps": 46.94,
-      "decompress_mbps": 123.4
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8457,
-      "ratio": 0.3437,
-      "compress_mbps": 43.65,
-      "decompress_mbps": 119.12
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8353,
-      "ratio": 0.3395,
-      "compress_mbps": 64.98,
-      "decompress_mbps": 109.7
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8301,
-      "ratio": 0.3374,
-      "compress_mbps": 42.45,
-      "decompress_mbps": 124.06
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 8212,
-      "ratio": 0.3338,
-      "compress_mbps": 58.84,
-      "decompress_mbps": 103.81
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 8172,
-      "ratio": 0.3322,
-      "compress_mbps": 48.55,
-      "decompress_mbps": 108.53
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 8171,
-      "ratio": 0.3321,
-      "compress_mbps": 50.28,
-      "decompress_mbps": 109.3
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 8171,
-      "ratio": 0.3321,
-      "compress_mbps": 49.23,
-      "decompress_mbps": 109.09
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 8171,
-      "ratio": 0.3321,
-      "compress_mbps": 53.75,
-      "decompress_mbps": 109.08
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3475,
-      "ratio": 0.3117,
-      "compress_mbps": 109.11,
-      "decompress_mbps": 96.06
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3305,
-      "ratio": 0.2964,
-      "compress_mbps": 102.67,
-      "decompress_mbps": 101.78
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3225,
-      "ratio": 0.2892,
-      "compress_mbps": 91.21,
-      "decompress_mbps": 104.25
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3192,
-      "ratio": 0.2863,
-      "compress_mbps": 100.3,
-      "decompress_mbps": 104.85
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3180,
-      "ratio": 0.2852,
-      "compress_mbps": 100.47,
-      "decompress_mbps": 98.18
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3168,
-      "ratio": 0.2841,
-      "compress_mbps": 94.55,
-      "decompress_mbps": 99.39
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3168,
-      "ratio": 0.2841,
-      "compress_mbps": 95.62,
-      "decompress_mbps": 95.6
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3168,
-      "ratio": 0.2841,
-      "compress_mbps": 91.52,
-      "decompress_mbps": 121.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3168,
-      "ratio": 0.2841,
-      "compress_mbps": 83.09,
-      "decompress_mbps": 95.05
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1275,
-      "ratio": 0.3426,
-      "compress_mbps": 59.58,
-      "decompress_mbps": 44.37
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1247,
-      "ratio": 0.3351,
-      "compress_mbps": 59.47,
-      "decompress_mbps": 52.13
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1239,
-      "ratio": 0.333,
-      "compress_mbps": 56.69,
-      "decompress_mbps": 51.11
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1238,
-      "ratio": 0.3327,
-      "compress_mbps": 58.55,
-      "decompress_mbps": 50.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1239,
-      "ratio": 0.333,
-      "compress_mbps": 48.99,
-      "decompress_mbps": 51.01
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1237,
-      "ratio": 0.3324,
-      "compress_mbps": 56.51,
-      "decompress_mbps": 50.1
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1237,
-      "ratio": 0.3324,
-      "compress_mbps": 55.71,
-      "decompress_mbps": 51.27
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1237,
-      "ratio": 0.3324,
-      "compress_mbps": 50.22,
-      "decompress_mbps": 48.37
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1237,
-      "ratio": 0.3324,
-      "compress_mbps": 55.39,
-      "decompress_mbps": 48.56
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 226284,
-      "ratio": 0.2197,
-      "compress_mbps": 113.28,
-      "decompress_mbps": 183.05
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 221369,
-      "ratio": 0.215,
-      "compress_mbps": 90.24,
-      "decompress_mbps": 255.24
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 218607,
-      "ratio": 0.2123,
-      "compress_mbps": 78.67,
-      "decompress_mbps": 187.61
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 217919,
-      "ratio": 0.2116,
-      "compress_mbps": 69.94,
-      "decompress_mbps": 195.29
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 217919,
-      "ratio": 0.2116,
-      "compress_mbps": 70.92,
-      "decompress_mbps": 195.59
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 217312,
-      "ratio": 0.211,
-      "compress_mbps": 44.09,
-      "decompress_mbps": 191.18
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 215966,
-      "ratio": 0.2097,
-      "compress_mbps": 31.15,
-      "decompress_mbps": 191.54
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 215930,
-      "ratio": 0.2097,
-      "compress_mbps": 14.32,
-      "decompress_mbps": 194.26
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 215912,
-      "ratio": 0.2097,
-      "compress_mbps": 11.1,
-      "decompress_mbps": 210.59
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 167622,
-      "ratio": 0.3928,
-      "compress_mbps": 64.39,
-      "decompress_mbps": 116.3
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 158003,
-      "ratio": 0.3702,
-      "compress_mbps": 64.34,
-      "decompress_mbps": 139.36
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 152928,
-      "ratio": 0.3584,
-      "compress_mbps": 46.67,
-      "decompress_mbps": 141.08
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 149886,
-      "ratio": 0.3512,
-      "compress_mbps": 33.71,
-      "decompress_mbps": 136.65
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 149767,
-      "ratio": 0.3509,
-      "compress_mbps": 39.31,
-      "decompress_mbps": 138
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 147818,
-      "ratio": 0.3464,
-      "compress_mbps": 33.18,
-      "decompress_mbps": 150.78
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 147733,
-      "ratio": 0.3462,
-      "compress_mbps": 32.42,
-      "decompress_mbps": 154.24
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 147709,
-      "ratio": 0.3461,
-      "compress_mbps": 32.15,
-      "decompress_mbps": 151.45
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 147705,
-      "ratio": 0.3461,
-      "compress_mbps": 32.65,
-      "decompress_mbps": 138.19
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 222866,
-      "ratio": 0.4625,
-      "compress_mbps": 58.92,
-      "decompress_mbps": 105.16
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 212925,
-      "ratio": 0.4419,
-      "compress_mbps": 49.52,
-      "decompress_mbps": 118.08
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 206913,
-      "ratio": 0.4294,
-      "compress_mbps": 40.5,
-      "decompress_mbps": 116.88
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 202875,
-      "ratio": 0.421,
-      "compress_mbps": 33.54,
-      "decompress_mbps": 111.31
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 202867,
-      "ratio": 0.421,
-      "compress_mbps": 33.57,
-      "decompress_mbps": 117.4
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 199818,
-      "ratio": 0.4147,
-      "compress_mbps": 28.4,
-      "decompress_mbps": 114.8
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 199664,
-      "ratio": 0.4144,
-      "compress_mbps": 27.76,
-      "decompress_mbps": 105.02
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 199634,
-      "ratio": 0.4143,
-      "compress_mbps": 28.19,
-      "decompress_mbps": 106.5
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 199634,
-      "ratio": 0.4143,
-      "compress_mbps": 27.99,
-      "decompress_mbps": 121
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 60580,
-      "ratio": 0.118,
-      "compress_mbps": 118.15,
-      "decompress_mbps": 253.84
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 59663,
-      "ratio": 0.1163,
-      "compress_mbps": 131.11,
-      "decompress_mbps": 295.73
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 59465,
-      "ratio": 0.1159,
-      "compress_mbps": 100.74,
-      "decompress_mbps": 295.91
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 59353,
-      "ratio": 0.1156,
-      "compress_mbps": 95.09,
-      "decompress_mbps": 302.88
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 58830,
-      "ratio": 0.1146,
-      "compress_mbps": 107.76,
-      "decompress_mbps": 221.47
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 57884,
-      "ratio": 0.1128,
-      "compress_mbps": 56.85,
-      "decompress_mbps": 285.29
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 57206,
-      "ratio": 0.1115,
-      "compress_mbps": 46.17,
-      "decompress_mbps": 299.77
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 56545,
-      "ratio": 0.1102,
-      "compress_mbps": 23.09,
-      "decompress_mbps": 280.1
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 56454,
-      "ratio": 0.11,
-      "compress_mbps": 9.11,
-      "decompress_mbps": 300.36
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 14194,
-      "ratio": 0.3712,
-      "compress_mbps": 83.27,
-      "decompress_mbps": 134.84
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 13770,
-      "ratio": 0.3601,
-      "compress_mbps": 74.14,
-      "decompress_mbps": 116.53
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13611,
-      "ratio": 0.3559,
-      "compress_mbps": 66.24,
-      "decompress_mbps": 115.38
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13534,
-      "ratio": 0.3539,
-      "compress_mbps": 61.31,
-      "decompress_mbps": 117.96
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13527,
-      "ratio": 0.3537,
-      "compress_mbps": 61.97,
-      "decompress_mbps": 148.27
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 13438,
-      "ratio": 0.3514,
-      "compress_mbps": 51.17,
-      "decompress_mbps": 142.65
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 13419,
-      "ratio": 0.3509,
-      "compress_mbps": 47.83,
-      "decompress_mbps": 125.84
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 13404,
-      "ratio": 0.3505,
-      "compress_mbps": 41.2,
-      "decompress_mbps": 118.77
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 13390,
-      "ratio": 0.3502,
-      "compress_mbps": 35.78,
-      "decompress_mbps": 116.99
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1832,
-      "ratio": 0.4334,
-      "compress_mbps": 41.01,
-      "decompress_mbps": 45
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1776,
-      "ratio": 0.4202,
-      "compress_mbps": 58.71,
-      "decompress_mbps": 64.9
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1764,
-      "ratio": 0.4173,
-      "compress_mbps": 57.37,
-      "decompress_mbps": 62.38
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1763,
-      "ratio": 0.4171,
-      "compress_mbps": 56.88,
-      "decompress_mbps": 53.28
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 59.36,
-      "decompress_mbps": 48.79
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 40.25,
-      "decompress_mbps": 47.27
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 57.06,
-      "decompress_mbps": 48.39
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 58.67,
-      "decompress_mbps": 52.39
-    },
-    {
-      "compressor": "js",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1760,
-      "ratio": 0.4164,
-      "compress_mbps": 58.3,
-      "decompress_mbps": 62.91
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 4462632,
-      "ratio": 0.4378,
-      "compress_mbps": 61.62,
-      "decompress_mbps": 170.85
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4244833,
-      "ratio": 0.4165,
-      "compress_mbps": 50.24,
-      "decompress_mbps": 201.42
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 4112285,
-      "ratio": 0.4035,
-      "compress_mbps": 42.04,
-      "decompress_mbps": 178.21
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 4020435,
-      "ratio": 0.3945,
-      "compress_mbps": 35.5,
-      "decompress_mbps": 142.52
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 4019177,
-      "ratio": 0.3943,
-      "compress_mbps": 35.31,
-      "decompress_mbps": 170.54
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3956464,
-      "ratio": 0.3882,
-      "compress_mbps": 28.75,
-      "decompress_mbps": 164.24
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3953310,
-      "ratio": 0.3879,
-      "compress_mbps": 28.47,
-      "decompress_mbps": 198.87
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3952872,
-      "ratio": 0.3878,
-      "compress_mbps": 29.08,
-      "decompress_mbps": 220.53
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3952872,
-      "ratio": 0.3878,
-      "compress_mbps": 29.21,
-      "decompress_mbps": 218.12
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 20177423,
-      "ratio": 0.3939,
-      "compress_mbps": 72.68,
-      "decompress_mbps": 209.54
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 19759467,
-      "ratio": 0.3858,
-      "compress_mbps": 63.85,
-      "decompress_mbps": 193.45
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 19583171,
-      "ratio": 0.3823,
-      "compress_mbps": 57.14,
-      "decompress_mbps": 206.47
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19479125,
-      "ratio": 0.3803,
-      "compress_mbps": 51.03,
-      "decompress_mbps": 205.14
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 19423693,
-      "ratio": 0.3792,
-      "compress_mbps": 49.13,
-      "decompress_mbps": 200.07
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 19337683,
-      "ratio": 0.3775,
-      "compress_mbps": 36.05,
-      "decompress_mbps": 188.48
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 19323922,
-      "ratio": 0.3773,
-      "compress_mbps": 29.08,
-      "decompress_mbps": 193.94
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19314797,
-      "ratio": 0.3771,
-      "compress_mbps": 19.5,
-      "decompress_mbps": 225.36
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 19312663,
-      "ratio": 0.377,
-      "compress_mbps": 11.12,
-      "decompress_mbps": 219.23
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3762978,
-      "ratio": 0.3774,
-      "compress_mbps": 78.68,
-      "decompress_mbps": 163.86
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3711615,
-      "ratio": 0.3723,
-      "compress_mbps": 68.1,
-      "decompress_mbps": 196.85
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3663131,
-      "ratio": 0.3674,
-      "compress_mbps": 57.01,
-      "decompress_mbps": 241.11
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3631512,
-      "ratio": 0.3642,
-      "compress_mbps": 49.21,
-      "decompress_mbps": 221.03
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3630867,
-      "ratio": 0.3642,
-      "compress_mbps": 48.78,
-      "decompress_mbps": 216.62
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3615953,
-      "ratio": 0.3627,
-      "compress_mbps": 37.72,
-      "decompress_mbps": 247.65
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3615518,
-      "ratio": 0.3626,
-      "compress_mbps": 35.3,
-      "decompress_mbps": 189.82
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3613845,
-      "ratio": 0.3625,
-      "compress_mbps": 30.03,
-      "decompress_mbps": 255.34
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3614283,
-      "ratio": 0.3625,
-      "compress_mbps": 26.24,
-      "decompress_mbps": 222.16
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 4418800,
-      "ratio": 0.1317,
-      "compress_mbps": 133,
-      "decompress_mbps": 338.57
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 4026774,
-      "ratio": 0.12,
-      "compress_mbps": 123.44,
-      "decompress_mbps": 339.7
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3837798,
-      "ratio": 0.1144,
-      "compress_mbps": 116.34,
-      "decompress_mbps": 370.54
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3751023,
-      "ratio": 0.1118,
-      "compress_mbps": 110.1,
-      "decompress_mbps": 361.38
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3643468,
-      "ratio": 0.1086,
-      "compress_mbps": 101.98,
-      "decompress_mbps": 371.36
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3379481,
-      "ratio": 0.1007,
-      "compress_mbps": 68.99,
-      "decompress_mbps": 366.05
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3354082,
-      "ratio": 0.1,
-      "compress_mbps": 61.49,
-      "decompress_mbps": 366.51
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 3330028,
-      "ratio": 0.0992,
-      "compress_mbps": 49.65,
-      "decompress_mbps": 396.52
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 3327482,
-      "ratio": 0.0992,
-      "compress_mbps": 37.41,
-      "decompress_mbps": 367.06
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3233790,
-      "ratio": 0.5256,
-      "compress_mbps": 52.65,
-      "decompress_mbps": 141.02
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3184644,
-      "ratio": 0.5176,
-      "compress_mbps": 48.35,
-      "decompress_mbps": 141.34
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3160521,
-      "ratio": 0.5137,
-      "compress_mbps": 44.16,
-      "decompress_mbps": 134.37
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3141929,
-      "ratio": 0.5107,
-      "compress_mbps": 40.04,
-      "decompress_mbps": 150.29
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3138514,
-      "ratio": 0.5101,
-      "compress_mbps": 39.11,
-      "decompress_mbps": 134.68
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3126843,
-      "ratio": 0.5082,
-      "compress_mbps": 32.81,
-      "decompress_mbps": 149.93
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3126796,
-      "ratio": 0.5082,
-      "compress_mbps": 30.63,
-      "decompress_mbps": 145.05
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3126322,
-      "ratio": 0.5082,
-      "compress_mbps": 27.28,
-      "decompress_mbps": 153.07
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3126286,
-      "ratio": 0.5082,
-      "compress_mbps": 23.43,
-      "decompress_mbps": 154.77
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 4076349,
-      "ratio": 0.4042,
-      "compress_mbps": 79.56,
-      "decompress_mbps": 217.72
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3914739,
-      "ratio": 0.3881,
-      "compress_mbps": 72.11,
-      "decompress_mbps": 235.6
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3845160,
-      "ratio": 0.3812,
-      "compress_mbps": 68.92,
-      "decompress_mbps": 265.95
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3822047,
-      "ratio": 0.379,
-      "compress_mbps": 65.9,
-      "decompress_mbps": 249.1
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3799472,
-      "ratio": 0.3767,
-      "compress_mbps": 60.47,
-      "decompress_mbps": 196.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3783861,
-      "ratio": 0.3752,
-      "compress_mbps": 59.24,
-      "decompress_mbps": 206.2
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3783432,
-      "ratio": 0.3751,
-      "compress_mbps": 57.5,
-      "decompress_mbps": 276.55
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3783342,
-      "ratio": 0.3751,
-      "compress_mbps": 57.79,
-      "decompress_mbps": 278.67
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3783342,
-      "ratio": 0.3751,
-      "compress_mbps": 57.86,
-      "decompress_mbps": 279.64
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2261112,
-      "ratio": 0.3412,
-      "compress_mbps": 71.4,
-      "decompress_mbps": 216.97
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2128691,
-      "ratio": 0.3212,
-      "compress_mbps": 58.57,
-      "decompress_mbps": 197.06
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2049023,
-      "ratio": 0.3092,
-      "compress_mbps": 48.53,
-      "decompress_mbps": 209.61
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 1990249,
-      "ratio": 0.3003,
-      "compress_mbps": 41.12,
-      "decompress_mbps": 207.91
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1975224,
-      "ratio": 0.298,
-      "compress_mbps": 39.61,
-      "decompress_mbps": 151.52
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1910262,
-      "ratio": 0.2882,
-      "compress_mbps": 28.21,
-      "decompress_mbps": 164.32
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1902923,
-      "ratio": 0.2871,
-      "compress_mbps": 25.04,
-      "decompress_mbps": 221.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1900964,
-      "ratio": 0.2868,
-      "compress_mbps": 23.45,
-      "decompress_mbps": 227.66
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1900958,
-      "ratio": 0.2868,
-      "compress_mbps": 24.4,
-      "decompress_mbps": 207.65
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 6016919,
-      "ratio": 0.2785,
-      "compress_mbps": 92.31,
-      "decompress_mbps": 250.38
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 5767272,
-      "ratio": 0.2669,
-      "compress_mbps": 81.02,
-      "decompress_mbps": 287.18
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5669548,
-      "ratio": 0.2624,
-      "compress_mbps": 75.87,
-      "decompress_mbps": 211.21
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5619947,
-      "ratio": 0.2601,
-      "compress_mbps": 68.8,
-      "decompress_mbps": 271.25
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5586034,
-      "ratio": 0.2585,
-      "compress_mbps": 64.77,
-      "decompress_mbps": 270.13
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5540130,
-      "ratio": 0.2564,
-      "compress_mbps": 50.72,
-      "decompress_mbps": 269.04
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5537271,
-      "ratio": 0.2563,
-      "compress_mbps": 45.58,
-      "decompress_mbps": 209.67
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5530686,
-      "ratio": 0.256,
-      "compress_mbps": 35.75,
-      "decompress_mbps": 303.18
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5529823,
-      "ratio": 0.2559,
-      "compress_mbps": 31.59,
-      "decompress_mbps": 227.31
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5602819,
-      "ratio": 0.7726,
-      "compress_mbps": 47.72,
-      "decompress_mbps": 166.89
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5504019,
-      "ratio": 0.759,
-      "compress_mbps": 42.76,
-      "decompress_mbps": 153.39
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5452816,
-      "ratio": 0.7519,
-      "compress_mbps": 38.01,
-      "decompress_mbps": 153.91
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5425752,
-      "ratio": 0.7482,
-      "compress_mbps": 35.6,
-      "decompress_mbps": 177.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5425752,
-      "ratio": 0.7482,
-      "compress_mbps": 36.17,
-      "decompress_mbps": 176.78
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5407602,
-      "ratio": 0.7457,
-      "compress_mbps": 30.72,
-      "decompress_mbps": 153.42
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5406417,
-      "ratio": 0.7455,
-      "compress_mbps": 30.08,
-      "decompress_mbps": 155.44
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5406380,
-      "ratio": 0.7455,
-      "compress_mbps": 30.76,
-      "decompress_mbps": 154.32
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5406380,
-      "ratio": 0.7455,
-      "compress_mbps": 30.68,
-      "decompress_mbps": 117.26
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 14342407,
-      "ratio": 0.3459,
-      "compress_mbps": 73.52,
-      "decompress_mbps": 197.71
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 13424966,
-      "ratio": 0.3238,
-      "compress_mbps": 63.27,
-      "decompress_mbps": 213.25
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 13061399,
-      "ratio": 0.315,
-      "compress_mbps": 56.27,
-      "decompress_mbps": 222.06
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12877207,
-      "ratio": 0.3106,
-      "compress_mbps": 49.84,
-      "decompress_mbps": 208.96
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12671090,
-      "ratio": 0.3056,
-      "compress_mbps": 47.71,
-      "decompress_mbps": 209.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12511088,
-      "ratio": 0.3018,
-      "compress_mbps": 40.67,
-      "decompress_mbps": 235.26
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12503313,
-      "ratio": 0.3016,
-      "compress_mbps": 39.02,
-      "decompress_mbps": 224.89
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12502263,
-      "ratio": 0.3016,
-      "compress_mbps": 39.56,
-      "decompress_mbps": 227.39
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 12502263,
-      "ratio": 0.3016,
-      "compress_mbps": 39.56,
-      "decompress_mbps": 225.48
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6022390,
-      "ratio": 0.7107,
-      "compress_mbps": 54.31,
-      "decompress_mbps": 145.97
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 5997124,
-      "ratio": 0.7077,
-      "compress_mbps": 48.84,
-      "decompress_mbps": 145.24
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 5979254,
-      "ratio": 0.7056,
-      "compress_mbps": 43.2,
-      "decompress_mbps": 149.3
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 5967955,
-      "ratio": 0.7042,
-      "compress_mbps": 42.03,
-      "decompress_mbps": 178.27
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 5967953,
-      "ratio": 0.7042,
-      "compress_mbps": 42.1,
-      "decompress_mbps": 155.23
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 5965386,
-      "ratio": 0.7039,
-      "compress_mbps": 41.26,
-      "decompress_mbps": 150.17
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 5965383,
-      "ratio": 0.7039,
-      "compress_mbps": 41,
-      "decompress_mbps": 152.03
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 5965383,
-      "ratio": 0.7039,
-      "compress_mbps": 40.8,
-      "decompress_mbps": 151.14
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 5965383,
-      "ratio": 0.7039,
-      "compress_mbps": 41.86,
-      "decompress_mbps": 155
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 985606,
-      "ratio": 0.1844,
-      "compress_mbps": 111.12,
-      "decompress_mbps": 305.94
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 852636,
-      "ratio": 0.1595,
-      "compress_mbps": 102.74,
-      "decompress_mbps": 250.95
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 814293,
-      "ratio": 0.1523,
-      "compress_mbps": 96.19,
-      "decompress_mbps": 221.84
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 788388,
-      "ratio": 0.1475,
-      "compress_mbps": 89.39,
-      "decompress_mbps": 250.71
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 749390,
-      "ratio": 0.1402,
-      "compress_mbps": 83.47,
-      "decompress_mbps": 304.92
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 706892,
-      "ratio": 0.1322,
-      "compress_mbps": 64.12,
-      "decompress_mbps": 266.99
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 705695,
-      "ratio": 0.132,
-      "compress_mbps": 64.27,
-      "decompress_mbps": 329.56
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 703904,
-      "ratio": 0.1317,
-      "compress_mbps": 61.16,
-      "decompress_mbps": 268.63
-    },
-    {
-      "compressor": "js",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 703900,
-      "ratio": 0.1317,
-      "compress_mbps": 60.89,
-      "decompress_mbps": 396.78
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 56099,
-      "ratio": 0.3689,
-      "compress_mbps": 88.44,
-      "decompress_mbps": 310.31
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 56099,
-      "ratio": 0.3689,
-      "compress_mbps": 87.92,
-      "decompress_mbps": 310.59
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 56099,
-      "ratio": 0.3689,
-      "compress_mbps": 88.84,
-      "decompress_mbps": 310.08
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 56099,
-      "ratio": 0.3689,
-      "compress_mbps": 88.64,
-      "decompress_mbps": 314.16
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 54531,
-      "ratio": 0.3585,
-      "compress_mbps": 55.46,
-      "decompress_mbps": 303.62
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 54068,
-      "ratio": 0.3555,
-      "compress_mbps": 42.11,
-      "decompress_mbps": 310.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 54003,
-      "ratio": 0.3551,
-      "compress_mbps": 37.45,
-      "decompress_mbps": 307.64
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 53974,
-      "ratio": 0.3549,
-      "compress_mbps": 33.15,
-      "decompress_mbps": 306.21
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 53974,
-      "ratio": 0.3549,
-      "compress_mbps": 33.03,
-      "decompress_mbps": 307.58
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 50031,
-      "ratio": 0.3997,
-      "compress_mbps": 82.91,
-      "decompress_mbps": 273.52
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 50031,
-      "ratio": 0.3997,
-      "compress_mbps": 83.46,
-      "decompress_mbps": 272.35
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 50031,
-      "ratio": 0.3997,
-      "compress_mbps": 84.13,
-      "decompress_mbps": 272.98
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 50031,
-      "ratio": 0.3997,
-      "compress_mbps": 83.95,
-      "decompress_mbps": 268.75
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 48753,
-      "ratio": 0.3895,
-      "compress_mbps": 50.79,
-      "decompress_mbps": 277.44
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 48557,
-      "ratio": 0.3879,
-      "compress_mbps": 40.8,
-      "decompress_mbps": 274.84
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 48523,
-      "ratio": 0.3876,
-      "compress_mbps": 38.65,
-      "decompress_mbps": 273.33
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 48522,
-      "ratio": 0.3876,
-      "compress_mbps": 37.86,
-      "decompress_mbps": 276.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 48522,
-      "ratio": 0.3876,
-      "compress_mbps": 37.9,
-      "decompress_mbps": 276.0
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 8182,
-      "ratio": 0.3326,
-      "compress_mbps": 164.27,
-      "decompress_mbps": 279.42
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 8182,
-      "ratio": 0.3326,
-      "compress_mbps": 172.17,
-      "decompress_mbps": 279.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 8182,
-      "ratio": 0.3326,
-      "compress_mbps": 171.79,
-      "decompress_mbps": 279.43
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8182,
-      "ratio": 0.3326,
-      "compress_mbps": 170.54,
-      "decompress_mbps": 279.22
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 7965,
-      "ratio": 0.3237,
-      "compress_mbps": 110.55,
-      "decompress_mbps": 288.06
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 7914,
-      "ratio": 0.3217,
-      "compress_mbps": 87.16,
-      "decompress_mbps": 290.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 7895,
-      "ratio": 0.3209,
-      "compress_mbps": 80.21,
-      "decompress_mbps": 290.06
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 7896,
-      "ratio": 0.3209,
-      "compress_mbps": 73.83,
-      "decompress_mbps": 287.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 7896,
-      "ratio": 0.3209,
-      "compress_mbps": 74.8,
-      "decompress_mbps": 285.58
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 3218,
-      "ratio": 0.2886,
-      "compress_mbps": 167.43,
-      "decompress_mbps": 252.93
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 3218,
-      "ratio": 0.2886,
-      "compress_mbps": 171.07,
-      "decompress_mbps": 257.31
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 3218,
-      "ratio": 0.2886,
-      "compress_mbps": 171.82,
-      "decompress_mbps": 258.29
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3218,
-      "ratio": 0.2886,
-      "compress_mbps": 166.85,
-      "decompress_mbps": 256.2
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3136,
-      "ratio": 0.2813,
-      "compress_mbps": 143.33,
-      "decompress_mbps": 259.73
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3115,
-      "ratio": 0.2794,
-      "compress_mbps": 126.88,
-      "decompress_mbps": 263.65
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 116.0,
-      "decompress_mbps": 266.62
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 105.81,
-      "decompress_mbps": 262.03
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3112,
-      "ratio": 0.2791,
-      "compress_mbps": 108.16,
-      "decompress_mbps": 263.41
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1221,
-      "ratio": 0.3281,
-      "compress_mbps": 119.04,
-      "decompress_mbps": 119.21
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1221,
-      "ratio": 0.3281,
-      "compress_mbps": 114.29,
-      "decompress_mbps": 121.57
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1221,
-      "ratio": 0.3281,
-      "compress_mbps": 111.93,
-      "decompress_mbps": 114.91
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1221,
-      "ratio": 0.3281,
-      "compress_mbps": 113.37,
-      "decompress_mbps": 116.95
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 104.47,
-      "decompress_mbps": 117.21
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 101.17,
-      "decompress_mbps": 116.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 99.01,
-      "decompress_mbps": 115.26
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 100.66,
-      "decompress_mbps": 116.17
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1207,
-      "ratio": 0.3244,
-      "compress_mbps": 100.75,
-      "decompress_mbps": 117.41
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 227063,
-      "ratio": 0.2205,
-      "compress_mbps": 226.33,
-      "decompress_mbps": 462.07
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 227063,
-      "ratio": 0.2205,
-      "compress_mbps": 232.22,
-      "decompress_mbps": 461.76
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 227063,
-      "ratio": 0.2205,
-      "compress_mbps": 226.95,
-      "decompress_mbps": 462.59
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 227063,
-      "ratio": 0.2205,
-      "compress_mbps": 231.82,
-      "decompress_mbps": 462.46
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 218313,
-      "ratio": 0.212,
-      "compress_mbps": 163.75,
-      "decompress_mbps": 447.06
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 215095,
-      "ratio": 0.2089,
-      "compress_mbps": 107.22,
-      "decompress_mbps": 448.7
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 213213,
-      "ratio": 0.2071,
-      "compress_mbps": 73.07,
-      "decompress_mbps": 450.65
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 210955,
-      "ratio": 0.2049,
-      "compress_mbps": 9.42,
-      "decompress_mbps": 452.49
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 210981,
-      "ratio": 0.2049,
-      "compress_mbps": 4.64,
-      "decompress_mbps": 454.09
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 148927,
-      "ratio": 0.349,
-      "compress_mbps": 92.55,
-      "decompress_mbps": 304.95
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 148927,
-      "ratio": 0.349,
-      "compress_mbps": 92.89,
-      "decompress_mbps": 306.86
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 148927,
-      "ratio": 0.349,
-      "compress_mbps": 92.22,
-      "decompress_mbps": 306.2
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 148927,
-      "ratio": 0.349,
-      "compress_mbps": 92.33,
-      "decompress_mbps": 304.41
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 145024,
-      "ratio": 0.3398,
-      "compress_mbps": 57.83,
-      "decompress_mbps": 305.53
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 144159,
-      "ratio": 0.3378,
-      "compress_mbps": 44.56,
-      "decompress_mbps": 304.1
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 143991,
-      "ratio": 0.3374,
-      "compress_mbps": 40.14,
-      "decompress_mbps": 306.23
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 143941,
-      "ratio": 0.3373,
-      "compress_mbps": 36.87,
-      "decompress_mbps": 306.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 143939,
-      "ratio": 0.3373,
-      "compress_mbps": 37.03,
-      "decompress_mbps": 305.69
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 200074,
-      "ratio": 0.4152,
-      "compress_mbps": 81.26,
-      "decompress_mbps": 255.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 200074,
-      "ratio": 0.4152,
-      "compress_mbps": 80.9,
-      "decompress_mbps": 255.49
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 200074,
-      "ratio": 0.4152,
-      "compress_mbps": 81.21,
-      "decompress_mbps": 255.67
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 200074,
-      "ratio": 0.4152,
-      "compress_mbps": 81.07,
-      "decompress_mbps": 256.32
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 194496,
-      "ratio": 0.4036,
-      "compress_mbps": 46.0,
-      "decompress_mbps": 247.64
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 193176,
-      "ratio": 0.4009,
-      "compress_mbps": 34.56,
-      "decompress_mbps": 253.55
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 192991,
-      "ratio": 0.4005,
-      "compress_mbps": 31.43,
-      "decompress_mbps": 250.63
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 192980,
-      "ratio": 0.4005,
-      "compress_mbps": 29.91,
-      "decompress_mbps": 251.77
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 192980,
-      "ratio": 0.4005,
-      "compress_mbps": 29.82,
-      "decompress_mbps": 253.98
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 57484,
-      "ratio": 0.112,
-      "compress_mbps": 294.39,
-      "decompress_mbps": 724.52
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 57484,
-      "ratio": 0.112,
-      "compress_mbps": 294.6,
-      "decompress_mbps": 721.16
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 57484,
-      "ratio": 0.112,
-      "compress_mbps": 294.93,
-      "decompress_mbps": 721.32
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 57484,
-      "ratio": 0.112,
-      "compress_mbps": 295.58,
-      "decompress_mbps": 727.0
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 56050,
-      "ratio": 0.1092,
-      "compress_mbps": 229.82,
-      "decompress_mbps": 759.78
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 55292,
-      "ratio": 0.1077,
-      "compress_mbps": 153.4,
-      "decompress_mbps": 778.62
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 54651,
-      "ratio": 0.1065,
-      "compress_mbps": 124.47,
-      "decompress_mbps": 790.77
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 52583,
-      "ratio": 0.1025,
-      "compress_mbps": 46.92,
-      "decompress_mbps": 823.54
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 51816,
-      "ratio": 0.101,
-      "compress_mbps": 15.63,
-      "decompress_mbps": 833.02
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 13765,
-      "ratio": 0.36,
-      "compress_mbps": 119.63,
-      "decompress_mbps": 301.35
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 13765,
-      "ratio": 0.36,
-      "compress_mbps": 118.87,
-      "decompress_mbps": 304.63
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 13765,
-      "ratio": 0.36,
-      "compress_mbps": 120.64,
-      "decompress_mbps": 303.05
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13765,
-      "ratio": 0.36,
-      "compress_mbps": 118.25,
-      "decompress_mbps": 303.27
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13290,
-      "ratio": 0.3475,
-      "compress_mbps": 89.99,
-      "decompress_mbps": 316.05
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 13258,
-      "ratio": 0.3467,
-      "compress_mbps": 68.72,
-      "decompress_mbps": 317.08
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 13246,
-      "ratio": 0.3464,
-      "compress_mbps": 57.01,
-      "decompress_mbps": 319.69
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 13236,
-      "ratio": 0.3461,
-      "compress_mbps": 25.4,
-      "decompress_mbps": 320.24
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 13233,
-      "ratio": 0.3461,
-      "compress_mbps": 16.12,
-      "decompress_mbps": 322.36
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 1742,
-      "ratio": 0.4121,
-      "compress_mbps": 95.7,
-      "decompress_mbps": 132.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 1742,
-      "ratio": 0.4121,
-      "compress_mbps": 98.31,
-      "decompress_mbps": 133.01
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 1742,
-      "ratio": 0.4121,
-      "compress_mbps": 97.54,
-      "decompress_mbps": 132.07
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 1742,
-      "ratio": 0.4121,
-      "compress_mbps": 100.39,
-      "decompress_mbps": 132.0
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 95.29,
-      "decompress_mbps": 132.31
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 95.54,
-      "decompress_mbps": 134.31
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 93.18,
-      "decompress_mbps": 133.95
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 95.09,
-      "decompress_mbps": 134.19
-    },
-    {
-      "compressor": "zig",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 1720,
-      "ratio": 0.4069,
-      "compress_mbps": 92.21,
-      "decompress_mbps": 134.59
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 3974126,
-      "ratio": 0.3899,
-      "compress_mbps": 84.07,
-      "decompress_mbps": 273.96
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 3974126,
-      "ratio": 0.3899,
-      "compress_mbps": 84.3,
-      "decompress_mbps": 273.56
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 3974126,
-      "ratio": 0.3899,
-      "compress_mbps": 83.99,
-      "decompress_mbps": 274.36
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 3974126,
-      "ratio": 0.3899,
-      "compress_mbps": 84.24,
-      "decompress_mbps": 272.3
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 3863846,
-      "ratio": 0.3791,
-      "compress_mbps": 49.03,
-      "decompress_mbps": 267.64
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3838854,
-      "ratio": 0.3766,
-      "compress_mbps": 37.71,
-      "decompress_mbps": 272.4
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3835182,
-      "ratio": 0.3763,
-      "compress_mbps": 33.64,
-      "decompress_mbps": 271.15
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3834518,
-      "ratio": 0.3762,
-      "compress_mbps": 31.63,
-      "decompress_mbps": 269.9
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3834518,
-      "ratio": 0.3762,
-      "compress_mbps": 31.46,
-      "decompress_mbps": 270.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 19877952,
-      "ratio": 0.3881,
-      "compress_mbps": 103.55,
-      "decompress_mbps": 250.87
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 19877952,
-      "ratio": 0.3881,
-      "compress_mbps": 103.76,
-      "decompress_mbps": 251.19
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 19877952,
-      "ratio": 0.3881,
-      "compress_mbps": 103.86,
-      "decompress_mbps": 251.37
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 19877952,
-      "ratio": 0.3881,
-      "compress_mbps": 103.63,
-      "decompress_mbps": 251.14
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 19578840,
-      "ratio": 0.3822,
-      "compress_mbps": 78.52,
-      "decompress_mbps": 258.92
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 19492445,
-      "ratio": 0.3806,
-      "compress_mbps": 58.0,
-      "decompress_mbps": 261.52
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 19463481,
-      "ratio": 0.38,
-      "compress_mbps": 46.5,
-      "decompress_mbps": 263.14
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 19444704,
-      "ratio": 0.3796,
-      "compress_mbps": 22.81,
-      "decompress_mbps": 262.15
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 19440748,
-      "ratio": 0.3796,
-      "compress_mbps": 13.07,
-      "decompress_mbps": 263.2
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3662279,
-      "ratio": 0.3673,
-      "compress_mbps": 112.24,
-      "decompress_mbps": 259.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3662279,
-      "ratio": 0.3673,
-      "compress_mbps": 112.65,
-      "decompress_mbps": 260.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3662279,
-      "ratio": 0.3673,
-      "compress_mbps": 111.43,
-      "decompress_mbps": 257.26
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3662279,
-      "ratio": 0.3673,
-      "compress_mbps": 112.43,
-      "decompress_mbps": 258.95
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3637736,
-      "ratio": 0.3648,
-      "compress_mbps": 65.79,
-      "decompress_mbps": 267.17
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3621530,
-      "ratio": 0.3632,
-      "compress_mbps": 46.42,
-      "decompress_mbps": 268.5
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3623924,
-      "ratio": 0.3635,
-      "compress_mbps": 42.48,
-      "decompress_mbps": 270.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3623112,
-      "ratio": 0.3634,
-      "compress_mbps": 33.07,
-      "decompress_mbps": 270.31
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3623382,
-      "ratio": 0.3634,
-      "compress_mbps": 24.87,
-      "decompress_mbps": 268.67
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 3580057,
-      "ratio": 0.1067,
-      "compress_mbps": 306.93,
-      "decompress_mbps": 882.12
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 3580057,
-      "ratio": 0.1067,
-      "compress_mbps": 309.49,
-      "decompress_mbps": 879.51
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 3580057,
-      "ratio": 0.1067,
-      "compress_mbps": 306.65,
-      "decompress_mbps": 865.76
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3580057,
-      "ratio": 0.1067,
-      "compress_mbps": 309.44,
-      "decompress_mbps": 876.41
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3268887,
-      "ratio": 0.0974,
-      "compress_mbps": 229.13,
-      "decompress_mbps": 923.49
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3131445,
-      "ratio": 0.0933,
-      "compress_mbps": 163.5,
-      "decompress_mbps": 955.29
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3080217,
-      "ratio": 0.0918,
-      "compress_mbps": 129.46,
-      "decompress_mbps": 960.33
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 2978354,
-      "ratio": 0.0888,
-      "compress_mbps": 57.16,
-      "decompress_mbps": 973.32
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 2947971,
-      "ratio": 0.0879,
-      "compress_mbps": 34.51,
-      "decompress_mbps": 973.37
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 3221973,
-      "ratio": 0.5237,
-      "compress_mbps": 72.44,
-      "decompress_mbps": 182.53
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3221973,
-      "ratio": 0.5237,
-      "compress_mbps": 72.2,
-      "decompress_mbps": 182.46
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3221973,
-      "ratio": 0.5237,
-      "compress_mbps": 72.32,
-      "decompress_mbps": 182.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3221973,
-      "ratio": 0.5237,
-      "compress_mbps": 72.36,
-      "decompress_mbps": 183.16
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3178914,
-      "ratio": 0.5167,
-      "compress_mbps": 55.82,
-      "decompress_mbps": 189.9
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3174170,
-      "ratio": 0.5159,
-      "compress_mbps": 49.39,
-      "decompress_mbps": 191.24
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3172734,
-      "ratio": 0.5157,
-      "compress_mbps": 45.82,
-      "decompress_mbps": 191.56
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3171353,
-      "ratio": 0.5155,
-      "compress_mbps": 38.64,
-      "decompress_mbps": 191.37
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3171299,
-      "ratio": 0.5155,
-      "compress_mbps": 34.82,
-      "decompress_mbps": 191.12
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 3791952,
-      "ratio": 0.376,
-      "compress_mbps": 123.34,
-      "decompress_mbps": 273.16
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 3791952,
-      "ratio": 0.376,
-      "compress_mbps": 122.2,
-      "decompress_mbps": 272.47
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 3791952,
-      "ratio": 0.376,
-      "compress_mbps": 121.33,
-      "decompress_mbps": 269.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3791952,
-      "ratio": 0.376,
-      "compress_mbps": 122.45,
-      "decompress_mbps": 274.58
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3654027,
-      "ratio": 0.3623,
-      "compress_mbps": 95.52,
-      "decompress_mbps": 276.5
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3652732,
-      "ratio": 0.3622,
-      "compress_mbps": 91.8,
-      "decompress_mbps": 276.29
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3652496,
-      "ratio": 0.3621,
-      "compress_mbps": 87.07,
-      "decompress_mbps": 275.95
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3652505,
-      "ratio": 0.3621,
-      "compress_mbps": 87.05,
-      "decompress_mbps": 277.5
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3652505,
-      "ratio": 0.3621,
-      "compress_mbps": 87.07,
-      "decompress_mbps": 276.53
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2009824,
-      "ratio": 0.3033,
-      "compress_mbps": 100.62,
-      "decompress_mbps": 354.06
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2009824,
-      "ratio": 0.3033,
-      "compress_mbps": 100.0,
-      "decompress_mbps": 353.82
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2009824,
-      "ratio": 0.3033,
-      "compress_mbps": 99.59,
-      "decompress_mbps": 351.77
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 2009824,
-      "ratio": 0.3033,
-      "compress_mbps": 99.81,
-      "decompress_mbps": 354.23
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1892183,
-      "ratio": 0.2855,
-      "compress_mbps": 53.63,
-      "decompress_mbps": 353.52
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1837957,
-      "ratio": 0.2773,
-      "compress_mbps": 30.64,
-      "decompress_mbps": 360.81
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1826603,
-      "ratio": 0.2756,
-      "compress_mbps": 24.41,
-      "decompress_mbps": 362.4
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1818702,
-      "ratio": 0.2744,
-      "compress_mbps": 16.09,
-      "decompress_mbps": 362.85
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1818702,
-      "ratio": 0.2744,
-      "compress_mbps": 15.95,
-      "decompress_mbps": 359.54
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 5633558,
-      "ratio": 0.2607,
-      "compress_mbps": 146.11,
-      "decompress_mbps": 399.24
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 5633558,
-      "ratio": 0.2607,
-      "compress_mbps": 145.88,
-      "decompress_mbps": 400.49
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 5633558,
-      "ratio": 0.2607,
-      "compress_mbps": 146.06,
-      "decompress_mbps": 396.62
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 5633558,
-      "ratio": 0.2607,
-      "compress_mbps": 144.39,
-      "decompress_mbps": 379.0
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 5501344,
-      "ratio": 0.2546,
-      "compress_mbps": 103.33,
-      "decompress_mbps": 402.09
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5464646,
-      "ratio": 0.2529,
-      "compress_mbps": 79.54,
-      "decompress_mbps": 407.14
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5429975,
-      "ratio": 0.2513,
-      "compress_mbps": 66.81,
-      "decompress_mbps": 408.73
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5419566,
-      "ratio": 0.2508,
-      "compress_mbps": 49.41,
-      "decompress_mbps": 410.08
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5417952,
-      "ratio": 0.2508,
-      "compress_mbps": 45.54,
-      "decompress_mbps": 407.63
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 5481930,
-      "ratio": 0.7559,
-      "compress_mbps": 60.47,
-      "decompress_mbps": 161.38
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 5481930,
-      "ratio": 0.7559,
-      "compress_mbps": 60.25,
-      "decompress_mbps": 161.25
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 5481930,
-      "ratio": 0.7559,
-      "compress_mbps": 60.34,
-      "decompress_mbps": 161.47
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5481930,
-      "ratio": 0.7559,
-      "compress_mbps": 60.28,
-      "decompress_mbps": 159.84
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5450496,
-      "ratio": 0.7516,
-      "compress_mbps": 46.56,
-      "decompress_mbps": 163.89
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5440281,
-      "ratio": 0.7502,
-      "compress_mbps": 42.07,
-      "decompress_mbps": 164.58
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5439077,
-      "ratio": 0.75,
-      "compress_mbps": 40.6,
-      "decompress_mbps": 164.64
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5438787,
-      "ratio": 0.75,
-      "compress_mbps": 39.98,
-      "decompress_mbps": 163.79
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5438787,
-      "ratio": 0.75,
-      "compress_mbps": 39.92,
-      "decompress_mbps": 165.07
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 12756531,
-      "ratio": 0.3077,
-      "compress_mbps": 108.43,
-      "decompress_mbps": 313.19
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 12756531,
-      "ratio": 0.3077,
-      "compress_mbps": 108.96,
-      "decompress_mbps": 316.83
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 12756531,
-      "ratio": 0.3077,
-      "compress_mbps": 108.45,
-      "decompress_mbps": 312.18
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 12756531,
-      "ratio": 0.3077,
-      "compress_mbps": 108.89,
-      "decompress_mbps": 315.83
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12238874,
-      "ratio": 0.2952,
-      "compress_mbps": 72.34,
-      "decompress_mbps": 317.65
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12086531,
-      "ratio": 0.2915,
-      "compress_mbps": 53.58,
-      "decompress_mbps": 323.18
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12020742,
-      "ratio": 0.2899,
-      "compress_mbps": 46.37,
-      "decompress_mbps": 319.97
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 11987253,
-      "ratio": 0.2891,
-      "compress_mbps": 38.17,
-      "decompress_mbps": 322.52
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 11987245,
-      "ratio": 0.2891,
-      "compress_mbps": 38.15,
-      "decompress_mbps": 319.56
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6273039,
-      "ratio": 0.7402,
-      "compress_mbps": 60.53,
-      "decompress_mbps": 146.13
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6273039,
-      "ratio": 0.7402,
-      "compress_mbps": 60.39,
-      "decompress_mbps": 146.09
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6273039,
-      "ratio": 0.7402,
-      "compress_mbps": 60.11,
-      "decompress_mbps": 146.99
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6273039,
-      "ratio": 0.7402,
-      "compress_mbps": 60.42,
-      "decompress_mbps": 146.5
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6244483,
-      "ratio": 0.7369,
-      "compress_mbps": 55.4,
-      "decompress_mbps": 148.54
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 6244482,
-      "ratio": 0.7369,
-      "compress_mbps": 55.47,
-      "decompress_mbps": 148.16
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 6244482,
-      "ratio": 0.7369,
-      "compress_mbps": 55.08,
-      "decompress_mbps": 147.42
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 6244480,
-      "ratio": 0.7369,
-      "compress_mbps": 55.49,
-      "decompress_mbps": 148.22
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 6244480,
-      "ratio": 0.7369,
-      "compress_mbps": 55.43,
-      "decompress_mbps": 147.23
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 785041,
-      "ratio": 0.1469,
-      "compress_mbps": 230.66,
-      "decompress_mbps": 673.8
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 785041,
-      "ratio": 0.1469,
-      "compress_mbps": 230.52,
-      "decompress_mbps": 670.21
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 785041,
-      "ratio": 0.1469,
-      "compress_mbps": 231.93,
-      "decompress_mbps": 669.9
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 785041,
-      "ratio": 0.1469,
-      "compress_mbps": 230.28,
-      "decompress_mbps": 671.23
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 716461,
-      "ratio": 0.134,
-      "compress_mbps": 166.09,
-      "decompress_mbps": 710.38
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 687053,
-      "ratio": 0.1285,
-      "compress_mbps": 124.29,
-      "decompress_mbps": 733.86
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 673597,
-      "ratio": 0.126,
-      "compress_mbps": 100.95,
-      "decompress_mbps": 744.02
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 662156,
-      "ratio": 0.1239,
-      "compress_mbps": 65.08,
-      "decompress_mbps": 750.21
-    },
-    {
-      "compressor": "zig",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 661610,
-      "ratio": 0.1238,
-      "compress_mbps": 61.06,
-      "decompress_mbps": 754.5
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 1,
-      "out_size": 73589,
-      "ratio": 0.4839,
-      "compress_mbps": 33.76,
-      "decompress_mbps": 57.05
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 2,
-      "out_size": 69878,
-      "ratio": 0.4595,
-      "compress_mbps": 32.08,
-      "decompress_mbps": 58.09
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 3,
-      "out_size": 66917,
-      "ratio": 0.44,
-      "compress_mbps": 26.68,
-      "decompress_mbps": 66.6
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 4,
-      "out_size": 59388,
-      "ratio": 0.3905,
-      "compress_mbps": 31.26,
-      "decompress_mbps": 80.36
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 5,
-      "out_size": 57062,
-      "ratio": 0.3752,
-      "compress_mbps": 22.77,
-      "decompress_mbps": 80.1
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 6,
-      "out_size": 55472,
-      "ratio": 0.3647,
-      "compress_mbps": 16.23,
-      "decompress_mbps": 79.12
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 7,
-      "out_size": 55265,
-      "ratio": 0.3634,
-      "compress_mbps": 14.29,
-      "decompress_mbps": 79.84
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 8,
-      "out_size": 55168,
-      "ratio": 0.3627,
-      "compress_mbps": 11.91,
-      "decompress_mbps": 78.92
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 9,
-      "out_size": 55168,
-      "ratio": 0.3627,
-      "compress_mbps": 11.93,
-      "decompress_mbps": 78.52
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 1,
-      "out_size": 64551,
-      "ratio": 0.5157,
-      "compress_mbps": 31.89,
-      "decompress_mbps": 53.82
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 2,
-      "out_size": 62089,
-      "ratio": 0.496,
-      "compress_mbps": 30.15,
-      "decompress_mbps": 57.83
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 3,
-      "out_size": 58690,
-      "ratio": 0.4688,
-      "compress_mbps": 24.34,
-      "decompress_mbps": 59.96
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 4,
-      "out_size": 53521,
-      "ratio": 0.4276,
-      "compress_mbps": 30.1,
-      "decompress_mbps": 79.96
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 5,
-      "out_size": 51677,
-      "ratio": 0.4128,
-      "compress_mbps": 20.89,
-      "decompress_mbps": 78.97
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 6,
-      "out_size": 50638,
-      "ratio": 0.4045,
-      "compress_mbps": 14.85,
-      "decompress_mbps": 82.68
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 7,
-      "out_size": 50501,
-      "ratio": 0.4034,
-      "compress_mbps": 13.53,
-      "decompress_mbps": 79.57
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 8,
-      "out_size": 50452,
-      "ratio": 0.403,
-      "compress_mbps": 12.59,
-      "decompress_mbps": 81.82
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 9,
-      "out_size": 50452,
-      "ratio": 0.403,
-      "compress_mbps": 12.59,
-      "decompress_mbps": 81.99
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 1,
-      "out_size": 9859,
-      "ratio": 0.4007,
-      "compress_mbps": 43.03,
-      "decompress_mbps": 111.15
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 2,
-      "out_size": 10473,
-      "ratio": 0.4257,
-      "compress_mbps": 47.23,
-      "decompress_mbps": 149.93
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 3,
-      "out_size": 10172,
-      "ratio": 0.4134,
-      "compress_mbps": 42.85,
-      "decompress_mbps": 148.23
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 4,
-      "out_size": 8692,
-      "ratio": 0.3533,
-      "compress_mbps": 40.47,
-      "decompress_mbps": 152.86
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 5,
-      "out_size": 8440,
-      "ratio": 0.343,
-      "compress_mbps": 36.18,
-      "decompress_mbps": 157.16
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 6,
-      "out_size": 8385,
-      "ratio": 0.3408,
-      "compress_mbps": 31.88,
-      "decompress_mbps": 158.84
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 7,
-      "out_size": 8366,
-      "ratio": 0.34,
-      "compress_mbps": 29.95,
-      "decompress_mbps": 158.95
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 8,
-      "out_size": 8367,
-      "ratio": 0.3401,
-      "compress_mbps": 28.71,
-      "decompress_mbps": 157.48
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 9,
-      "out_size": 8367,
-      "ratio": 0.3401,
-      "compress_mbps": 28.72,
-      "decompress_mbps": 156.54
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 1,
-      "out_size": 4822,
-      "ratio": 0.4325,
-      "compress_mbps": 54.35,
-      "decompress_mbps": 187.68
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 2,
-      "out_size": 4593,
-      "ratio": 0.4119,
-      "compress_mbps": 52.8,
-      "decompress_mbps": 193.41
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 3,
-      "out_size": 4381,
-      "ratio": 0.3929,
-      "compress_mbps": 49.8,
-      "decompress_mbps": 200.8
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 4,
-      "out_size": 3725,
-      "ratio": 0.3341,
-      "compress_mbps": 51.8,
-      "decompress_mbps": 202.76
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 5,
-      "out_size": 3614,
-      "ratio": 0.3241,
-      "compress_mbps": 43.83,
-      "decompress_mbps": 208.48
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 6,
-      "out_size": 3578,
-      "ratio": 0.3209,
-      "compress_mbps": 39.35,
-      "decompress_mbps": 209.91
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 7,
-      "out_size": 3572,
-      "ratio": 0.3204,
-      "compress_mbps": 36.83,
-      "decompress_mbps": 210.72
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 8,
-      "out_size": 3568,
-      "ratio": 0.32,
-      "compress_mbps": 34.7,
-      "decompress_mbps": 208.41
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 9,
-      "out_size": 3568,
-      "ratio": 0.32,
-      "compress_mbps": 33.66,
-      "decompress_mbps": 206.14
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 1,
-      "out_size": 1738,
-      "ratio": 0.4671,
-      "compress_mbps": 30.09,
-      "decompress_mbps": 176.72
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 2,
-      "out_size": 1709,
-      "ratio": 0.4593,
-      "compress_mbps": 30.1,
-      "decompress_mbps": 174.49
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 3,
-      "out_size": 1694,
-      "ratio": 0.4553,
-      "compress_mbps": 31.7,
-      "decompress_mbps": 180.35
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 4,
-      "out_size": 1458,
-      "ratio": 0.3918,
-      "compress_mbps": 29.73,
-      "decompress_mbps": 187.58
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 5,
-      "out_size": 1441,
-      "ratio": 0.3873,
-      "compress_mbps": 28.44,
-      "decompress_mbps": 189.94
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 6,
-      "out_size": 1440,
-      "ratio": 0.387,
-      "compress_mbps": 27.18,
-      "decompress_mbps": 189.99
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 7,
-      "out_size": 1440,
-      "ratio": 0.387,
-      "compress_mbps": 27.68,
-      "decompress_mbps": 190.15
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 8,
-      "out_size": 1440,
-      "ratio": 0.387,
-      "compress_mbps": 26.12,
-      "decompress_mbps": 189.99
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 9,
-      "out_size": 1440,
-      "ratio": 0.387,
-      "compress_mbps": 27.78,
-      "decompress_mbps": 191.2
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 1,
-      "out_size": 260073,
-      "ratio": 0.2526,
-      "compress_mbps": 52.45,
-      "decompress_mbps": 56.85
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 2,
-      "out_size": 296764,
-      "ratio": 0.2882,
-      "compress_mbps": 48.94,
-      "decompress_mbps": 76.97
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 3,
-      "out_size": 288989,
-      "ratio": 0.2806,
-      "compress_mbps": 37.59,
-      "decompress_mbps": 77.33
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 4,
-      "out_size": 246442,
-      "ratio": 0.2393,
-      "compress_mbps": 54.71,
-      "decompress_mbps": 83.32
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 5,
-      "out_size": 218888,
-      "ratio": 0.2126,
-      "compress_mbps": 40.79,
-      "decompress_mbps": 76.86
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 6,
-      "out_size": 217830,
-      "ratio": 0.2115,
-      "compress_mbps": 24.16,
-      "decompress_mbps": 88.24
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 7,
-      "out_size": 221437,
-      "ratio": 0.215,
-      "compress_mbps": 19.26,
-      "decompress_mbps": 86.6
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 8,
-      "out_size": 219666,
-      "ratio": 0.2133,
-      "compress_mbps": 5.49,
-      "decompress_mbps": 86.51
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 9,
-      "out_size": 219921,
-      "ratio": 0.2136,
-      "compress_mbps": 2.77,
-      "decompress_mbps": 85.35
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 1,
-      "out_size": 194588,
-      "ratio": 0.456,
-      "compress_mbps": 34.47,
-      "decompress_mbps": 51.9
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 2,
-      "out_size": 185757,
-      "ratio": 0.4353,
-      "compress_mbps": 32.92,
-      "decompress_mbps": 49.65
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 3,
-      "out_size": 175850,
-      "ratio": 0.4121,
-      "compress_mbps": 27.11,
-      "decompress_mbps": 59.21
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 4,
-      "out_size": 155951,
-      "ratio": 0.3654,
-      "compress_mbps": 31.95,
-      "decompress_mbps": 73.02
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 5,
-      "out_size": 150274,
-      "ratio": 0.3521,
-      "compress_mbps": 23.12,
-      "decompress_mbps": 71.4
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 6,
-      "out_size": 147958,
-      "ratio": 0.3467,
-      "compress_mbps": 16.73,
-      "decompress_mbps": 72.74
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 7,
-      "out_size": 147522,
-      "ratio": 0.3457,
-      "compress_mbps": 14.93,
-      "decompress_mbps": 70.21
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 8,
-      "out_size": 147331,
-      "ratio": 0.3452,
-      "compress_mbps": 13.5,
-      "decompress_mbps": 68.78
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 9,
-      "out_size": 147328,
-      "ratio": 0.3452,
-      "compress_mbps": 13.48,
-      "decompress_mbps": 70.75
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 1,
-      "out_size": 256904,
-      "ratio": 0.5331,
-      "compress_mbps": 29.73,
-      "decompress_mbps": 46.55
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 2,
-      "out_size": 245675,
-      "ratio": 0.5098,
-      "compress_mbps": 28.42,
-      "decompress_mbps": 50.05
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 3,
-      "out_size": 231519,
-      "ratio": 0.4805,
-      "compress_mbps": 22.58,
-      "decompress_mbps": 56.23
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 4,
-      "out_size": 210028,
-      "ratio": 0.4359,
-      "compress_mbps": 27.54,
-      "decompress_mbps": 64.61
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 5,
-      "out_size": 203312,
-      "ratio": 0.4219,
-      "compress_mbps": 18.52,
-      "decompress_mbps": 61.6
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 6,
-      "out_size": 199287,
-      "ratio": 0.4136,
-      "compress_mbps": 12.88,
-      "decompress_mbps": 65.73
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 7,
-      "out_size": 198474,
-      "ratio": 0.4119,
-      "compress_mbps": 11.21,
-      "decompress_mbps": 66.4
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 8,
-      "out_size": 198080,
-      "ratio": 0.4111,
-      "compress_mbps": 8.88,
-      "decompress_mbps": 65.36
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 9,
-      "out_size": 198080,
-      "ratio": 0.4111,
-      "compress_mbps": 8.84,
-      "decompress_mbps": 65.03
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 1,
-      "out_size": 71229,
-      "ratio": 0.1388,
-      "compress_mbps": 82.96,
-      "decompress_mbps": 136.59
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 2,
-      "out_size": 69946,
-      "ratio": 0.1363,
-      "compress_mbps": 78.92,
-      "decompress_mbps": 137.96
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 3,
-      "out_size": 68538,
-      "ratio": 0.1335,
-      "compress_mbps": 69.23,
-      "decompress_mbps": 151.76
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 4,
-      "out_size": 61320,
-      "ratio": 0.1195,
-      "compress_mbps": 65.87,
-      "decompress_mbps": 164.26
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 5,
-      "out_size": 59993,
-      "ratio": 0.1169,
-      "compress_mbps": 57.15,
-      "decompress_mbps": 169.1
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 6,
-      "out_size": 58637,
-      "ratio": 0.1143,
-      "compress_mbps": 41.42,
-      "decompress_mbps": 166.25
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 7,
-      "out_size": 58209,
-      "ratio": 0.1134,
-      "compress_mbps": 35.38,
-      "decompress_mbps": 173.09
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 8,
-      "out_size": 55749,
-      "ratio": 0.1086,
-      "compress_mbps": 19.35,
-      "decompress_mbps": 176.71
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 9,
-      "out_size": 54927,
-      "ratio": 0.107,
-      "compress_mbps": 7.52,
-      "decompress_mbps": 176.17
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 1,
-      "out_size": 16399,
-      "ratio": 0.4288,
-      "compress_mbps": 36.37,
-      "decompress_mbps": 86.67
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 2,
-      "out_size": 15933,
-      "ratio": 0.4167,
-      "compress_mbps": 33.72,
-      "decompress_mbps": 88.83
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 3,
-      "out_size": 15739,
-      "ratio": 0.4116,
-      "compress_mbps": 28.05,
-      "decompress_mbps": 87.94
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 4,
-      "out_size": 13834,
-      "ratio": 0.3618,
-      "compress_mbps": 31.73,
-      "decompress_mbps": 108.86
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 5,
-      "out_size": 13463,
-      "ratio": 0.3521,
-      "compress_mbps": 25.96,
-      "decompress_mbps": 111.56
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 6,
-      "out_size": 13353,
-      "ratio": 0.3492,
-      "compress_mbps": 18.86,
-      "decompress_mbps": 111.15
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 7,
-      "out_size": 13317,
-      "ratio": 0.3482,
-      "compress_mbps": 15.93,
-      "decompress_mbps": 113.26
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 8,
-      "out_size": 13255,
-      "ratio": 0.3466,
-      "compress_mbps": 8.38,
-      "decompress_mbps": 110.11
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 9,
-      "out_size": 13171,
-      "ratio": 0.3444,
-      "compress_mbps": 4.16,
-      "decompress_mbps": 114.39
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 1,
-      "out_size": 2512,
-      "ratio": 0.5943,
-      "compress_mbps": 29.63,
-      "decompress_mbps": 155.88
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 2,
-      "out_size": 2477,
-      "ratio": 0.586,
-      "compress_mbps": 29.51,
-      "decompress_mbps": 158.96
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 3,
-      "out_size": 2452,
-      "ratio": 0.5801,
-      "compress_mbps": 30.37,
-      "decompress_mbps": 157.34
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 4,
-      "out_size": 2110,
-      "ratio": 0.4992,
-      "compress_mbps": 29.99,
-      "decompress_mbps": 162.81
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 5,
-      "out_size": 2086,
-      "ratio": 0.4935,
-      "compress_mbps": 28.87,
-      "decompress_mbps": 169.5
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 6,
-      "out_size": 2086,
-      "ratio": 0.4935,
-      "compress_mbps": 28.86,
-      "decompress_mbps": 167.98
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 7,
-      "out_size": 2086,
-      "ratio": 0.4935,
-      "compress_mbps": 28.5,
-      "decompress_mbps": 169.54
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 8,
-      "out_size": 2086,
-      "ratio": 0.4935,
-      "compress_mbps": 27.54,
-      "decompress_mbps": 169.65
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 9,
-      "out_size": 2086,
-      "ratio": 0.4935,
-      "compress_mbps": 28.63,
-      "decompress_mbps": 169.5
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 1,
-      "out_size": 5183792,
-      "ratio": 0.5086,
-      "compress_mbps": 31.31,
-      "decompress_mbps": 40.47
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 2,
-      "out_size": 4956750,
-      "ratio": 0.4863,
-      "compress_mbps": 29.97,
-      "decompress_mbps": 43.45
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 3,
-      "out_size": 4644095,
-      "ratio": 0.4556,
-      "compress_mbps": 24.06,
-      "decompress_mbps": 47.94
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 4,
-      "out_size": 4178564,
-      "ratio": 0.41,
-      "compress_mbps": 29.06,
-      "decompress_mbps": 61.99
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 5,
-      "out_size": 4034632,
-      "ratio": 0.3958,
-      "compress_mbps": 19.92,
-      "decompress_mbps": 61.3
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 6,
-      "out_size": 3952244,
-      "ratio": 0.3878,
-      "compress_mbps": 13.83,
-      "decompress_mbps": 61.12
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 7,
-      "out_size": 3938822,
-      "ratio": 0.3864,
-      "compress_mbps": 12.23,
-      "decompress_mbps": 62.83
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 8,
-      "out_size": 3935171,
-      "ratio": 0.3861,
-      "compress_mbps": 10.76,
-      "decompress_mbps": 60.2
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 9,
-      "out_size": 3935171,
-      "ratio": 0.3861,
-      "compress_mbps": 10.72,
-      "decompress_mbps": 60.89
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 1,
-      "out_size": 25320013,
-      "ratio": 0.4943,
-      "compress_mbps": 31.71,
-      "decompress_mbps": 34.88
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 2,
-      "out_size": 24804084,
-      "ratio": 0.4843,
-      "compress_mbps": 30.3,
-      "decompress_mbps": 36.64
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 3,
-      "out_size": 24241121,
-      "ratio": 0.4733,
-      "compress_mbps": 25.73,
-      "decompress_mbps": 37.97
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 4,
-      "out_size": 20950547,
-      "ratio": 0.409,
-      "compress_mbps": 28.84,
-      "decompress_mbps": 44.03
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 5,
-      "out_size": 20592289,
-      "ratio": 0.402,
-      "compress_mbps": 24.29,
-      "decompress_mbps": 46.14
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 6,
-      "out_size": 20445232,
-      "ratio": 0.3992,
-      "compress_mbps": 18.69,
-      "decompress_mbps": 46.11
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 7,
-      "out_size": 20407676,
-      "ratio": 0.3984,
-      "compress_mbps": 15.95,
-      "decompress_mbps": 46.63
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 8,
-      "out_size": 20389473,
-      "ratio": 0.3981,
-      "compress_mbps": 10.13,
-      "decompress_mbps": 45.4
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 9,
-      "out_size": 20386824,
-      "ratio": 0.398,
-      "compress_mbps": 6.82,
-      "decompress_mbps": 46.45
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 3964698,
-      "ratio": 0.3976,
-      "compress_mbps": 37.98,
-      "decompress_mbps": 48.02
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 3936391,
-      "ratio": 0.3948,
-      "compress_mbps": 35.52,
-      "decompress_mbps": 47.93
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 3823540,
-      "ratio": 0.3835,
-      "compress_mbps": 27.78,
-      "decompress_mbps": 51.72
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 3799601,
-      "ratio": 0.3811,
-      "compress_mbps": 33.02,
-      "decompress_mbps": 63.69
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 3830938,
-      "ratio": 0.3842,
-      "compress_mbps": 22.58,
-      "decompress_mbps": 58.61
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 3808303,
-      "ratio": 0.382,
-      "compress_mbps": 14.79,
-      "decompress_mbps": 57.61
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3802814,
-      "ratio": 0.3814,
-      "compress_mbps": 12.14,
-      "decompress_mbps": 57.87
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3800355,
-      "ratio": 0.3812,
-      "compress_mbps": 6.76,
-      "decompress_mbps": 59.01
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3799676,
-      "ratio": 0.3811,
-      "compress_mbps": 6.05,
-      "decompress_mbps": 59.07
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 1,
-      "out_size": 4899547,
-      "ratio": 0.146,
-      "compress_mbps": 95.3,
-      "decompress_mbps": 131.63
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 2,
-      "out_size": 4587004,
-      "ratio": 0.1367,
-      "compress_mbps": 94.92,
-      "decompress_mbps": 142.96
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 3,
-      "out_size": 4229035,
-      "ratio": 0.126,
-      "compress_mbps": 90.43,
-      "decompress_mbps": 152.33
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 4,
-      "out_size": 3791322,
-      "ratio": 0.113,
-      "compress_mbps": 81.61,
-      "decompress_mbps": 160.66
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 5,
-      "out_size": 3449193,
-      "ratio": 0.1028,
-      "compress_mbps": 72.81,
-      "decompress_mbps": 168.1
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 6,
-      "out_size": 3269452,
-      "ratio": 0.0974,
-      "compress_mbps": 58.66,
-      "decompress_mbps": 173.37
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 7,
-      "out_size": 3211286,
-      "ratio": 0.0957,
-      "compress_mbps": 50.59,
-      "decompress_mbps": 173.62
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 8,
-      "out_size": 3101534,
-      "ratio": 0.0924,
-      "compress_mbps": 27.5,
-      "decompress_mbps": 174.42
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 9,
-      "out_size": 3058177,
-      "ratio": 0.0911,
-      "compress_mbps": 16.6,
-      "decompress_mbps": 177.54
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 1,
-      "out_size": 4024327,
-      "ratio": 0.6541,
-      "compress_mbps": 22.81,
-      "decompress_mbps": 29.95
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 2,
-      "out_size": 3953722,
-      "ratio": 0.6427,
-      "compress_mbps": 21.66,
-      "decompress_mbps": 30.5
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 3,
-      "out_size": 3887921,
-      "ratio": 0.632,
-      "compress_mbps": 18.47,
-      "decompress_mbps": 31.15
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 4,
-      "out_size": 3320440,
-      "ratio": 0.5397,
-      "compress_mbps": 21.3,
-      "decompress_mbps": 37.41
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 5,
-      "out_size": 3279338,
-      "ratio": 0.533,
-      "compress_mbps": 17.83,
-      "decompress_mbps": 38.07
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 6,
-      "out_size": 3254309,
-      "ratio": 0.529,
-      "compress_mbps": 14.0,
-      "decompress_mbps": 37.9
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 7,
-      "out_size": 3250139,
-      "ratio": 0.5283,
-      "compress_mbps": 12.22,
-      "decompress_mbps": 38.09
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 8,
-      "out_size": 3247018,
-      "ratio": 0.5278,
-      "compress_mbps": 10.17,
-      "decompress_mbps": 38.03
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 9,
-      "out_size": 3246865,
-      "ratio": 0.5278,
-      "compress_mbps": 9.51,
-      "decompress_mbps": 38.0
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 1,
-      "out_size": 4471091,
-      "ratio": 0.4433,
-      "compress_mbps": 34.91,
-      "decompress_mbps": 69.94
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 2,
-      "out_size": 4372105,
-      "ratio": 0.4335,
-      "compress_mbps": 33.82,
-      "decompress_mbps": 71.85
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 3,
-      "out_size": 4305270,
-      "ratio": 0.4269,
-      "compress_mbps": 30.7,
-      "decompress_mbps": 73.16
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 4,
-      "out_size": 3920495,
-      "ratio": 0.3887,
-      "compress_mbps": 30.3,
-      "decompress_mbps": 64.84
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 5,
-      "out_size": 3853177,
-      "ratio": 0.382,
-      "compress_mbps": 26.63,
-      "decompress_mbps": 63.95
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 6,
-      "out_size": 3780878,
-      "ratio": 0.3749,
-      "compress_mbps": 23.38,
-      "decompress_mbps": 64.31
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 7,
-      "out_size": 3763880,
-      "ratio": 0.3732,
-      "compress_mbps": 20.2,
-      "decompress_mbps": 72.93
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 8,
-      "out_size": 3757719,
-      "ratio": 0.3726,
-      "compress_mbps": 18.3,
-      "decompress_mbps": 73.42
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 9,
-      "out_size": 3757719,
-      "ratio": 0.3726,
-      "compress_mbps": 18.25,
-      "decompress_mbps": 72.55
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 1,
-      "out_size": 2722387,
-      "ratio": 0.4108,
-      "compress_mbps": 38.01,
-      "decompress_mbps": 64.73
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 2,
-      "out_size": 2572544,
-      "ratio": 0.3882,
-      "compress_mbps": 36.87,
-      "decompress_mbps": 70.55
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 3,
-      "out_size": 2384328,
-      "ratio": 0.3598,
-      "compress_mbps": 29.15,
-      "decompress_mbps": 78.64
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 4,
-      "out_size": 2112060,
-      "ratio": 0.3187,
-      "compress_mbps": 36.42,
-      "decompress_mbps": 85.62
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 5,
-      "out_size": 1991581,
-      "ratio": 0.3005,
-      "compress_mbps": 25.34,
-      "decompress_mbps": 91.01
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 6,
-      "out_size": 1917866,
-      "ratio": 0.2894,
-      "compress_mbps": 15.03,
-      "decompress_mbps": 90.85
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 7,
-      "out_size": 1895353,
-      "ratio": 0.286,
-      "compress_mbps": 11.08,
-      "decompress_mbps": 90.48
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 8,
-      "out_size": 1880740,
-      "ratio": 0.2838,
-      "compress_mbps": 5.59,
-      "decompress_mbps": 90.95
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 9,
-      "out_size": 1880711,
-      "ratio": 0.2838,
-      "compress_mbps": 5.56,
-      "decompress_mbps": 92.3
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 1,
-      "out_size": 7441483,
-      "ratio": 0.3444,
-      "compress_mbps": 43.78,
-      "decompress_mbps": 66.88
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 2,
-      "out_size": 7229248,
-      "ratio": 0.3346,
-      "compress_mbps": 43.14,
-      "decompress_mbps": 69.03
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 3,
-      "out_size": 7083451,
-      "ratio": 0.3278,
-      "compress_mbps": 38.92,
-      "decompress_mbps": 71.31
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 4,
-      "out_size": 6189639,
-      "ratio": 0.2865,
-      "compress_mbps": 42.2,
-      "decompress_mbps": 92.76
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 5,
-      "out_size": 6053058,
-      "ratio": 0.2802,
-      "compress_mbps": 35.08,
-      "decompress_mbps": 96.18
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 6,
-      "out_size": 5988137,
-      "ratio": 0.2771,
-      "compress_mbps": 28.51,
-      "decompress_mbps": 101.1
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 7,
-      "out_size": 5949908,
-      "ratio": 0.2754,
-      "compress_mbps": 25.19,
-      "decompress_mbps": 103.3
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 8,
-      "out_size": 5936656,
-      "ratio": 0.2748,
-      "compress_mbps": 19.22,
-      "decompress_mbps": 106.46
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 9,
-      "out_size": 5934701,
-      "ratio": 0.2747,
-      "compress_mbps": 17.98,
-      "decompress_mbps": 105.25
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 1,
-      "out_size": 6335542,
-      "ratio": 0.8736,
-      "compress_mbps": 18.44,
-      "decompress_mbps": 31.75
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 2,
-      "out_size": 6247260,
-      "ratio": 0.8615,
-      "compress_mbps": 17.59,
-      "decompress_mbps": 48.2
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 3,
-      "out_size": 6064713,
-      "ratio": 0.8363,
-      "compress_mbps": 15.15,
-      "decompress_mbps": 56.49
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 4,
-      "out_size": 5568111,
-      "ratio": 0.7678,
-      "compress_mbps": 17.55,
-      "decompress_mbps": 58.99
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 5,
-      "out_size": 5544524,
-      "ratio": 0.7646,
-      "compress_mbps": 14.42,
-      "decompress_mbps": 64.88
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 6,
-      "out_size": 5513056,
-      "ratio": 0.7602,
-      "compress_mbps": 11.94,
-      "decompress_mbps": 62.87
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 7,
-      "out_size": 5508915,
-      "ratio": 0.7596,
-      "compress_mbps": 11.32,
-      "decompress_mbps": 64.42
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 8,
-      "out_size": 5508365,
-      "ratio": 0.7596,
-      "compress_mbps": 10.52,
-      "decompress_mbps": 65.26
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 9,
-      "out_size": 5508365,
-      "ratio": 0.7596,
-      "compress_mbps": 10.57,
-      "decompress_mbps": 64.3
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 1,
-      "out_size": 16776095,
-      "ratio": 0.4046,
-      "compress_mbps": 37.73,
-      "decompress_mbps": 50.93
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 2,
-      "out_size": 16032651,
-      "ratio": 0.3867,
-      "compress_mbps": 36.24,
-      "decompress_mbps": 54.65
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 3,
-      "out_size": 15180334,
-      "ratio": 0.3662,
-      "compress_mbps": 31.28,
-      "decompress_mbps": 51.85
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 4,
-      "out_size": 13261924,
-      "ratio": 0.3199,
-      "compress_mbps": 35.24,
-      "decompress_mbps": 68.67
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 5,
-      "out_size": 12706028,
-      "ratio": 0.3065,
-      "compress_mbps": 27.63,
-      "decompress_mbps": 70.4
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 6,
-      "out_size": 12464158,
-      "ratio": 0.3006,
-      "compress_mbps": 21.0,
-      "decompress_mbps": 70.64
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 7,
-      "out_size": 12375954,
-      "ratio": 0.2985,
-      "compress_mbps": 18.31,
-      "decompress_mbps": 73.55
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 8,
-      "out_size": 12321552,
-      "ratio": 0.2972,
-      "compress_mbps": 14.45,
-      "decompress_mbps": 70.76
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 9,
-      "out_size": 12320276,
-      "ratio": 0.2972,
-      "compress_mbps": 14.41,
-      "decompress_mbps": 70.34
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 1,
-      "out_size": 6799201,
-      "ratio": 0.8023,
-      "compress_mbps": 18.34,
-      "decompress_mbps": 18.29
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 2,
-      "out_size": 6800500,
-      "ratio": 0.8025,
-      "compress_mbps": 16.95,
-      "decompress_mbps": 18.49
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 3,
-      "out_size": 6803212,
-      "ratio": 0.8028,
-      "compress_mbps": 14.91,
-      "decompress_mbps": 18.44
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 4,
-      "out_size": 6264611,
-      "ratio": 0.7393,
-      "compress_mbps": 17.32,
-      "decompress_mbps": 24.91
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 5,
-      "out_size": 6217901,
-      "ratio": 0.7337,
-      "compress_mbps": 15.76,
-      "decompress_mbps": 25.36
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 6,
-      "out_size": 6201999,
-      "ratio": 0.7319,
-      "compress_mbps": 15.32,
-      "decompress_mbps": 25.35
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 7,
-      "out_size": 6201883,
-      "ratio": 0.7319,
-      "compress_mbps": 15.24,
-      "decompress_mbps": 25.06
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 8,
-      "out_size": 6201887,
-      "ratio": 0.7319,
-      "compress_mbps": 15.22,
-      "decompress_mbps": 24.94
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 9,
-      "out_size": 6201887,
-      "ratio": 0.7319,
-      "compress_mbps": 15.3,
-      "decompress_mbps": 24.93
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 1,
-      "out_size": 1081679,
-      "ratio": 0.2024,
-      "compress_mbps": 74.26,
-      "decompress_mbps": 106.26
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 2,
-      "out_size": 1001890,
-      "ratio": 0.1874,
-      "compress_mbps": 74.05,
-      "decompress_mbps": 118.21
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 3,
-      "out_size": 921722,
-      "ratio": 0.1724,
-      "compress_mbps": 67.22,
-      "decompress_mbps": 127.75
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 4,
-      "out_size": 849263,
-      "ratio": 0.1589,
-      "compress_mbps": 64.23,
-      "decompress_mbps": 142.53
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 5,
-      "out_size": 771964,
-      "ratio": 0.1444,
-      "compress_mbps": 54.81,
-      "decompress_mbps": 144.22
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 6,
-      "out_size": 728098,
-      "ratio": 0.1362,
-      "compress_mbps": 43.49,
-      "decompress_mbps": 150.41
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 7,
-      "out_size": 713635,
-      "ratio": 0.1335,
-      "compress_mbps": 37.23,
-      "decompress_mbps": 154.84
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 8,
-      "out_size": 699093,
-      "ratio": 0.1308,
-      "compress_mbps": 27.08,
-      "decompress_mbps": 146.56
-    },
-    {
-      "compressor": "ocaml",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 9,
-      "out_size": 698459,
-      "ratio": 0.1307,
-      "compress_mbps": 25.17,
-      "decompress_mbps": 148.81
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 10,
-      "out_size": 51721,
-      "ratio": 0.3401,
-      "compress_mbps": 12.25,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 11,
-      "out_size": 51662,
-      "ratio": 0.3397,
-      "compress_mbps": 8.43,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 12,
-      "out_size": 51662,
-      "ratio": 0.3397,
-      "compress_mbps": 5.17,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 10,
-      "out_size": 46657,
-      "ratio": 0.3727,
-      "compress_mbps": 13.72,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 11,
-      "out_size": 46515,
-      "ratio": 0.3716,
-      "compress_mbps": 9.35,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 12,
-      "out_size": 46469,
-      "ratio": 0.3712,
-      "compress_mbps": 7.14,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 10,
-      "out_size": 7725,
-      "ratio": 0.314,
-      "compress_mbps": 15.97,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 11,
-      "out_size": 7727,
-      "ratio": 0.3141,
-      "compress_mbps": 10.79,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 12,
-      "out_size": 7723,
-      "ratio": 0.3139,
-      "compress_mbps": 7.17,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 10,
-      "out_size": 3026,
-      "ratio": 0.2714,
-      "compress_mbps": 17.74,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 11,
-      "out_size": 3024,
-      "ratio": 0.2712,
-      "compress_mbps": 14.13,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 12,
-      "out_size": 3024,
-      "ratio": 0.2712,
-      "compress_mbps": 10.64,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 10,
-      "out_size": 1186,
-      "ratio": 0.3187,
-      "compress_mbps": 41.49,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 11,
-      "out_size": 1186,
-      "ratio": 0.3187,
-      "compress_mbps": 33.55,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 12,
-      "out_size": 1186,
-      "ratio": 0.3187,
-      "compress_mbps": 24.35,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 10,
-      "out_size": 179347,
-      "ratio": 0.1742,
-      "compress_mbps": 30.91,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 11,
-      "out_size": 179096,
-      "ratio": 0.1739,
-      "compress_mbps": 20.04,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 12,
-      "out_size": 179049,
-      "ratio": 0.1739,
-      "compress_mbps": 15.47,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 10,
-      "out_size": 138116,
-      "ratio": 0.3236,
-      "compress_mbps": 12.77,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 11,
-      "out_size": 137923,
-      "ratio": 0.3232,
-      "compress_mbps": 8.78,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 12,
-      "out_size": 137921,
-      "ratio": 0.3232,
-      "compress_mbps": 7.43,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 10,
-      "out_size": 185328,
-      "ratio": 0.3846,
-      "compress_mbps": 12.88,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 11,
-      "out_size": 184440,
-      "ratio": 0.3828,
-      "compress_mbps": 9.1,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 12,
-      "out_size": 184371,
-      "ratio": 0.3826,
-      "compress_mbps": 5.56,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 10,
-      "out_size": 51319,
-      "ratio": 0.1,
-      "compress_mbps": 12.87,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 11,
-      "out_size": 49675,
-      "ratio": 0.0968,
-      "compress_mbps": 6.13,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 12,
-      "out_size": 49194,
-      "ratio": 0.0959,
-      "compress_mbps": 3.65,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 10,
-      "out_size": 11975,
-      "ratio": 0.3132,
-      "compress_mbps": 20.05,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 11,
-      "out_size": 11966,
-      "ratio": 0.3129,
-      "compress_mbps": 13.4,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 12,
-      "out_size": 11965,
-      "ratio": 0.3129,
-      "compress_mbps": 10.77,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 10,
-      "out_size": 1692,
-      "ratio": 0.4003,
-      "compress_mbps": 54.22,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 11,
-      "out_size": 1690,
-      "ratio": 0.3998,
-      "compress_mbps": 45.3,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 12,
-      "out_size": 1690,
-      "ratio": 0.3998,
-      "compress_mbps": 29.74,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 10,
-      "out_size": 3681797,
-      "ratio": 0.3612,
-      "compress_mbps": 12.62,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 11,
-      "out_size": 3679289,
-      "ratio": 0.361,
-      "compress_mbps": 9.26,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 12,
-      "out_size": 3679105,
-      "ratio": 0.361,
-      "compress_mbps": 7.67,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 10,
-      "out_size": 18268811,
-      "ratio": 0.3567,
-      "compress_mbps": 16.35,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 11,
-      "out_size": 18245674,
-      "ratio": 0.3562,
-      "compress_mbps": 11.71,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 12,
-      "out_size": 18241312,
-      "ratio": 0.3561,
-      "compress_mbps": 9.35,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 10,
-      "out_size": 3461494,
-      "ratio": 0.3472,
-      "compress_mbps": 18.28,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 11,
-      "out_size": 3446053,
-      "ratio": 0.3456,
-      "compress_mbps": 10.54,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 12,
-      "out_size": 3447985,
-      "ratio": 0.3458,
-      "compress_mbps": 5.38,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 10,
-      "out_size": 2782465,
-      "ratio": 0.0829,
-      "compress_mbps": 8.49,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 11,
-      "out_size": 2751857,
-      "ratio": 0.082,
-      "compress_mbps": 5.54,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 12,
-      "out_size": 2748273,
-      "ratio": 0.0819,
-      "compress_mbps": 4.07,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 10,
-      "out_size": 2995902,
-      "ratio": 0.487,
-      "compress_mbps": 19.22,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 11,
-      "out_size": 2994386,
-      "ratio": 0.4867,
-      "compress_mbps": 14.58,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 12,
-      "out_size": 2994086,
-      "ratio": 0.4867,
-      "compress_mbps": 12.48,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 10,
-      "out_size": 3608746,
-      "ratio": 0.3578,
-      "compress_mbps": 19.08,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 11,
-      "out_size": 3608161,
-      "ratio": 0.3578,
-      "compress_mbps": 14.81,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 12,
-      "out_size": 3608138,
-      "ratio": 0.3577,
-      "compress_mbps": 13.22,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 10,
-      "out_size": 1697693,
-      "ratio": 0.2562,
-      "compress_mbps": 8.9,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 11,
-      "out_size": 1696742,
-      "ratio": 0.256,
-      "compress_mbps": 6.68,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 12,
-      "out_size": 1696488,
-      "ratio": 0.256,
-      "compress_mbps": 5.74,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 10,
-      "out_size": 5137640,
-      "ratio": 0.2378,
-      "compress_mbps": 16.05,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 11,
-      "out_size": 5122694,
-      "ratio": 0.2371,
-      "compress_mbps": 9.68,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 12,
-      "out_size": 5118130,
-      "ratio": 0.2369,
-      "compress_mbps": 7.0,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 10,
-      "out_size": 5250862,
-      "ratio": 0.7241,
-      "compress_mbps": 25.53,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 11,
-      "out_size": 5250747,
-      "ratio": 0.724,
-      "compress_mbps": 20.83,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 12,
-      "out_size": 5250745,
-      "ratio": 0.724,
-      "compress_mbps": 19.39,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 10,
-      "out_size": 11526846,
-      "ratio": 0.278,
-      "compress_mbps": 10.51,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 11,
-      "out_size": 11520969,
-      "ratio": 0.2779,
-      "compress_mbps": 7.08,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 12,
-      "out_size": 11520871,
-      "ratio": 0.2779,
-      "compress_mbps": 6.12,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 10,
-      "out_size": 5748096,
-      "ratio": 0.6783,
-      "compress_mbps": 38.25,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 11,
-      "out_size": 5747172,
-      "ratio": 0.6782,
-      "compress_mbps": 29.45,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 12,
-      "out_size": 5747146,
-      "ratio": 0.6782,
-      "compress_mbps": 26.58,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 10,
-      "out_size": 637425,
-      "ratio": 0.1193,
-      "compress_mbps": 12.15,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 11,
-      "out_size": 630827,
-      "ratio": 0.118,
-      "compress_mbps": 7.32,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "libdeflate",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 12,
-      "out_size": 629349,
-      "ratio": 0.1177,
-      "compress_mbps": 4.73,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/alice29.txt",
-      "size": 152089,
-      "level": 10,
-      "out_size": 52115,
-      "ratio": 0.3427,
-      "compress_mbps": 1.82,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/asyoulik.txt",
-      "size": 125179,
-      "level": 10,
-      "out_size": 46881,
-      "ratio": 0.3745,
-      "compress_mbps": 2.08,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/cp.html",
-      "size": 24603,
-      "level": 10,
-      "out_size": 7730,
-      "ratio": 0.3142,
-      "compress_mbps": 2.53,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/fields.c",
-      "size": 11150,
-      "level": 10,
-      "out_size": 3030,
-      "ratio": 0.2717,
-      "compress_mbps": 2.44,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/grammar.lsp",
-      "size": 3721,
-      "level": 10,
-      "out_size": 1191,
-      "ratio": 0.3201,
-      "compress_mbps": 2.14,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/kennedy.xls",
-      "size": 1029744,
-      "level": 10,
-      "out_size": 178311,
-      "ratio": 0.1732,
-      "compress_mbps": 1.17,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/lcet10.txt",
-      "size": 426754,
-      "level": 10,
-      "out_size": 138684,
-      "ratio": 0.325,
-      "compress_mbps": 1.93,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/plrabn12.txt",
-      "size": 481861,
-      "level": 10,
-      "out_size": 186472,
-      "ratio": 0.387,
-      "compress_mbps": 1.79,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/ptt5",
-      "size": 513216,
-      "level": 10,
-      "out_size": 52368,
-      "ratio": 0.102,
-      "compress_mbps": 3.12,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/sum",
-      "size": 38240,
-      "level": 10,
-      "out_size": 12277,
-      "ratio": 0.3211,
-      "compress_mbps": 2.16,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "canterbury/xargs.1",
-      "size": 4227,
-      "level": 10,
-      "out_size": 1696,
-      "ratio": 0.4012,
-      "compress_mbps": 2.47,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/dickens",
-      "size": 10192446,
-      "level": 10,
-      "out_size": 3712353,
-      "ratio": 0.3642,
-      "compress_mbps": 1.8,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mozilla",
-      "size": 51220480,
-      "level": 10,
-      "out_size": 18524576,
-      "ratio": 0.3617,
-      "compress_mbps": 1.77,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 10,
-      "out_size": 3523172,
-      "ratio": 0.3534,
-      "compress_mbps": 1.86,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/nci",
-      "size": 33553445,
-      "level": 10,
-      "out_size": 2930422,
-      "ratio": 0.0873,
-      "compress_mbps": 1.68,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/ooffice",
-      "size": 6152192,
-      "level": 10,
-      "out_size": 3017814,
-      "ratio": 0.4905,
-      "compress_mbps": 2.36,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/osdb",
-      "size": 10085684,
-      "level": 10,
-      "out_size": 3647718,
-      "ratio": 0.3617,
-      "compress_mbps": 2.77,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/reymont",
-      "size": 6627202,
-      "level": 10,
-      "out_size": 1724649,
-      "ratio": 0.2602,
-      "compress_mbps": 1.18,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/samba",
-      "size": 21606400,
-      "level": 10,
-      "out_size": 5179097,
-      "ratio": 0.2397,
-      "compress_mbps": 2.22,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/sao",
-      "size": 7251944,
-      "level": 10,
-      "out_size": 5261135,
-      "ratio": 0.7255,
-      "compress_mbps": 2.52,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/webster",
-      "size": 41458703,
-      "level": 10,
-      "out_size": 11640134,
-      "ratio": 0.2808,
-      "compress_mbps": 1.62,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/x-ray",
-      "size": 8474240,
-      "level": 10,
-      "out_size": 5825680,
-      "ratio": 0.6875,
-      "compress_mbps": 3.31,
-      "decompress_mbps": null
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/xml",
-      "size": 5345280,
-      "level": 10,
-      "out_size": 643958,
-      "ratio": 0.1205,
-      "compress_mbps": 2.56,
-      "decompress_mbps": null
-    }
-  ]
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56316,
+   "ratio": 0.3703,
+   "compress_mbps": 42.23,
+   "decompress_mbps": 213.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 55646,
+   "ratio": 0.3659,
+   "compress_mbps": 38.03,
+   "decompress_mbps": 233.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 54681,
+   "ratio": 0.3595,
+   "compress_mbps": 28.99,
+   "decompress_mbps": 236.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54437,
+   "ratio": 0.3579,
+   "compress_mbps": 22.91,
+   "decompress_mbps": 238.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54348,
+   "ratio": 0.3573,
+   "compress_mbps": 19.05,
+   "decompress_mbps": 245.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54140,
+   "ratio": 0.356,
+   "compress_mbps": 16.77,
+   "decompress_mbps": 246.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54127,
+   "ratio": 0.3559,
+   "compress_mbps": 13.61,
+   "decompress_mbps": 246.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53082,
+   "ratio": 0.349,
+   "compress_mbps": 3.23,
+   "decompress_mbps": 242.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 53135,
+   "ratio": 0.4245,
+   "compress_mbps": 49.96,
+   "decompress_mbps": 180.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50187,
+   "ratio": 0.4009,
+   "compress_mbps": 38.94,
+   "decompress_mbps": 196.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49810,
+   "ratio": 0.3979,
+   "compress_mbps": 35.79,
+   "decompress_mbps": 214.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 48992,
+   "ratio": 0.3914,
+   "compress_mbps": 27.2,
+   "decompress_mbps": 217.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 23.57,
+   "decompress_mbps": 219.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48715,
+   "ratio": 0.3892,
+   "compress_mbps": 18.11,
+   "decompress_mbps": 223.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 17.17,
+   "decompress_mbps": 223.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 13.71,
+   "decompress_mbps": 224.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47620,
+   "ratio": 0.3804,
+   "compress_mbps": 3.41,
+   "decompress_mbps": 224.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8476,
+   "ratio": 0.3445,
+   "compress_mbps": 39.89,
+   "decompress_mbps": 217.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8271,
+   "ratio": 0.3362,
+   "compress_mbps": 35.22,
+   "decompress_mbps": 224.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8158,
+   "ratio": 0.3316,
+   "compress_mbps": 34.4,
+   "decompress_mbps": 229.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 7961,
+   "ratio": 0.3236,
+   "compress_mbps": 31.07,
+   "decompress_mbps": 237.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7932,
+   "ratio": 0.3224,
+   "compress_mbps": 26.45,
+   "decompress_mbps": 245.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7938,
+   "ratio": 0.3226,
+   "compress_mbps": 23.03,
+   "decompress_mbps": 246.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 22.08,
+   "decompress_mbps": 248.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 16.17,
+   "decompress_mbps": 248.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7806,
+   "ratio": 0.3173,
+   "compress_mbps": 4.14,
+   "decompress_mbps": 249.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3509,
+   "ratio": 0.3147,
+   "compress_mbps": 26.08,
+   "decompress_mbps": 151.57
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3269,
+   "ratio": 0.2932,
+   "compress_mbps": 24.14,
+   "decompress_mbps": 153.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3208,
+   "ratio": 0.2877,
+   "compress_mbps": 23.41,
+   "decompress_mbps": 157.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3141,
+   "ratio": 0.2817,
+   "compress_mbps": 21.76,
+   "decompress_mbps": 160.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 19.66,
+   "decompress_mbps": 160.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3135,
+   "ratio": 0.2812,
+   "compress_mbps": 18.05,
+   "decompress_mbps": 162.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 17.35,
+   "decompress_mbps": 162.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 11.64,
+   "decompress_mbps": 162.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3057,
+   "ratio": 0.2742,
+   "compress_mbps": 4.15,
+   "decompress_mbps": 162.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1282,
+   "ratio": 0.3445,
+   "compress_mbps": 12.51,
+   "decompress_mbps": 71.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1225,
+   "ratio": 0.3292,
+   "compress_mbps": 11.95,
+   "decompress_mbps": 72.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 11.84,
+   "decompress_mbps": 71.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 11.77,
+   "decompress_mbps": 72.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 11.43,
+   "decompress_mbps": 72.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 10.4,
+   "decompress_mbps": 72.68
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 10.4,
+   "decompress_mbps": 72.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 6.18,
+   "decompress_mbps": 72.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1205,
+   "ratio": 0.3238,
+   "compress_mbps": 3.41,
+   "decompress_mbps": 72.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 251793,
+   "ratio": 0.2445,
+   "compress_mbps": 104.94,
+   "decompress_mbps": 342.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 242565,
+   "ratio": 0.2356,
+   "compress_mbps": 78.17,
+   "decompress_mbps": 371.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 242532,
+   "ratio": 0.2355,
+   "compress_mbps": 65.23,
+   "decompress_mbps": 393.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 239804,
+   "ratio": 0.2329,
+   "compress_mbps": 60.42,
+   "decompress_mbps": 417.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 215530,
+   "ratio": 0.2093,
+   "compress_mbps": 30.01,
+   "decompress_mbps": 389.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 201414,
+   "ratio": 0.1956,
+   "compress_mbps": 20.12,
+   "decompress_mbps": 415.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 200711,
+   "ratio": 0.1949,
+   "compress_mbps": 13.12,
+   "decompress_mbps": 418.61
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 200719,
+   "ratio": 0.1949,
+   "compress_mbps": 8.16,
+   "decompress_mbps": 424.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 183445,
+   "ratio": 0.1781,
+   "compress_mbps": 2.51,
+   "decompress_mbps": 425.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 160674,
+   "ratio": 0.3765,
+   "compress_mbps": 61.26,
+   "decompress_mbps": 198.55
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 149787,
+   "ratio": 0.351,
+   "compress_mbps": 46.35,
+   "decompress_mbps": 214.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148055,
+   "ratio": 0.3469,
+   "compress_mbps": 41.66,
+   "decompress_mbps": 239.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 145631,
+   "ratio": 0.3413,
+   "compress_mbps": 31.36,
+   "decompress_mbps": 242.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145321,
+   "ratio": 0.3405,
+   "compress_mbps": 25.25,
+   "decompress_mbps": 244.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 145046,
+   "ratio": 0.3399,
+   "compress_mbps": 20.32,
+   "decompress_mbps": 249.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144554,
+   "ratio": 0.3387,
+   "compress_mbps": 18.36,
+   "decompress_mbps": 250.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144540,
+   "ratio": 0.3387,
+   "compress_mbps": 14.97,
+   "decompress_mbps": 250.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 141031,
+   "ratio": 0.3305,
+   "compress_mbps": 3.23,
+   "decompress_mbps": 251.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 212588,
+   "ratio": 0.4412,
+   "compress_mbps": 52.3,
+   "decompress_mbps": 171.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 199981,
+   "ratio": 0.415,
+   "compress_mbps": 38.93,
+   "decompress_mbps": 190.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 198551,
+   "ratio": 0.4121,
+   "compress_mbps": 35.02,
+   "decompress_mbps": 210.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 195460,
+   "ratio": 0.4056,
+   "compress_mbps": 24.59,
+   "decompress_mbps": 213.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194902,
+   "ratio": 0.4045,
+   "compress_mbps": 20.74,
+   "decompress_mbps": 212.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195177,
+   "ratio": 0.405,
+   "compress_mbps": 17.65,
+   "decompress_mbps": 216.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194385,
+   "ratio": 0.4034,
+   "compress_mbps": 15.79,
+   "decompress_mbps": 216.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194380,
+   "ratio": 0.4034,
+   "compress_mbps": 12.97,
+   "decompress_mbps": 216.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 190711,
+   "ratio": 0.3958,
+   "compress_mbps": 2.98,
+   "decompress_mbps": 216.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60161,
+   "ratio": 0.1172,
+   "compress_mbps": 160.01,
+   "decompress_mbps": 465.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 58873,
+   "ratio": 0.1147,
+   "compress_mbps": 123.86,
+   "decompress_mbps": 497.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58327,
+   "ratio": 0.1137,
+   "compress_mbps": 108.63,
+   "decompress_mbps": 536.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 55673,
+   "ratio": 0.1085,
+   "compress_mbps": 76.13,
+   "decompress_mbps": 458.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 54950,
+   "ratio": 0.1071,
+   "compress_mbps": 51.19,
+   "decompress_mbps": 488.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55259,
+   "ratio": 0.1077,
+   "compress_mbps": 36.24,
+   "decompress_mbps": 534.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53713,
+   "ratio": 0.1047,
+   "compress_mbps": 26.75,
+   "decompress_mbps": 567.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52897,
+   "ratio": 0.1031,
+   "compress_mbps": 18.69,
+   "decompress_mbps": 612.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52729,
+   "ratio": 0.1027,
+   "compress_mbps": 4.73,
+   "decompress_mbps": 628.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14249,
+   "ratio": 0.3726,
+   "compress_mbps": 29.56,
+   "decompress_mbps": 183.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13825,
+   "ratio": 0.3615,
+   "compress_mbps": 27.04,
+   "decompress_mbps": 188.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13751,
+   "ratio": 0.3596,
+   "compress_mbps": 26.18,
+   "decompress_mbps": 191.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13366,
+   "ratio": 0.3495,
+   "compress_mbps": 23.31,
+   "decompress_mbps": 199.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13346,
+   "ratio": 0.349,
+   "compress_mbps": 20.1,
+   "decompress_mbps": 208.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13040,
+   "ratio": 0.341,
+   "compress_mbps": 9.47,
+   "decompress_mbps": 214.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13035,
+   "ratio": 0.3409,
+   "compress_mbps": 8.57,
+   "decompress_mbps": 215.68
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13028,
+   "ratio": 0.3407,
+   "compress_mbps": 6.1,
+   "decompress_mbps": 218.11
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12522,
+   "ratio": 0.3275,
+   "compress_mbps": 3.54,
+   "decompress_mbps": 217.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1800,
+   "ratio": 0.4258,
+   "compress_mbps": 13.91,
+   "decompress_mbps": 77.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 13.36,
+   "decompress_mbps": 76.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 13.31,
+   "decompress_mbps": 77.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 13.06,
+   "decompress_mbps": 78.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 12.8,
+   "decompress_mbps": 78.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 11.23,
+   "decompress_mbps": 78.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 11.3,
+   "decompress_mbps": 78.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 6.81,
+   "decompress_mbps": 79.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1708,
+   "ratio": 0.4041,
+   "compress_mbps": 3.9,
+   "decompress_mbps": 78.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65130,
+   "ratio": 0.4282,
+   "compress_mbps": 118.84,
+   "decompress_mbps": 399.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62270,
+   "ratio": 0.4094,
+   "compress_mbps": 101.78,
+   "decompress_mbps": 418.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 59488,
+   "ratio": 0.3911,
+   "compress_mbps": 67.0,
+   "decompress_mbps": 435.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 57679,
+   "ratio": 0.3792,
+   "compress_mbps": 71.67,
+   "decompress_mbps": 414.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55616,
+   "ratio": 0.3657,
+   "compress_mbps": 41.81,
+   "decompress_mbps": 408.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54398,
+   "ratio": 0.3577,
+   "compress_mbps": 25.53,
+   "decompress_mbps": 421.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54253,
+   "ratio": 0.3567,
+   "compress_mbps": 21.45,
+   "decompress_mbps": 423.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 16.99,
+   "decompress_mbps": 425.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 16.98,
+   "decompress_mbps": 423.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56791,
+   "ratio": 0.4537,
+   "compress_mbps": 115.6,
+   "decompress_mbps": 394.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54652,
+   "ratio": 0.4366,
+   "compress_mbps": 97.78,
+   "decompress_mbps": 407.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 52663,
+   "ratio": 0.4207,
+   "compress_mbps": 62.36,
+   "decompress_mbps": 428.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 51266,
+   "ratio": 0.4095,
+   "compress_mbps": 67.4,
+   "decompress_mbps": 398.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49622,
+   "ratio": 0.3964,
+   "compress_mbps": 37.32,
+   "decompress_mbps": 386.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 395.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48801,
+   "ratio": 0.3898,
+   "compress_mbps": 20.02,
+   "decompress_mbps": 397.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.15,
+   "decompress_mbps": 395.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.14,
+   "decompress_mbps": 399.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9028,
+   "ratio": 0.3669,
+   "compress_mbps": 414.75,
+   "decompress_mbps": 1058.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8811,
+   "ratio": 0.3581,
+   "compress_mbps": 218.08,
+   "decompress_mbps": 1085.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8616,
+   "ratio": 0.3502,
+   "compress_mbps": 163.26,
+   "decompress_mbps": 1104.41
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8219,
+   "ratio": 0.3341,
+   "compress_mbps": 116.35,
+   "decompress_mbps": 1113.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8001,
+   "ratio": 0.3252,
+   "compress_mbps": 84.93,
+   "decompress_mbps": 1146.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7955,
+   "ratio": 0.3233,
+   "compress_mbps": 68.91,
+   "decompress_mbps": 1156.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7933,
+   "ratio": 0.3224,
+   "compress_mbps": 62.88,
+   "decompress_mbps": 1159.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.08,
+   "decompress_mbps": 1161.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.09,
+   "decompress_mbps": 1160.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3647,
+   "ratio": 0.3271,
+   "compress_mbps": 426.79,
+   "decompress_mbps": 1073.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3501,
+   "ratio": 0.314,
+   "compress_mbps": 408.84,
+   "decompress_mbps": 1117.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3393,
+   "ratio": 0.3043,
+   "compress_mbps": 338.35,
+   "decompress_mbps": 1147.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3215,
+   "ratio": 0.2883,
+   "compress_mbps": 271.93,
+   "decompress_mbps": 1175.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3140,
+   "ratio": 0.2816,
+   "compress_mbps": 205.2,
+   "decompress_mbps": 1205.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 154.1,
+   "decompress_mbps": 1215.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 131.87,
+   "decompress_mbps": 1216.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.18,
+   "decompress_mbps": 1216.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 110.92,
+   "decompress_mbps": 1220.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1326,
+   "ratio": 0.3564,
+   "compress_mbps": 317.29,
+   "decompress_mbps": 787.88
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1306,
+   "ratio": 0.351,
+   "compress_mbps": 310.71,
+   "decompress_mbps": 796.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1301,
+   "ratio": 0.3496,
+   "compress_mbps": 291.04,
+   "decompress_mbps": 799.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 233.69,
+   "decompress_mbps": 825.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 198.9,
+   "decompress_mbps": 831.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 177.77,
+   "decompress_mbps": 832.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 170.71,
+   "decompress_mbps": 821.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 167.8,
+   "decompress_mbps": 826.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 168.26,
+   "decompress_mbps": 828.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 242293,
+   "ratio": 0.2353,
+   "compress_mbps": 261.91,
+   "decompress_mbps": 834.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 233553,
+   "ratio": 0.2268,
+   "compress_mbps": 248.46,
+   "decompress_mbps": 990.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 228222,
+   "ratio": 0.2216,
+   "compress_mbps": 195.71,
+   "decompress_mbps": 1047.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 223668,
+   "ratio": 0.2172,
+   "compress_mbps": 177.25,
+   "decompress_mbps": 1079.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 205994,
+   "ratio": 0.2,
+   "compress_mbps": 110.7,
+   "decompress_mbps": 1038.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 203986,
+   "ratio": 0.1981,
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1033.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207681,
+   "ratio": 0.2017,
+   "compress_mbps": 37.08,
+   "decompress_mbps": 1027.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 206827,
+   "ratio": 0.2009,
+   "compress_mbps": 7.29,
+   "decompress_mbps": 1001.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207023,
+   "ratio": 0.201,
+   "compress_mbps": 3.43,
+   "decompress_mbps": 1007.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 174124,
+   "ratio": 0.408,
+   "compress_mbps": 124.52,
+   "decompress_mbps": 403.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 166150,
+   "ratio": 0.3893,
+   "compress_mbps": 105.75,
+   "decompress_mbps": 410.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 158784,
+   "ratio": 0.3721,
+   "compress_mbps": 70.62,
+   "decompress_mbps": 431.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 152782,
+   "ratio": 0.358,
+   "compress_mbps": 74.37,
+   "decompress_mbps": 417.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147196,
+   "ratio": 0.3449,
+   "compress_mbps": 43.69,
+   "decompress_mbps": 412.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144898,
+   "ratio": 0.3395,
+   "compress_mbps": 26.54,
+   "decompress_mbps": 422.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144589,
+   "ratio": 0.3388,
+   "compress_mbps": 23.0,
+   "decompress_mbps": 422.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144436,
+   "ratio": 0.3385,
+   "compress_mbps": 19.77,
+   "decompress_mbps": 426.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144433,
+   "ratio": 0.3384,
+   "compress_mbps": 19.7,
+   "decompress_mbps": 427.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228883,
+   "ratio": 0.475,
+   "compress_mbps": 108.85,
+   "decompress_mbps": 379.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 219047,
+   "ratio": 0.4546,
+   "compress_mbps": 91.35,
+   "decompress_mbps": 396.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 209408,
+   "ratio": 0.4346,
+   "compress_mbps": 55.73,
+   "decompress_mbps": 408.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 205916,
+   "ratio": 0.4273,
+   "compress_mbps": 62.79,
+   "decompress_mbps": 384.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199188,
+   "ratio": 0.4134,
+   "compress_mbps": 33.23,
+   "decompress_mbps": 365.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195255,
+   "ratio": 0.4052,
+   "compress_mbps": 19.51,
+   "decompress_mbps": 371.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194657,
+   "ratio": 0.404,
+   "compress_mbps": 16.52,
+   "decompress_mbps": 368.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 13.04,
+   "decompress_mbps": 372.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 13.03,
+   "decompress_mbps": 376.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 65553,
+   "ratio": 0.1277,
+   "compress_mbps": 277.05,
+   "decompress_mbps": 898.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 63891,
+   "ratio": 0.1245,
+   "compress_mbps": 249.81,
+   "decompress_mbps": 925.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 62515,
+   "ratio": 0.1218,
+   "compress_mbps": 196.22,
+   "decompress_mbps": 996.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 58451,
+   "ratio": 0.1139,
+   "compress_mbps": 170.56,
+   "decompress_mbps": 705.74
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 57410,
+   "ratio": 0.1119,
+   "compress_mbps": 131.27,
+   "decompress_mbps": 733.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 56459,
+   "ratio": 0.11,
+   "compress_mbps": 77.73,
+   "decompress_mbps": 785.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55358,
+   "ratio": 0.1079,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 824.41
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52991,
+   "ratio": 0.1033,
+   "compress_mbps": 27.8,
+   "decompress_mbps": 878.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52215,
+   "ratio": 0.1017,
+   "compress_mbps": 9.91,
+   "decompress_mbps": 892.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14112,
+   "ratio": 0.369,
+   "compress_mbps": 130.36,
+   "decompress_mbps": 944.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13815,
+   "ratio": 0.3613,
+   "compress_mbps": 110.11,
+   "decompress_mbps": 978.68
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13795,
+   "ratio": 0.3607,
+   "compress_mbps": 79.64,
+   "decompress_mbps": 1014.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13375,
+   "ratio": 0.3498,
+   "compress_mbps": 81.09,
+   "decompress_mbps": 997.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13062,
+   "ratio": 0.3416,
+   "compress_mbps": 56.15,
+   "decompress_mbps": 1040.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12984,
+   "ratio": 0.3395,
+   "compress_mbps": 33.24,
+   "decompress_mbps": 1062.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12949,
+   "ratio": 0.3386,
+   "compress_mbps": 25.62,
+   "decompress_mbps": 1070.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12894,
+   "ratio": 0.3372,
+   "compress_mbps": 11.1,
+   "decompress_mbps": 1080.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12832,
+   "ratio": 0.3356,
+   "compress_mbps": 5.1,
+   "decompress_mbps": 1081.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1846,
+   "ratio": 0.4367,
+   "compress_mbps": 290.31,
+   "decompress_mbps": 710.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1820,
+   "ratio": 0.4306,
+   "compress_mbps": 284.39,
+   "decompress_mbps": 723.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1808,
+   "ratio": 0.4277,
+   "compress_mbps": 272.54,
+   "decompress_mbps": 726.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1749,
+   "ratio": 0.4138,
+   "compress_mbps": 226.28,
+   "decompress_mbps": 749.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 202.59,
+   "decompress_mbps": 753.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 199.81,
+   "decompress_mbps": 754.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 196.62,
+   "decompress_mbps": 753.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.1,
+   "decompress_mbps": 754.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.89,
+   "decompress_mbps": 752.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 76470,
+   "ratio": 0.5028,
+   "compress_mbps": 156.81,
+   "decompress_mbps": 442.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62765,
+   "ratio": 0.4127,
+   "compress_mbps": 133.14,
+   "decompress_mbps": 491.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57162,
+   "ratio": 0.3758,
+   "compress_mbps": 72.46,
+   "decompress_mbps": 549.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56826,
+   "ratio": 0.3736,
+   "compress_mbps": 64.54,
+   "decompress_mbps": 540.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55696,
+   "ratio": 0.3662,
+   "compress_mbps": 46.93,
+   "decompress_mbps": 528.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54440,
+   "ratio": 0.3579,
+   "compress_mbps": 26.59,
+   "decompress_mbps": 545.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54283,
+   "ratio": 0.3569,
+   "compress_mbps": 22.46,
+   "decompress_mbps": 546.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54221,
+   "ratio": 0.3565,
+   "compress_mbps": 19.77,
+   "decompress_mbps": 546.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54217,
+   "ratio": 0.3565,
+   "compress_mbps": 19.52,
+   "decompress_mbps": 546.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64926,
+   "ratio": 0.5187,
+   "compress_mbps": 150.76,
+   "decompress_mbps": 420.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54985,
+   "ratio": 0.4393,
+   "compress_mbps": 124.87,
+   "decompress_mbps": 468.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51148,
+   "ratio": 0.4086,
+   "compress_mbps": 67.28,
+   "decompress_mbps": 536.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50599,
+   "ratio": 0.4042,
+   "compress_mbps": 59.25,
+   "decompress_mbps": 526.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49775,
+   "ratio": 0.3976,
+   "compress_mbps": 42.72,
+   "decompress_mbps": 513.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48967,
+   "ratio": 0.3912,
+   "compress_mbps": 25.03,
+   "decompress_mbps": 524.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48870,
+   "ratio": 0.3904,
+   "compress_mbps": 22.21,
+   "decompress_mbps": 523.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.95,
+   "decompress_mbps": 522.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.95,
+   "decompress_mbps": 524.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 10024,
+   "ratio": 0.4074,
+   "compress_mbps": 568.72,
+   "decompress_mbps": 906.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8577,
+   "ratio": 0.3486,
+   "compress_mbps": 269.07,
+   "decompress_mbps": 929.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8168,
+   "ratio": 0.332,
+   "compress_mbps": 155.49,
+   "decompress_mbps": 951.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8069,
+   "ratio": 0.328,
+   "compress_mbps": 116.17,
+   "decompress_mbps": 969.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7997,
+   "ratio": 0.325,
+   "compress_mbps": 100.13,
+   "decompress_mbps": 1001.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7952,
+   "ratio": 0.3232,
+   "compress_mbps": 74.99,
+   "decompress_mbps": 1003.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 72.24,
+   "decompress_mbps": 1009.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 71.2,
+   "decompress_mbps": 1009.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 70.94,
+   "decompress_mbps": 1010.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4061,
+   "ratio": 0.3642,
+   "compress_mbps": 505.27,
+   "decompress_mbps": 857.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3446,
+   "ratio": 0.3091,
+   "compress_mbps": 303.09,
+   "decompress_mbps": 902.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3201,
+   "ratio": 0.2871,
+   "compress_mbps": 235.32,
+   "decompress_mbps": 933.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 196.56,
+   "decompress_mbps": 955.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3139,
+   "ratio": 0.2815,
+   "compress_mbps": 162.35,
+   "decompress_mbps": 979.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 116.87,
+   "decompress_mbps": 990.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 106.87,
+   "decompress_mbps": 991.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.44,
+   "decompress_mbps": 992.11
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.35,
+   "decompress_mbps": 992.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1410,
+   "ratio": 0.3789,
+   "compress_mbps": 365.35,
+   "decompress_mbps": 595.71
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1262,
+   "ratio": 0.3392,
+   "compress_mbps": 234.59,
+   "decompress_mbps": 602.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 206.3,
+   "decompress_mbps": 606.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 178.27,
+   "decompress_mbps": 624.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 163.31,
+   "decompress_mbps": 633.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.91,
+   "decompress_mbps": 631.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.05,
+   "decompress_mbps": 632.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.52,
+   "decompress_mbps": 634.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.39,
+   "decompress_mbps": 634.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 274412,
+   "ratio": 0.2665,
+   "compress_mbps": 452.12,
+   "decompress_mbps": 796.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 213239,
+   "ratio": 0.2071,
+   "compress_mbps": 274.72,
+   "decompress_mbps": 895.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 232107,
+   "ratio": 0.2254,
+   "compress_mbps": 137.22,
+   "decompress_mbps": 936.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 202733,
+   "ratio": 0.1969,
+   "compress_mbps": 130.42,
+   "decompress_mbps": 942.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 207803,
+   "ratio": 0.2018,
+   "compress_mbps": 84.44,
+   "decompress_mbps": 954.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 205270,
+   "ratio": 0.1993,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 981.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 209951,
+   "ratio": 0.2039,
+   "compress_mbps": 19.33,
+   "decompress_mbps": 997.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 209656,
+   "ratio": 0.2036,
+   "compress_mbps": 12.25,
+   "decompress_mbps": 1008.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 209189,
+   "ratio": 0.2031,
+   "compress_mbps": 8.96,
+   "decompress_mbps": 1009.49
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 208640,
+   "ratio": 0.4889,
+   "compress_mbps": 157.34,
+   "decompress_mbps": 424.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 167329,
+   "ratio": 0.3921,
+   "compress_mbps": 138.54,
+   "decompress_mbps": 464.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 151097,
+   "ratio": 0.3541,
+   "compress_mbps": 73.57,
+   "decompress_mbps": 510.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 150035,
+   "ratio": 0.3516,
+   "compress_mbps": 66.59,
+   "decompress_mbps": 511.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147375,
+   "ratio": 0.3453,
+   "compress_mbps": 48.11,
+   "decompress_mbps": 508.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144908,
+   "ratio": 0.3396,
+   "compress_mbps": 28.06,
+   "decompress_mbps": 519.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144562,
+   "ratio": 0.3387,
+   "compress_mbps": 24.64,
+   "decompress_mbps": 517.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144449,
+   "ratio": 0.3385,
+   "compress_mbps": 22.41,
+   "decompress_mbps": 518.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144438,
+   "ratio": 0.3385,
+   "compress_mbps": 22.31,
+   "decompress_mbps": 518.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 264549,
+   "ratio": 0.549,
+   "compress_mbps": 135.43,
+   "decompress_mbps": 376.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 223724,
+   "ratio": 0.4643,
+   "compress_mbps": 118.93,
+   "decompress_mbps": 422.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 204825,
+   "ratio": 0.4251,
+   "compress_mbps": 60.63,
+   "decompress_mbps": 478.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 203945,
+   "ratio": 0.4232,
+   "compress_mbps": 53.94,
+   "decompress_mbps": 474.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199780,
+   "ratio": 0.4146,
+   "compress_mbps": 37.91,
+   "decompress_mbps": 457.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195417,
+   "ratio": 0.4055,
+   "compress_mbps": 21.2,
+   "decompress_mbps": 468.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194796,
+   "ratio": 0.4043,
+   "compress_mbps": 17.9,
+   "decompress_mbps": 467.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194543,
+   "ratio": 0.4037,
+   "compress_mbps": 15.72,
+   "decompress_mbps": 467.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194460,
+   "ratio": 0.4036,
+   "compress_mbps": 15.05,
+   "decompress_mbps": 468.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 67436,
+   "ratio": 0.1314,
+   "compress_mbps": 627.54,
+   "decompress_mbps": 1004.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59257,
+   "ratio": 0.1155,
+   "compress_mbps": 278.61,
+   "decompress_mbps": 1060.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58316,
+   "ratio": 0.1136,
+   "compress_mbps": 181.72,
+   "decompress_mbps": 1145.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 56291,
+   "ratio": 0.1097,
+   "compress_mbps": 185.03,
+   "decompress_mbps": 1154.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56220,
+   "ratio": 0.1095,
+   "compress_mbps": 146.23,
+   "decompress_mbps": 1207.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55972,
+   "ratio": 0.1091,
+   "compress_mbps": 74.5,
+   "decompress_mbps": 1263.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55121,
+   "ratio": 0.1074,
+   "compress_mbps": 52.14,
+   "decompress_mbps": 1305.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 54124,
+   "ratio": 0.1055,
+   "compress_mbps": 36.7,
+   "decompress_mbps": 1378.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 53699,
+   "ratio": 0.1046,
+   "compress_mbps": 28.66,
+   "decompress_mbps": 1411.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 15612,
+   "ratio": 0.4083,
+   "compress_mbps": 502.51,
+   "decompress_mbps": 850.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14133,
+   "ratio": 0.3696,
+   "compress_mbps": 145.19,
+   "decompress_mbps": 890.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13341,
+   "ratio": 0.3489,
+   "compress_mbps": 88.72,
+   "decompress_mbps": 911.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13289,
+   "ratio": 0.3475,
+   "compress_mbps": 83.64,
+   "decompress_mbps": 941.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13052,
+   "ratio": 0.3413,
+   "compress_mbps": 66.83,
+   "decompress_mbps": 973.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12996,
+   "ratio": 0.3399,
+   "compress_mbps": 37.14,
+   "decompress_mbps": 986.7
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12972,
+   "ratio": 0.3392,
+   "compress_mbps": 27.2,
+   "decompress_mbps": 990.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12951,
+   "ratio": 0.3387,
+   "compress_mbps": 19.04,
+   "decompress_mbps": 996.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12933,
+   "ratio": 0.3382,
+   "compress_mbps": 14.86,
+   "decompress_mbps": 1010.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1988,
+   "ratio": 0.4703,
+   "compress_mbps": 340.18,
+   "decompress_mbps": 548.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1802,
+   "ratio": 0.4263,
+   "compress_mbps": 218.94,
+   "decompress_mbps": 554.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 205.58,
+   "decompress_mbps": 558.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 171.81,
+   "decompress_mbps": 573.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 167.66,
+   "decompress_mbps": 582.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.66,
+   "decompress_mbps": 582.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.44,
+   "decompress_mbps": 580.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 167.1,
+   "decompress_mbps": 579.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.8,
+   "decompress_mbps": 579.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 59790,
+   "ratio": 0.3931,
+   "compress_mbps": 262.72,
+   "decompress_mbps": 1002.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 57173,
+   "ratio": 0.3759,
+   "compress_mbps": 181.24,
+   "decompress_mbps": 1076.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56189,
+   "ratio": 0.3694,
+   "compress_mbps": 150.83,
+   "decompress_mbps": 1150.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 55816,
+   "ratio": 0.367,
+   "compress_mbps": 138.22,
+   "decompress_mbps": 1189.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54758,
+   "ratio": 0.36,
+   "compress_mbps": 109.12,
+   "decompress_mbps": 1241.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54220,
+   "ratio": 0.3565,
+   "compress_mbps": 84.01,
+   "decompress_mbps": 1281.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 53801,
+   "ratio": 0.3537,
+   "compress_mbps": 61.34,
+   "decompress_mbps": 1284.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53573,
+   "ratio": 0.3522,
+   "compress_mbps": 38.99,
+   "decompress_mbps": 1281.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53546,
+   "ratio": 0.3521,
+   "compress_mbps": 34.49,
+   "decompress_mbps": 1286.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 52276,
+   "ratio": 0.4176,
+   "compress_mbps": 244.27,
+   "decompress_mbps": 941.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50534,
+   "ratio": 0.4037,
+   "compress_mbps": 169.26,
+   "decompress_mbps": 994.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49919,
+   "ratio": 0.3988,
+   "compress_mbps": 142.29,
+   "decompress_mbps": 1056.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49715,
+   "ratio": 0.3972,
+   "compress_mbps": 131.62,
+   "decompress_mbps": 1092.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48735,
+   "ratio": 0.3893,
+   "compress_mbps": 101.28,
+   "decompress_mbps": 1138.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48422,
+   "ratio": 0.3868,
+   "compress_mbps": 79.56,
+   "decompress_mbps": 1159.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48249,
+   "ratio": 0.3854,
+   "compress_mbps": 61.42,
+   "decompress_mbps": 1167.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 47977,
+   "ratio": 0.3833,
+   "compress_mbps": 43.01,
+   "decompress_mbps": 1163.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47971,
+   "ratio": 0.3832,
+   "compress_mbps": 41.05,
+   "decompress_mbps": 1168.97
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 694.12,
+   "decompress_mbps": 956.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8380,
+   "ratio": 0.3406,
+   "compress_mbps": 439.72,
+   "decompress_mbps": 974.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8286,
+   "ratio": 0.3368,
+   "compress_mbps": 403.73,
+   "decompress_mbps": 993.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8163,
+   "ratio": 0.3318,
+   "compress_mbps": 378.68,
+   "decompress_mbps": 1003.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8053,
+   "ratio": 0.3273,
+   "compress_mbps": 335.07,
+   "decompress_mbps": 1027.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7986,
+   "ratio": 0.3246,
+   "compress_mbps": 277.67,
+   "decompress_mbps": 1035.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7954,
+   "ratio": 0.3233,
+   "compress_mbps": 191.05,
+   "decompress_mbps": 1026.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 129.56,
+   "decompress_mbps": 1035.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 125.42,
+   "decompress_mbps": 1013.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3401,
+   "ratio": 0.305,
+   "compress_mbps": 586.93,
+   "decompress_mbps": 768.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3307,
+   "ratio": 0.2966,
+   "compress_mbps": 398.24,
+   "decompress_mbps": 792.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3242,
+   "ratio": 0.2908,
+   "compress_mbps": 371.5,
+   "decompress_mbps": 810.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3205,
+   "ratio": 0.2874,
+   "compress_mbps": 349.62,
+   "decompress_mbps": 821.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3150,
+   "ratio": 0.2825,
+   "compress_mbps": 313.81,
+   "decompress_mbps": 837.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3126,
+   "ratio": 0.2804,
+   "compress_mbps": 267.83,
+   "decompress_mbps": 842.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3106,
+   "ratio": 0.2786,
+   "compress_mbps": 206.71,
+   "decompress_mbps": 846.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 147.91,
+   "decompress_mbps": 842.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 140.39,
+   "decompress_mbps": 846.34
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1251,
+   "ratio": 0.3362,
+   "compress_mbps": 377.39,
+   "decompress_mbps": 426.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 267.66,
+   "decompress_mbps": 433.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 258.72,
+   "decompress_mbps": 433.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 253.94,
+   "decompress_mbps": 439.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 240.44,
+   "decompress_mbps": 443.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 222.65,
+   "decompress_mbps": 441.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 203.53,
+   "decompress_mbps": 438.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.68,
+   "decompress_mbps": 444.08
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.88,
+   "decompress_mbps": 438.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 221813,
+   "ratio": 0.2154,
+   "compress_mbps": 593.83,
+   "decompress_mbps": 1009.94
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 199825,
+   "ratio": 0.1941,
+   "compress_mbps": 409.25,
+   "decompress_mbps": 1460.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 195675,
+   "ratio": 0.19,
+   "compress_mbps": 283.23,
+   "decompress_mbps": 1526.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 195664,
+   "ratio": 0.19,
+   "compress_mbps": 279.77,
+   "decompress_mbps": 1536.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 198900,
+   "ratio": 0.1932,
+   "compress_mbps": 239.94,
+   "decompress_mbps": 1127.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 199347,
+   "ratio": 0.1936,
+   "compress_mbps": 204.69,
+   "decompress_mbps": 1130.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 199777,
+   "ratio": 0.194,
+   "compress_mbps": 123.53,
+   "decompress_mbps": 1190.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 182094,
+   "ratio": 0.1768,
+   "compress_mbps": 25.66,
+   "decompress_mbps": 1169.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 181451,
+   "ratio": 0.1762,
+   "compress_mbps": 13.61,
+   "decompress_mbps": 1173.47
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 159063,
+   "ratio": 0.3727,
+   "compress_mbps": 263.86,
+   "decompress_mbps": 1029.34
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 152115,
+   "ratio": 0.3564,
+   "compress_mbps": 187.44,
+   "decompress_mbps": 1105.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 149162,
+   "ratio": 0.3495,
+   "compress_mbps": 156.82,
+   "decompress_mbps": 1189.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148359,
+   "ratio": 0.3476,
+   "compress_mbps": 142.61,
+   "decompress_mbps": 1033.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145353,
+   "ratio": 0.3406,
+   "compress_mbps": 113.35,
+   "decompress_mbps": 997.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144209,
+   "ratio": 0.3379,
+   "compress_mbps": 87.48,
+   "decompress_mbps": 1037.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143604,
+   "ratio": 0.3365,
+   "compress_mbps": 66.64,
+   "decompress_mbps": 1039.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 142086,
+   "ratio": 0.3329,
+   "compress_mbps": 44.24,
+   "decompress_mbps": 1035.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 142027,
+   "ratio": 0.3328,
+   "compress_mbps": 40.46,
+   "decompress_mbps": 1038.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 210662,
+   "ratio": 0.4372,
+   "compress_mbps": 228.71,
+   "decompress_mbps": 869.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 202881,
+   "ratio": 0.421,
+   "compress_mbps": 158.66,
+   "decompress_mbps": 939.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200409,
+   "ratio": 0.4159,
+   "compress_mbps": 132.96,
+   "decompress_mbps": 1019.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 199678,
+   "ratio": 0.4144,
+   "compress_mbps": 122.96,
+   "decompress_mbps": 839.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195798,
+   "ratio": 0.4063,
+   "compress_mbps": 93.4,
+   "decompress_mbps": 789.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194029,
+   "ratio": 0.4027,
+   "compress_mbps": 71.6,
+   "decompress_mbps": 813.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192773,
+   "ratio": 0.4001,
+   "compress_mbps": 50.41,
+   "decompress_mbps": 835.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 191739,
+   "ratio": 0.3979,
+   "compress_mbps": 33.69,
+   "decompress_mbps": 841.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 191676,
+   "ratio": 0.3978,
+   "compress_mbps": 31.1,
+   "decompress_mbps": 839.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 58079,
+   "ratio": 0.1132,
+   "compress_mbps": 373.38,
+   "decompress_mbps": 1687.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57838,
+   "ratio": 0.1127,
+   "compress_mbps": 413.69,
+   "decompress_mbps": 1800.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57554,
+   "ratio": 0.1121,
+   "compress_mbps": 394.76,
+   "decompress_mbps": 1899.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57064,
+   "ratio": 0.1112,
+   "compress_mbps": 374.05,
+   "decompress_mbps": 1741.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55743,
+   "ratio": 0.1086,
+   "compress_mbps": 343.45,
+   "decompress_mbps": 1793.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55102,
+   "ratio": 0.1074,
+   "compress_mbps": 285.08,
+   "decompress_mbps": 1869.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54742,
+   "ratio": 0.1067,
+   "compress_mbps": 193.03,
+   "decompress_mbps": 1929.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 53133,
+   "ratio": 0.1035,
+   "compress_mbps": 102.77,
+   "decompress_mbps": 1996.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52186,
+   "ratio": 0.1017,
+   "compress_mbps": 72.32,
+   "decompress_mbps": 2031.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14122,
+   "ratio": 0.3693,
+   "compress_mbps": 648.66,
+   "decompress_mbps": 823.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13374,
+   "ratio": 0.3497,
+   "compress_mbps": 338.62,
+   "decompress_mbps": 879.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13293,
+   "ratio": 0.3476,
+   "compress_mbps": 257.73,
+   "decompress_mbps": 960.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13259,
+   "ratio": 0.3467,
+   "compress_mbps": 263.83,
+   "decompress_mbps": 960.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 12641,
+   "ratio": 0.3306,
+   "compress_mbps": 190.13,
+   "decompress_mbps": 990.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12432,
+   "ratio": 0.3251,
+   "compress_mbps": 164.05,
+   "decompress_mbps": 1006.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12439,
+   "ratio": 0.3253,
+   "compress_mbps": 122.43,
+   "decompress_mbps": 1013.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12579,
+   "ratio": 0.3289,
+   "compress_mbps": 67.61,
+   "decompress_mbps": 1025.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12574,
+   "ratio": 0.3288,
+   "compress_mbps": 47.47,
+   "decompress_mbps": 1031.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1777,
+   "ratio": 0.4204,
+   "compress_mbps": 386.35,
+   "decompress_mbps": 403.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1756,
+   "ratio": 0.4154,
+   "compress_mbps": 260.77,
+   "decompress_mbps": 408.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 257.14,
+   "decompress_mbps": 410.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1740,
+   "ratio": 0.4116,
+   "compress_mbps": 254.99,
+   "decompress_mbps": 414.73
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1722,
+   "ratio": 0.4074,
+   "compress_mbps": 240.47,
+   "decompress_mbps": 415.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1721,
+   "ratio": 0.4071,
+   "compress_mbps": 235.91,
+   "decompress_mbps": 415.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 234.75,
+   "decompress_mbps": 415.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 217.57,
+   "decompress_mbps": 417.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 216.75,
+   "decompress_mbps": 416.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4259644,
+   "ratio": 0.4179,
+   "compress_mbps": 55.48,
+   "decompress_mbps": 175.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3977395,
+   "ratio": 0.3902,
+   "compress_mbps": 41.33,
+   "decompress_mbps": 190.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3945296,
+   "ratio": 0.3871,
+   "compress_mbps": 36.93,
+   "decompress_mbps": 209.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3882303,
+   "ratio": 0.3809,
+   "compress_mbps": 26.78,
+   "decompress_mbps": 213.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3870984,
+   "ratio": 0.3798,
+   "compress_mbps": 22.24,
+   "decompress_mbps": 213.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3878499,
+   "ratio": 0.3805,
+   "compress_mbps": 19.39,
+   "decompress_mbps": 221.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3865234,
+   "ratio": 0.3792,
+   "compress_mbps": 17.03,
+   "decompress_mbps": 219.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3864805,
+   "ratio": 0.3792,
+   "compress_mbps": 13.68,
+   "decompress_mbps": 219.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3790404,
+   "ratio": 0.3719,
+   "compress_mbps": 3.13,
+   "decompress_mbps": 219.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21267086,
+   "ratio": 0.4152,
+   "compress_mbps": 70.17,
+   "decompress_mbps": 192.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20802983,
+   "ratio": 0.4061,
+   "compress_mbps": 56.03,
+   "decompress_mbps": 200.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20665485,
+   "ratio": 0.4035,
+   "compress_mbps": 52.53,
+   "decompress_mbps": 200.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20393572,
+   "ratio": 0.3982,
+   "compress_mbps": 39.36,
+   "decompress_mbps": 211.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20264932,
+   "ratio": 0.3956,
+   "compress_mbps": 27.75,
+   "decompress_mbps": 220.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19208910,
+   "ratio": 0.375,
+   "compress_mbps": 16.0,
+   "decompress_mbps": 224.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19177573,
+   "ratio": 0.3744,
+   "compress_mbps": 12.71,
+   "decompress_mbps": 226.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19172591,
+   "ratio": 0.3743,
+   "compress_mbps": 8.06,
+   "decompress_mbps": 227.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18723512,
+   "ratio": 0.3655,
+   "compress_mbps": 3.21,
+   "decompress_mbps": 224.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3864163,
+   "ratio": 0.3876,
+   "compress_mbps": 68.39,
+   "decompress_mbps": 205.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3734957,
+   "ratio": 0.3746,
+   "compress_mbps": 53.45,
+   "decompress_mbps": 214.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3708443,
+   "ratio": 0.3719,
+   "compress_mbps": 46.13,
+   "decompress_mbps": 224.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3707604,
+   "ratio": 0.3719,
+   "compress_mbps": 31.41,
+   "decompress_mbps": 209.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3705174,
+   "ratio": 0.3716,
+   "compress_mbps": 24.67,
+   "decompress_mbps": 205.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3612809,
+   "ratio": 0.3623,
+   "compress_mbps": 18.76,
+   "decompress_mbps": 214.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3608980,
+   "ratio": 0.362,
+   "compress_mbps": 16.25,
+   "decompress_mbps": 218.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3609490,
+   "ratio": 0.362,
+   "compress_mbps": 10.4,
+   "decompress_mbps": 219.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3598941,
+   "ratio": 0.361,
+   "compress_mbps": 3.58,
+   "decompress_mbps": 227.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3785443,
+   "ratio": 0.1128,
+   "compress_mbps": 200.7,
+   "decompress_mbps": 597.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3761560,
+   "ratio": 0.1121,
+   "compress_mbps": 129.81,
+   "decompress_mbps": 670.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3606997,
+   "ratio": 0.1075,
+   "compress_mbps": 113.5,
+   "decompress_mbps": 745.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3225450,
+   "ratio": 0.0961,
+   "compress_mbps": 86.31,
+   "decompress_mbps": 746.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3145121,
+   "ratio": 0.0937,
+   "compress_mbps": 56.88,
+   "decompress_mbps": 826.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3158854,
+   "ratio": 0.0941,
+   "compress_mbps": 52.7,
+   "decompress_mbps": 880.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3124878,
+   "ratio": 0.0931,
+   "compress_mbps": 36.79,
+   "decompress_mbps": 893.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3112207,
+   "ratio": 0.0928,
+   "compress_mbps": 27.52,
+   "decompress_mbps": 914.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3083394,
+   "ratio": 0.0919,
+   "compress_mbps": 3.08,
+   "decompress_mbps": 908.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3357083,
+   "ratio": 0.5457,
+   "compress_mbps": 48.27,
+   "decompress_mbps": 128.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3285077,
+   "ratio": 0.534,
+   "compress_mbps": 41.14,
+   "decompress_mbps": 132.57
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3272746,
+   "ratio": 0.532,
+   "compress_mbps": 39.54,
+   "decompress_mbps": 137.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3237094,
+   "ratio": 0.5262,
+   "compress_mbps": 32.36,
+   "decompress_mbps": 146.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3233792,
+   "ratio": 0.5256,
+   "compress_mbps": 28.73,
+   "decompress_mbps": 150.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3168386,
+   "ratio": 0.515,
+   "compress_mbps": 15.9,
+   "decompress_mbps": 155.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3165783,
+   "ratio": 0.5146,
+   "compress_mbps": 14.78,
+   "decompress_mbps": 157.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3165909,
+   "ratio": 0.5146,
+   "compress_mbps": 8.64,
+   "decompress_mbps": 157.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3055775,
+   "ratio": 0.4967,
+   "compress_mbps": 3.72,
+   "decompress_mbps": 156.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3838828,
+   "ratio": 0.3806,
+   "compress_mbps": 78.07,
+   "decompress_mbps": 230.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3792520,
+   "ratio": 0.376,
+   "compress_mbps": 59.51,
+   "decompress_mbps": 238.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3783171,
+   "ratio": 0.3751,
+   "compress_mbps": 57.57,
+   "decompress_mbps": 242.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3706928,
+   "ratio": 0.3675,
+   "compress_mbps": 51.95,
+   "decompress_mbps": 257.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3707010,
+   "ratio": 0.3676,
+   "compress_mbps": 48.42,
+   "decompress_mbps": 259.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3707065,
+   "ratio": 0.3676,
+   "compress_mbps": 31.44,
+   "decompress_mbps": 254.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 31.18,
+   "decompress_mbps": 255.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 256.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3693258,
+   "ratio": 0.3662,
+   "compress_mbps": 4.84,
+   "decompress_mbps": 269.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2254442,
+   "ratio": 0.3402,
+   "compress_mbps": 69.34,
+   "decompress_mbps": 222.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2044843,
+   "ratio": 0.3086,
+   "compress_mbps": 48.71,
+   "decompress_mbps": 233.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 1992105,
+   "ratio": 0.3006,
+   "compress_mbps": 39.96,
+   "decompress_mbps": 254.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1901081,
+   "ratio": 0.2869,
+   "compress_mbps": 26.08,
+   "decompress_mbps": 263.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1874829,
+   "ratio": 0.2829,
+   "compress_mbps": 15.73,
+   "decompress_mbps": 261.36
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1867098,
+   "ratio": 0.2817,
+   "compress_mbps": 17.43,
+   "decompress_mbps": 276.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1843421,
+   "ratio": 0.2782,
+   "compress_mbps": 12.08,
+   "decompress_mbps": 280.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1841388,
+   "ratio": 0.2779,
+   "compress_mbps": 9.72,
+   "decompress_mbps": 282.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1794155,
+   "ratio": 0.2707,
+   "compress_mbps": 2.47,
+   "decompress_mbps": 290.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6406301,
+   "ratio": 0.2965,
+   "compress_mbps": 95.14,
+   "decompress_mbps": 293.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6102377,
+   "ratio": 0.2824,
+   "compress_mbps": 72.18,
+   "decompress_mbps": 313.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 6022184,
+   "ratio": 0.2787,
+   "compress_mbps": 66.12,
+   "decompress_mbps": 325.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5880979,
+   "ratio": 0.2722,
+   "compress_mbps": 49.54,
+   "decompress_mbps": 333.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5839944,
+   "ratio": 0.2703,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 344.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5425813,
+   "ratio": 0.2511,
+   "compress_mbps": 26.23,
+   "decompress_mbps": 352.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5409983,
+   "ratio": 0.2504,
+   "compress_mbps": 23.21,
+   "decompress_mbps": 354.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5407066,
+   "ratio": 0.2503,
+   "compress_mbps": 16.46,
+   "decompress_mbps": 358.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5257833,
+   "ratio": 0.2433,
+   "compress_mbps": 3.99,
+   "decompress_mbps": 355.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5612204,
+   "ratio": 0.7739,
+   "compress_mbps": 41.24,
+   "decompress_mbps": 129.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5533875,
+   "ratio": 0.7631,
+   "compress_mbps": 35.17,
+   "decompress_mbps": 132.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5522436,
+   "ratio": 0.7615,
+   "compress_mbps": 33.18,
+   "decompress_mbps": 136.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5498823,
+   "ratio": 0.7583,
+   "compress_mbps": 27.58,
+   "decompress_mbps": 139.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5496802,
+   "ratio": 0.758,
+   "compress_mbps": 25.9,
+   "decompress_mbps": 137.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5478405,
+   "ratio": 0.7554,
+   "compress_mbps": 17.38,
+   "decompress_mbps": 137.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5474648,
+   "ratio": 0.7549,
+   "compress_mbps": 16.62,
+   "decompress_mbps": 138.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5429363,
+   "ratio": 0.7487,
+   "compress_mbps": 7.87,
+   "decompress_mbps": 140.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5301868,
+   "ratio": 0.7311,
+   "compress_mbps": 3.62,
+   "decompress_mbps": 141.55
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13727247,
+   "ratio": 0.3311,
+   "compress_mbps": 71.12,
+   "decompress_mbps": 223.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12940398,
+   "ratio": 0.3121,
+   "compress_mbps": 54.34,
+   "decompress_mbps": 241.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12703756,
+   "ratio": 0.3064,
+   "compress_mbps": 50.41,
+   "decompress_mbps": 262.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12229398,
+   "ratio": 0.295,
+   "compress_mbps": 37.77,
+   "decompress_mbps": 260.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12123671,
+   "ratio": 0.2924,
+   "compress_mbps": 27.53,
+   "decompress_mbps": 272.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12167341,
+   "ratio": 0.2935,
+   "compress_mbps": 24.55,
+   "decompress_mbps": 279.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12109369,
+   "ratio": 0.2921,
+   "compress_mbps": 20.64,
+   "decompress_mbps": 282.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12106058,
+   "ratio": 0.292,
+   "compress_mbps": 16.36,
+   "decompress_mbps": 282.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11868997,
+   "ratio": 0.2863,
+   "compress_mbps": 3.24,
+   "decompress_mbps": 282.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6438176,
+   "ratio": 0.7597,
+   "compress_mbps": 39.06,
+   "decompress_mbps": 126.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6392101,
+   "ratio": 0.7543,
+   "compress_mbps": 37.61,
+   "decompress_mbps": 126.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6392124,
+   "ratio": 0.7543,
+   "compress_mbps": 37.91,
+   "decompress_mbps": 128.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6368719,
+   "ratio": 0.7515,
+   "compress_mbps": 35.76,
+   "decompress_mbps": 117.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6368717,
+   "ratio": 0.7515,
+   "compress_mbps": 35.9,
+   "decompress_mbps": 119.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 9.54,
+   "decompress_mbps": 119.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 9.45,
+   "decompress_mbps": 120.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 5.47,
+   "decompress_mbps": 119.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5949045,
+   "ratio": 0.702,
+   "compress_mbps": 4.32,
+   "decompress_mbps": 121.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 858525,
+   "ratio": 0.1606,
+   "compress_mbps": 151.44,
+   "decompress_mbps": 419.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 846807,
+   "ratio": 0.1584,
+   "compress_mbps": 101.03,
+   "decompress_mbps": 455.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 806798,
+   "ratio": 0.1509,
+   "compress_mbps": 92.34,
+   "decompress_mbps": 503.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 721655,
+   "ratio": 0.135,
+   "compress_mbps": 69.35,
+   "decompress_mbps": 556.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 710636,
+   "ratio": 0.1329,
+   "compress_mbps": 50.05,
+   "decompress_mbps": 606.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 688375,
+   "ratio": 0.1288,
+   "compress_mbps": 42.12,
+   "decompress_mbps": 594.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 676544,
+   "ratio": 0.1266,
+   "compress_mbps": 34.28,
+   "decompress_mbps": 666.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 674362,
+   "ratio": 0.1262,
+   "compress_mbps": 26.55,
+   "decompress_mbps": 676.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 669438,
+   "ratio": 0.1252,
+   "compress_mbps": 3.92,
+   "decompress_mbps": 664.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4585612,
+   "ratio": 0.4499,
+   "compress_mbps": 113.67,
+   "decompress_mbps": 354.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4389474,
+   "ratio": 0.4307,
+   "compress_mbps": 96.07,
+   "decompress_mbps": 375.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4192079,
+   "ratio": 0.4113,
+   "compress_mbps": 59.36,
+   "decompress_mbps": 412.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4095021,
+   "ratio": 0.4018,
+   "compress_mbps": 66.19,
+   "decompress_mbps": 389.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3949169,
+   "ratio": 0.3875,
+   "compress_mbps": 35.97,
+   "decompress_mbps": 376.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3871628,
+   "ratio": 0.3799,
+   "compress_mbps": 21.24,
+   "decompress_mbps": 384.89
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3858876,
+   "ratio": 0.3786,
+   "compress_mbps": 17.58,
+   "decompress_mbps": 387.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.07,
+   "decompress_mbps": 385.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.07,
+   "decompress_mbps": 391.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20577220,
+   "ratio": 0.4017,
+   "compress_mbps": 113.25,
+   "decompress_mbps": 364.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20247697,
+   "ratio": 0.3953,
+   "compress_mbps": 100.51,
+   "decompress_mbps": 370.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19987880,
+   "ratio": 0.3902,
+   "compress_mbps": 75.64,
+   "decompress_mbps": 340.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19512665,
+   "ratio": 0.381,
+   "compress_mbps": 71.76,
+   "decompress_mbps": 363.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19213507,
+   "ratio": 0.3751,
+   "compress_mbps": 51.35,
+   "decompress_mbps": 370.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19089118,
+   "ratio": 0.3727,
+   "compress_mbps": 33.44,
+   "decompress_mbps": 376.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19061204,
+   "ratio": 0.3721,
+   "compress_mbps": 27.31,
+   "decompress_mbps": 380.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19040998,
+   "ratio": 0.3717,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 379.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19044390,
+   "ratio": 0.3718,
+   "compress_mbps": 9.54,
+   "decompress_mbps": 385.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3828360,
+   "ratio": 0.384,
+   "compress_mbps": 144.91,
+   "decompress_mbps": 453.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3798539,
+   "ratio": 0.381,
+   "compress_mbps": 128.29,
+   "decompress_mbps": 497.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3674568,
+   "ratio": 0.3685,
+   "compress_mbps": 80.47,
+   "decompress_mbps": 515.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3680923,
+   "ratio": 0.3692,
+   "compress_mbps": 89.36,
+   "decompress_mbps": 457.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3698707,
+   "ratio": 0.371,
+   "compress_mbps": 48.13,
+   "decompress_mbps": 427.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3675935,
+   "ratio": 0.3687,
+   "compress_mbps": 26.41,
+   "decompress_mbps": 437.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3670281,
+   "ratio": 0.3681,
+   "compress_mbps": 20.84,
+   "decompress_mbps": 444.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3661103,
+   "ratio": 0.3672,
+   "compress_mbps": 10.94,
+   "decompress_mbps": 458.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3660788,
+   "ratio": 0.3672,
+   "compress_mbps": 9.47,
+   "decompress_mbps": 459.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4624591,
+   "ratio": 0.1378,
+   "compress_mbps": 332.0,
+   "decompress_mbps": 831.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4303176,
+   "ratio": 0.1282,
+   "compress_mbps": 310.37,
+   "decompress_mbps": 841.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4010156,
+   "ratio": 0.1195,
+   "compress_mbps": 257.47,
+   "decompress_mbps": 926.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3713866,
+   "ratio": 0.1107,
+   "compress_mbps": 212.08,
+   "decompress_mbps": 896.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3378136,
+   "ratio": 0.1007,
+   "compress_mbps": 166.1,
+   "decompress_mbps": 954.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3200182,
+   "ratio": 0.0954,
+   "compress_mbps": 113.17,
+   "decompress_mbps": 986.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3141278,
+   "ratio": 0.0936,
+   "compress_mbps": 90.33,
+   "decompress_mbps": 999.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3031199,
+   "ratio": 0.0903,
+   "compress_mbps": 39.16,
+   "decompress_mbps": 1017.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2987995,
+   "ratio": 0.0891,
+   "compress_mbps": 21.44,
+   "decompress_mbps": 1033.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3290526,
+   "ratio": 0.5349,
+   "compress_mbps": 79.06,
+   "decompress_mbps": 257.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3238282,
+   "ratio": 0.5264,
+   "compress_mbps": 72.38,
+   "decompress_mbps": 263.21
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3193366,
+   "ratio": 0.5191,
+   "compress_mbps": 57.0,
+   "decompress_mbps": 265.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3158012,
+   "ratio": 0.5133,
+   "compress_mbps": 55.65,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3115309,
+   "ratio": 0.5064,
+   "compress_mbps": 39.25,
+   "decompress_mbps": 269.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3097288,
+   "ratio": 0.5034,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 264.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3094363,
+   "ratio": 0.503,
+   "compress_mbps": 21.86,
+   "decompress_mbps": 268.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3093026,
+   "ratio": 0.5028,
+   "compress_mbps": 16.97,
+   "decompress_mbps": 270.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3092920,
+   "ratio": 0.5027,
+   "compress_mbps": 15.53,
+   "decompress_mbps": 269.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076385,
+   "ratio": 0.4042,
+   "compress_mbps": 125.81,
+   "decompress_mbps": 474.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3991014,
+   "ratio": 0.3957,
+   "compress_mbps": 117.17,
+   "decompress_mbps": 494.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3934055,
+   "ratio": 0.3901,
+   "compress_mbps": 93.6,
+   "decompress_mbps": 511.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3825092,
+   "ratio": 0.3793,
+   "compress_mbps": 85.49,
+   "decompress_mbps": 513.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3752932,
+   "ratio": 0.3721,
+   "compress_mbps": 64.41,
+   "decompress_mbps": 496.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3695164,
+   "ratio": 0.3664,
+   "compress_mbps": 49.22,
+   "decompress_mbps": 507.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3676881,
+   "ratio": 0.3646,
+   "compress_mbps": 38.17,
+   "decompress_mbps": 515.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2376424,
+   "ratio": 0.3586,
+   "compress_mbps": 130.38,
+   "decompress_mbps": 393.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2259060,
+   "ratio": 0.3409,
+   "compress_mbps": 112.03,
+   "decompress_mbps": 411.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2135664,
+   "ratio": 0.3223,
+   "compress_mbps": 72.25,
+   "decompress_mbps": 435.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2052793,
+   "ratio": 0.3098,
+   "compress_mbps": 81.67,
+   "decompress_mbps": 430.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1932127,
+   "ratio": 0.2915,
+   "compress_mbps": 45.23,
+   "decompress_mbps": 432.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1860865,
+   "ratio": 0.2808,
+   "compress_mbps": 22.82,
+   "decompress_mbps": 440.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1838671,
+   "ratio": 0.2774,
+   "compress_mbps": 15.96,
+   "decompress_mbps": 441.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823235,
+   "ratio": 0.2751,
+   "compress_mbps": 8.12,
+   "decompress_mbps": 436.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823190,
+   "ratio": 0.2751,
+   "compress_mbps": 8.15,
+   "decompress_mbps": 439.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6329449,
+   "ratio": 0.2929,
+   "compress_mbps": 169.74,
+   "decompress_mbps": 460.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6128866,
+   "ratio": 0.2837,
+   "compress_mbps": 155.55,
+   "decompress_mbps": 557.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5982546,
+   "ratio": 0.2769,
+   "compress_mbps": 125.39,
+   "decompress_mbps": 581.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5656400,
+   "ratio": 0.2618,
+   "compress_mbps": 116.92,
+   "decompress_mbps": 576.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5511352,
+   "ratio": 0.2551,
+   "compress_mbps": 82.58,
+   "decompress_mbps": 587.65
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5451399,
+   "ratio": 0.2523,
+   "compress_mbps": 56.59,
+   "decompress_mbps": 593.88
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5417123,
+   "ratio": 0.2507,
+   "compress_mbps": 46.71,
+   "decompress_mbps": 596.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5404364,
+   "ratio": 0.2501,
+   "compress_mbps": 32.73,
+   "decompress_mbps": 602.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5402704,
+   "ratio": 0.2501,
+   "compress_mbps": 29.69,
+   "decompress_mbps": 390.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5567768,
+   "ratio": 0.7678,
+   "compress_mbps": 32.89,
+   "decompress_mbps": 211.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504009,
+   "ratio": 0.759,
+   "compress_mbps": 38.32,
+   "decompress_mbps": 168.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5439339,
+   "ratio": 0.7501,
+   "compress_mbps": 29.43,
+   "decompress_mbps": 230.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5394604,
+   "ratio": 0.7439,
+   "compress_mbps": 32.68,
+   "decompress_mbps": 256.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5370116,
+   "ratio": 0.7405,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 312.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5331793,
+   "ratio": 0.7352,
+   "compress_mbps": 20.53,
+   "decompress_mbps": 329.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5327677,
+   "ratio": 0.7347,
+   "compress_mbps": 21.16,
+   "decompress_mbps": 348.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.96,
+   "decompress_mbps": 349.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.95,
+   "decompress_mbps": 346.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14991236,
+   "ratio": 0.3616,
+   "compress_mbps": 136.65,
+   "decompress_mbps": 380.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14249692,
+   "ratio": 0.3437,
+   "compress_mbps": 120.34,
+   "decompress_mbps": 401.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13627761,
+   "ratio": 0.3287,
+   "compress_mbps": 87.73,
+   "decompress_mbps": 414.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13001990,
+   "ratio": 0.3136,
+   "compress_mbps": 85.4,
+   "decompress_mbps": 395.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12445991,
+   "ratio": 0.3002,
+   "compress_mbps": 55.03,
+   "decompress_mbps": 392.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12213941,
+   "ratio": 0.2946,
+   "compress_mbps": 36.53,
+   "decompress_mbps": 400.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12130416,
+   "ratio": 0.2926,
+   "compress_mbps": 29.65,
+   "decompress_mbps": 401.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12073697,
+   "ratio": 0.2912,
+   "compress_mbps": 21.5,
+   "decompress_mbps": 403.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12073469,
+   "ratio": 0.2912,
+   "compress_mbps": 21.33,
+   "decompress_mbps": 403.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6033926,
+   "ratio": 0.712,
+   "compress_mbps": 75.49,
+   "decompress_mbps": 294.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997474,
+   "ratio": 0.7077,
+   "compress_mbps": 68.78,
+   "decompress_mbps": 305.32
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5966621,
+   "ratio": 0.7041,
+   "compress_mbps": 55.63,
+   "decompress_mbps": 312.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6091108,
+   "ratio": 0.7188,
+   "compress_mbps": 46.09,
+   "decompress_mbps": 267.15
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6053566,
+   "ratio": 0.7143,
+   "compress_mbps": 37.26,
+   "decompress_mbps": 274.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6045111,
+   "ratio": 0.7134,
+   "compress_mbps": 34.97,
+   "decompress_mbps": 276.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6045034,
+   "ratio": 0.7133,
+   "compress_mbps": 34.92,
+   "decompress_mbps": 278.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.97,
+   "decompress_mbps": 277.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.94,
+   "decompress_mbps": 277.39
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 965242,
+   "ratio": 0.1806,
+   "compress_mbps": 264.31,
+   "decompress_mbps": 697.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 887265,
+   "ratio": 0.166,
+   "compress_mbps": 246.22,
+   "decompress_mbps": 752.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 822167,
+   "ratio": 0.1538,
+   "compress_mbps": 191.48,
+   "decompress_mbps": 797.39
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 807518,
+   "ratio": 0.1511,
+   "compress_mbps": 169.01,
+   "decompress_mbps": 768.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 730574,
+   "ratio": 0.1367,
+   "compress_mbps": 121.75,
+   "decompress_mbps": 815.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687991,
+   "ratio": 0.1287,
+   "compress_mbps": 79.31,
+   "decompress_mbps": 872.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673933,
+   "ratio": 0.1261,
+   "compress_mbps": 64.99,
+   "decompress_mbps": 887.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659518,
+   "ratio": 0.1234,
+   "compress_mbps": 43.0,
+   "decompress_mbps": 884.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658899,
+   "ratio": 0.1233,
+   "compress_mbps": 39.85,
+   "decompress_mbps": 896.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5363862,
+   "ratio": 0.5263,
+   "compress_mbps": 141.65,
+   "decompress_mbps": 389.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4438205,
+   "ratio": 0.4354,
+   "compress_mbps": 128.9,
+   "decompress_mbps": 428.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4054333,
+   "ratio": 0.3978,
+   "compress_mbps": 63.86,
+   "decompress_mbps": 475.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4038550,
+   "ratio": 0.3962,
+   "compress_mbps": 57.76,
+   "decompress_mbps": 469.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3954920,
+   "ratio": 0.388,
+   "compress_mbps": 40.27,
+   "decompress_mbps": 462.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3872874,
+   "ratio": 0.38,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 470.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3859937,
+   "ratio": 0.3787,
+   "compress_mbps": 18.83,
+   "decompress_mbps": 472.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3855935,
+   "ratio": 0.3783,
+   "compress_mbps": 17.07,
+   "decompress_mbps": 469.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3855791,
+   "ratio": 0.3783,
+   "compress_mbps": 17.01,
+   "decompress_mbps": 470.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 22334882,
+   "ratio": 0.4361,
+   "compress_mbps": 233.89,
+   "decompress_mbps": 370.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20150366,
+   "ratio": 0.3934,
+   "compress_mbps": 119.97,
+   "decompress_mbps": 375.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19495014,
+   "ratio": 0.3806,
+   "compress_mbps": 70.13,
+   "decompress_mbps": 389.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19424978,
+   "ratio": 0.3792,
+   "compress_mbps": 71.02,
+   "decompress_mbps": 402.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19298736,
+   "ratio": 0.3768,
+   "compress_mbps": 54.1,
+   "decompress_mbps": 393.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19179167,
+   "ratio": 0.3744,
+   "compress_mbps": 29.69,
+   "decompress_mbps": 422.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19151324,
+   "ratio": 0.3739,
+   "compress_mbps": 21.89,
+   "decompress_mbps": 422.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19144373,
+   "ratio": 0.3738,
+   "compress_mbps": 16.59,
+   "decompress_mbps": 407.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19141383,
+   "ratio": 0.3737,
+   "compress_mbps": 14.17,
+   "decompress_mbps": 420.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 4249731,
+   "ratio": 0.4262,
+   "compress_mbps": 313.35,
+   "decompress_mbps": 528.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3775479,
+   "ratio": 0.3787,
+   "compress_mbps": 156.84,
+   "decompress_mbps": 517.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3656966,
+   "ratio": 0.3668,
+   "compress_mbps": 79.84,
+   "decompress_mbps": 574.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3740378,
+   "ratio": 0.3751,
+   "compress_mbps": 67.57,
+   "decompress_mbps": 534.79
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3713604,
+   "ratio": 0.3725,
+   "compress_mbps": 48.45,
+   "decompress_mbps": 501.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3683556,
+   "ratio": 0.3694,
+   "compress_mbps": 24.87,
+   "decompress_mbps": 515.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3683797,
+   "ratio": 0.3695,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 521.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3684477,
+   "ratio": 0.3695,
+   "compress_mbps": 14.34,
+   "decompress_mbps": 540.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3679414,
+   "ratio": 0.369,
+   "compress_mbps": 12.34,
+   "decompress_mbps": 542.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 5594622,
+   "ratio": 0.1667,
+   "compress_mbps": 433.55,
+   "decompress_mbps": 834.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4179532,
+   "ratio": 0.1246,
+   "compress_mbps": 327.38,
+   "decompress_mbps": 926.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3542329,
+   "ratio": 0.1056,
+   "compress_mbps": 211.33,
+   "decompress_mbps": 842.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3323363,
+   "ratio": 0.099,
+   "compress_mbps": 197.38,
+   "decompress_mbps": 872.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3230343,
+   "ratio": 0.0963,
+   "compress_mbps": 161.61,
+   "decompress_mbps": 952.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3123421,
+   "ratio": 0.0931,
+   "compress_mbps": 95.69,
+   "decompress_mbps": 997.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3093778,
+   "ratio": 0.0922,
+   "compress_mbps": 70.53,
+   "decompress_mbps": 972.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3067318,
+   "ratio": 0.0914,
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1013.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3050695,
+   "ratio": 0.0909,
+   "compress_mbps": 41.98,
+   "decompress_mbps": 1022.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3543611,
+   "ratio": 0.576,
+   "compress_mbps": 169.2,
+   "decompress_mbps": 269.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3226818,
+   "ratio": 0.5245,
+   "compress_mbps": 86.03,
+   "decompress_mbps": 287.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3144140,
+   "ratio": 0.5111,
+   "compress_mbps": 52.6,
+   "decompress_mbps": 297.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129833,
+   "ratio": 0.5087,
+   "compress_mbps": 51.39,
+   "decompress_mbps": 324.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3114809,
+   "ratio": 0.5063,
+   "compress_mbps": 40.29,
+   "decompress_mbps": 338.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3095705,
+   "ratio": 0.5032,
+   "compress_mbps": 25.04,
+   "decompress_mbps": 345.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3090055,
+   "ratio": 0.5023,
+   "compress_mbps": 20.39,
+   "decompress_mbps": 345.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3087665,
+   "ratio": 0.5019,
+   "compress_mbps": 17.41,
+   "decompress_mbps": 345.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3087158,
+   "ratio": 0.5018,
+   "compress_mbps": 16.29,
+   "decompress_mbps": 345.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 5419510,
+   "ratio": 0.5373,
+   "compress_mbps": 243.36,
+   "decompress_mbps": 535.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3982547,
+   "ratio": 0.3949,
+   "compress_mbps": 122.38,
+   "decompress_mbps": 550.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3806102,
+   "ratio": 0.3774,
+   "compress_mbps": 80.86,
+   "decompress_mbps": 568.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3761477,
+   "ratio": 0.373,
+   "compress_mbps": 78.11,
+   "decompress_mbps": 603.06
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3740298,
+   "ratio": 0.3709,
+   "compress_mbps": 67.07,
+   "decompress_mbps": 611.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3686116,
+   "ratio": 0.3655,
+   "compress_mbps": 49.52,
+   "decompress_mbps": 637.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3668442,
+   "ratio": 0.3637,
+   "compress_mbps": 38.85,
+   "decompress_mbps": 662.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3665072,
+   "ratio": 0.3634,
+   "compress_mbps": 33.15,
+   "decompress_mbps": 657.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665057,
+   "ratio": 0.3634,
+   "compress_mbps": 32.94,
+   "decompress_mbps": 653.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2842321,
+   "ratio": 0.4289,
+   "compress_mbps": 193.08,
+   "decompress_mbps": 443.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2232180,
+   "ratio": 0.3368,
+   "compress_mbps": 151.04,
+   "decompress_mbps": 514.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2003056,
+   "ratio": 0.3022,
+   "compress_mbps": 81.92,
+   "decompress_mbps": 551.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1985375,
+   "ratio": 0.2996,
+   "compress_mbps": 74.08,
+   "decompress_mbps": 566.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1933775,
+   "ratio": 0.2918,
+   "compress_mbps": 51.93,
+   "decompress_mbps": 538.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1858103,
+   "ratio": 0.2804,
+   "compress_mbps": 22.05,
+   "decompress_mbps": 541.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1840414,
+   "ratio": 0.2777,
+   "compress_mbps": 15.15,
+   "decompress_mbps": 550.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1831679,
+   "ratio": 0.2764,
+   "compress_mbps": 11.76,
+   "decompress_mbps": 543.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1827137,
+   "ratio": 0.2757,
+   "compress_mbps": 10.16,
+   "decompress_mbps": 544.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7089759,
+   "ratio": 0.3281,
+   "compress_mbps": 290.79,
+   "decompress_mbps": 557.71
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5966231,
+   "ratio": 0.2761,
+   "compress_mbps": 174.66,
+   "decompress_mbps": 619.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5611838,
+   "ratio": 0.2597,
+   "compress_mbps": 111.67,
+   "decompress_mbps": 648.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5535436,
+   "ratio": 0.2562,
+   "compress_mbps": 105.54,
+   "decompress_mbps": 672.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5480971,
+   "ratio": 0.2537,
+   "compress_mbps": 81.52,
+   "decompress_mbps": 680.77
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5437556,
+   "ratio": 0.2517,
+   "compress_mbps": 49.47,
+   "decompress_mbps": 697.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5432108,
+   "ratio": 0.2514,
+   "compress_mbps": 40.48,
+   "decompress_mbps": 694.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5428571,
+   "ratio": 0.2512,
+   "compress_mbps": 33.62,
+   "decompress_mbps": 700.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5425526,
+   "ratio": 0.2511,
+   "compress_mbps": 30.51,
+   "decompress_mbps": 703.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5900800,
+   "ratio": 0.8137,
+   "compress_mbps": 188.47,
+   "decompress_mbps": 324.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5523611,
+   "ratio": 0.7617,
+   "compress_mbps": 69.45,
+   "decompress_mbps": 340.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5393086,
+   "ratio": 0.7437,
+   "compress_mbps": 40.33,
+   "decompress_mbps": 351.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5401582,
+   "ratio": 0.7448,
+   "compress_mbps": 40.72,
+   "decompress_mbps": 367.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5371274,
+   "ratio": 0.7407,
+   "compress_mbps": 31.31,
+   "decompress_mbps": 358.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5330096,
+   "ratio": 0.735,
+   "compress_mbps": 20.8,
+   "decompress_mbps": 365.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325437,
+   "ratio": 0.7343,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 366.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5323934,
+   "ratio": 0.7341,
+   "compress_mbps": 18.05,
+   "decompress_mbps": 364.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323621,
+   "ratio": 0.7341,
+   "compress_mbps": 17.67,
+   "decompress_mbps": 364.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 17587173,
+   "ratio": 0.4242,
+   "compress_mbps": 185.73,
+   "decompress_mbps": 379.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14171707,
+   "ratio": 0.3418,
+   "compress_mbps": 149.15,
+   "decompress_mbps": 409.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12774851,
+   "ratio": 0.3081,
+   "compress_mbps": 85.71,
+   "decompress_mbps": 440.79
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12612554,
+   "ratio": 0.3042,
+   "compress_mbps": 76.13,
+   "decompress_mbps": 444.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12392339,
+   "ratio": 0.2989,
+   "compress_mbps": 58.1,
+   "decompress_mbps": 457.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12158314,
+   "ratio": 0.2933,
+   "compress_mbps": 34.41,
+   "decompress_mbps": 463.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12107840,
+   "ratio": 0.292,
+   "compress_mbps": 27.64,
+   "decompress_mbps": 466.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12081311,
+   "ratio": 0.2914,
+   "compress_mbps": 22.88,
+   "decompress_mbps": 462.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12081011,
+   "ratio": 0.2914,
+   "compress_mbps": 22.78,
+   "decompress_mbps": 460.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6527324,
+   "ratio": 0.7703,
+   "compress_mbps": 238.95,
+   "decompress_mbps": 330.7
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6051483,
+   "ratio": 0.7141,
+   "compress_mbps": 75.62,
+   "decompress_mbps": 332.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6010123,
+   "ratio": 0.7092,
+   "compress_mbps": 52.06,
+   "decompress_mbps": 334.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6024815,
+   "ratio": 0.711,
+   "compress_mbps": 44.63,
+   "decompress_mbps": 286.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6005181,
+   "ratio": 0.7086,
+   "compress_mbps": 40.44,
+   "decompress_mbps": 293.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5997508,
+   "ratio": 0.7077,
+   "compress_mbps": 37.97,
+   "decompress_mbps": 295.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.87,
+   "decompress_mbps": 295.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.82,
+   "decompress_mbps": 295.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.76,
+   "decompress_mbps": 292.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1147652,
+   "ratio": 0.2147,
+   "compress_mbps": 388.67,
+   "decompress_mbps": 761.65
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 919639,
+   "ratio": 0.172,
+   "compress_mbps": 262.86,
+   "decompress_mbps": 956.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 752341,
+   "ratio": 0.1407,
+   "compress_mbps": 167.46,
+   "decompress_mbps": 1057.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 735537,
+   "ratio": 0.1376,
+   "compress_mbps": 161.37,
+   "decompress_mbps": 1037.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 706789,
+   "ratio": 0.1322,
+   "compress_mbps": 123.5,
+   "decompress_mbps": 1129.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 676279,
+   "ratio": 0.1265,
+   "compress_mbps": 69.53,
+   "decompress_mbps": 1219.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668772,
+   "ratio": 0.1251,
+   "compress_mbps": 55.97,
+   "decompress_mbps": 1208.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 665340,
+   "ratio": 0.1245,
+   "compress_mbps": 47.61,
+   "decompress_mbps": 1208.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 664273,
+   "ratio": 0.1243,
+   "compress_mbps": 45.85,
+   "decompress_mbps": 1218.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4217525,
+   "ratio": 0.4138,
+   "compress_mbps": 243.85,
+   "decompress_mbps": 801.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4053259,
+   "ratio": 0.3977,
+   "compress_mbps": 170.19,
+   "decompress_mbps": 864.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3989875,
+   "ratio": 0.3915,
+   "compress_mbps": 140.0,
+   "decompress_mbps": 934.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3972869,
+   "ratio": 0.3898,
+   "compress_mbps": 127.83,
+   "decompress_mbps": 825.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3894026,
+   "ratio": 0.3821,
+   "compress_mbps": 99.29,
+   "decompress_mbps": 791.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3859436,
+   "ratio": 0.3787,
+   "compress_mbps": 75.65,
+   "decompress_mbps": 819.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3837515,
+   "ratio": 0.3765,
+   "compress_mbps": 55.71,
+   "decompress_mbps": 796.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3811467,
+   "ratio": 0.374,
+   "compress_mbps": 36.03,
+   "decompress_mbps": 816.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3810354,
+   "ratio": 0.3738,
+   "compress_mbps": 32.76,
+   "decompress_mbps": 816.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20192961,
+   "ratio": 0.3942,
+   "compress_mbps": 242.16,
+   "decompress_mbps": 676.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19374226,
+   "ratio": 0.3783,
+   "compress_mbps": 185.69,
+   "decompress_mbps": 710.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19234937,
+   "ratio": 0.3755,
+   "compress_mbps": 173.04,
+   "decompress_mbps": 727.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19145385,
+   "ratio": 0.3738,
+   "compress_mbps": 162.62,
+   "decompress_mbps": 728.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 18878875,
+   "ratio": 0.3686,
+   "compress_mbps": 142.62,
+   "decompress_mbps": 741.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 18805391,
+   "ratio": 0.3671,
+   "compress_mbps": 117.71,
+   "decompress_mbps": 750.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 18749947,
+   "ratio": 0.3661,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 759.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 18718540,
+   "ratio": 0.3655,
+   "compress_mbps": 47.56,
+   "decompress_mbps": 766.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18713659,
+   "ratio": 0.3654,
+   "compress_mbps": 33.49,
+   "decompress_mbps": 676.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3740775,
+   "ratio": 0.3752,
+   "compress_mbps": 293.42,
+   "decompress_mbps": 755.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3707407,
+   "ratio": 0.3718,
+   "compress_mbps": 217.45,
+   "decompress_mbps": 768.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3672389,
+   "ratio": 0.3683,
+   "compress_mbps": 185.43,
+   "decompress_mbps": 809.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3660011,
+   "ratio": 0.3671,
+   "compress_mbps": 171.62,
+   "decompress_mbps": 751.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3664245,
+   "ratio": 0.3675,
+   "compress_mbps": 141.37,
+   "decompress_mbps": 712.85
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3648644,
+   "ratio": 0.3659,
+   "compress_mbps": 106.84,
+   "decompress_mbps": 739.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3635323,
+   "ratio": 0.3646,
+   "compress_mbps": 68.34,
+   "decompress_mbps": 735.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3624778,
+   "ratio": 0.3635,
+   "compress_mbps": 43.04,
+   "decompress_mbps": 773.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3625176,
+   "ratio": 0.3636,
+   "compress_mbps": 38.87,
+   "decompress_mbps": 757.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3837577,
+   "ratio": 0.1144,
+   "compress_mbps": 609.02,
+   "decompress_mbps": 1491.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3714632,
+   "ratio": 0.1107,
+   "compress_mbps": 462.85,
+   "decompress_mbps": 1747.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3599455,
+   "ratio": 0.1073,
+   "compress_mbps": 427.07,
+   "decompress_mbps": 1882.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3431843,
+   "ratio": 0.1023,
+   "compress_mbps": 388.74,
+   "decompress_mbps": 1763.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268188,
+   "ratio": 0.0974,
+   "compress_mbps": 346.67,
+   "decompress_mbps": 1777.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3091741,
+   "ratio": 0.0921,
+   "compress_mbps": 264.16,
+   "decompress_mbps": 1787.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3032499,
+   "ratio": 0.0904,
+   "compress_mbps": 186.41,
+   "decompress_mbps": 1846.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2949097,
+   "ratio": 0.0879,
+   "compress_mbps": 97.63,
+   "decompress_mbps": 1789.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2925243,
+   "ratio": 0.0872,
+   "compress_mbps": 69.23,
+   "decompress_mbps": 1757.94
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3275124,
+   "ratio": 0.5324,
+   "compress_mbps": 166.26,
+   "decompress_mbps": 462.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3150806,
+   "ratio": 0.5121,
+   "compress_mbps": 128.39,
+   "decompress_mbps": 483.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3137061,
+   "ratio": 0.5099,
+   "compress_mbps": 120.82,
+   "decompress_mbps": 502.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129676,
+   "ratio": 0.5087,
+   "compress_mbps": 116.89,
+   "decompress_mbps": 518.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3079277,
+   "ratio": 0.5005,
+   "compress_mbps": 99.99,
+   "decompress_mbps": 536.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3072378,
+   "ratio": 0.4994,
+   "compress_mbps": 88.82,
+   "decompress_mbps": 533.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3068123,
+   "ratio": 0.4987,
+   "compress_mbps": 76.38,
+   "decompress_mbps": 542.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3067299,
+   "ratio": 0.4986,
+   "compress_mbps": 55.33,
+   "decompress_mbps": 533.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3066968,
+   "ratio": 0.4985,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 507.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3868663,
+   "ratio": 0.3836,
+   "compress_mbps": 285.16,
+   "decompress_mbps": 772.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3839158,
+   "ratio": 0.3807,
+   "compress_mbps": 213.22,
+   "decompress_mbps": 914.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3818964,
+   "ratio": 0.3787,
+   "compress_mbps": 197.74,
+   "decompress_mbps": 936.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3789325,
+   "ratio": 0.3757,
+   "compress_mbps": 179.66,
+   "decompress_mbps": 954.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3666476,
+   "ratio": 0.3635,
+   "compress_mbps": 157.89,
+   "decompress_mbps": 942.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3660266,
+   "ratio": 0.3629,
+   "compress_mbps": 142.43,
+   "decompress_mbps": 987.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3659491,
+   "ratio": 0.3628,
+   "compress_mbps": 135.11,
+   "decompress_mbps": 999.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3654863,
+   "ratio": 0.3624,
+   "compress_mbps": 114.32,
+   "decompress_mbps": 1009.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3654860,
+   "ratio": 0.3624,
+   "compress_mbps": 114.27,
+   "decompress_mbps": 1001.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2197055,
+   "ratio": 0.3315,
+   "compress_mbps": 300.85,
+   "decompress_mbps": 858.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2082309,
+   "ratio": 0.3142,
+   "compress_mbps": 214.77,
+   "decompress_mbps": 1130.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2021047,
+   "ratio": 0.305,
+   "compress_mbps": 178.67,
+   "decompress_mbps": 1236.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990952,
+   "ratio": 0.3004,
+   "compress_mbps": 157.4,
+   "decompress_mbps": 1146.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1921113,
+   "ratio": 0.2899,
+   "compress_mbps": 127.99,
+   "decompress_mbps": 1093.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1876257,
+   "ratio": 0.2831,
+   "compress_mbps": 86.94,
+   "decompress_mbps": 1090.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1832695,
+   "ratio": 0.2765,
+   "compress_mbps": 46.02,
+   "decompress_mbps": 1103.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1809967,
+   "ratio": 0.2731,
+   "compress_mbps": 24.27,
+   "decompress_mbps": 1063.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1806374,
+   "ratio": 0.2726,
+   "compress_mbps": 19.83,
+   "decompress_mbps": 1054.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5866517,
+   "ratio": 0.2715,
+   "compress_mbps": 338.52,
+   "decompress_mbps": 979.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5695942,
+   "ratio": 0.2636,
+   "compress_mbps": 258.0,
+   "decompress_mbps": 1031.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5605878,
+   "ratio": 0.2595,
+   "compress_mbps": 233.32,
+   "decompress_mbps": 1100.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5553432,
+   "ratio": 0.257,
+   "compress_mbps": 216.59,
+   "decompress_mbps": 1079.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5416713,
+   "ratio": 0.2507,
+   "compress_mbps": 186.71,
+   "decompress_mbps": 1066.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5337149,
+   "ratio": 0.247,
+   "compress_mbps": 142.78,
+   "decompress_mbps": 1079.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5310181,
+   "ratio": 0.2458,
+   "compress_mbps": 100.23,
+   "decompress_mbps": 1069.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5272761,
+   "ratio": 0.244,
+   "compress_mbps": 62.39,
+   "decompress_mbps": 1089.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5270405,
+   "ratio": 0.2439,
+   "compress_mbps": 50.04,
+   "decompress_mbps": 1101.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5575128,
+   "ratio": 0.7688,
+   "compress_mbps": 162.23,
+   "decompress_mbps": 485.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5417142,
+   "ratio": 0.747,
+   "compress_mbps": 116.65,
+   "decompress_mbps": 518.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5397999,
+   "ratio": 0.7444,
+   "compress_mbps": 105.25,
+   "decompress_mbps": 528.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5391125,
+   "ratio": 0.7434,
+   "compress_mbps": 99.31,
+   "decompress_mbps": 542.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5352212,
+   "ratio": 0.738,
+   "compress_mbps": 87.58,
+   "decompress_mbps": 513.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5335405,
+   "ratio": 0.7357,
+   "compress_mbps": 73.79,
+   "decompress_mbps": 526.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325697,
+   "ratio": 0.7344,
+   "compress_mbps": 63.45,
+   "decompress_mbps": 513.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5324004,
+   "ratio": 0.7341,
+   "compress_mbps": 52.34,
+   "decompress_mbps": 522.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323197,
+   "ratio": 0.734,
+   "compress_mbps": 50.85,
+   "decompress_mbps": 511.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13550569,
+   "ratio": 0.3268,
+   "compress_mbps": 266.06,
+   "decompress_mbps": 891.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13130705,
+   "ratio": 0.3167,
+   "compress_mbps": 199.84,
+   "decompress_mbps": 973.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12839361,
+   "ratio": 0.3097,
+   "compress_mbps": 176.74,
+   "decompress_mbps": 1015.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12601933,
+   "ratio": 0.304,
+   "compress_mbps": 161.98,
+   "decompress_mbps": 899.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12310776,
+   "ratio": 0.2969,
+   "compress_mbps": 131.58,
+   "decompress_mbps": 879.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12140474,
+   "ratio": 0.2928,
+   "compress_mbps": 104.62,
+   "decompress_mbps": 887.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12025296,
+   "ratio": 0.2901,
+   "compress_mbps": 75.01,
+   "decompress_mbps": 892.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11893824,
+   "ratio": 0.2869,
+   "compress_mbps": 45.87,
+   "decompress_mbps": 886.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11882496,
+   "ratio": 0.2866,
+   "compress_mbps": 39.46,
+   "decompress_mbps": 930.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6293390,
+   "ratio": 0.7426,
+   "compress_mbps": 145.39,
+   "decompress_mbps": 523.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6058412,
+   "ratio": 0.7149,
+   "compress_mbps": 120.35,
+   "decompress_mbps": 529.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6058381,
+   "ratio": 0.7149,
+   "compress_mbps": 120.3,
+   "decompress_mbps": 539.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6058363,
+   "ratio": 0.7149,
+   "compress_mbps": 120.03,
+   "decompress_mbps": 437.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5998400,
+   "ratio": 0.7078,
+   "compress_mbps": 108.52,
+   "decompress_mbps": 459.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5998438,
+   "ratio": 0.7078,
+   "compress_mbps": 108.55,
+   "decompress_mbps": 463.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5998439,
+   "ratio": 0.7078,
+   "compress_mbps": 108.18,
+   "decompress_mbps": 462.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 90.15,
+   "decompress_mbps": 462.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 90.18,
+   "decompress_mbps": 454.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 887708,
+   "ratio": 0.1661,
+   "compress_mbps": 492.83,
+   "decompress_mbps": 1270.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 843475,
+   "ratio": 0.1578,
+   "compress_mbps": 363.79,
+   "decompress_mbps": 1801.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 793388,
+   "ratio": 0.1484,
+   "compress_mbps": 337.16,
+   "decompress_mbps": 1867.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 747602,
+   "ratio": 0.1399,
+   "compress_mbps": 304.24,
+   "decompress_mbps": 1819.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 718615,
+   "ratio": 0.1344,
+   "compress_mbps": 263.07,
+   "decompress_mbps": 1830.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 684405,
+   "ratio": 0.128,
+   "compress_mbps": 206.4,
+   "decompress_mbps": 1920.08
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 664859,
+   "ratio": 0.1244,
+   "compress_mbps": 142.72,
+   "decompress_mbps": 1906.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 650835,
+   "ratio": 0.1218,
+   "compress_mbps": 81.56,
+   "decompress_mbps": 1892.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 649494,
+   "ratio": 0.1215,
+   "compress_mbps": 68.13,
+   "decompress_mbps": 1902.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65708,
+   "ratio": 0.432,
+   "compress_mbps": 42.56,
+   "decompress_mbps": 61.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 60259,
+   "ratio": 0.3962,
+   "compress_mbps": 26.21,
+   "decompress_mbps": 68.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 58544,
+   "ratio": 0.3849,
+   "compress_mbps": 21.92,
+   "decompress_mbps": 69.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56238,
+   "ratio": 0.3698,
+   "compress_mbps": 21.46,
+   "decompress_mbps": 70.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54764,
+   "ratio": 0.3601,
+   "compress_mbps": 16.16,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54311,
+   "ratio": 0.3571,
+   "compress_mbps": 10.7,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54262,
+   "ratio": 0.3568,
+   "compress_mbps": 9.8,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.57,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.65,
+   "decompress_mbps": 72.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56882,
+   "ratio": 0.4544,
+   "compress_mbps": 37.25,
+   "decompress_mbps": 55.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52826,
+   "ratio": 0.422,
+   "compress_mbps": 23.05,
+   "decompress_mbps": 62.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51625,
+   "ratio": 0.4124,
+   "compress_mbps": 22.69,
+   "decompress_mbps": 65.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50034,
+   "ratio": 0.3997,
+   "compress_mbps": 22.5,
+   "decompress_mbps": 65.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48912,
+   "ratio": 0.3907,
+   "compress_mbps": 12.62,
+   "decompress_mbps": 65.42
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48738,
+   "ratio": 0.3893,
+   "compress_mbps": 11.77,
+   "decompress_mbps": 65.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48719,
+   "ratio": 0.3892,
+   "compress_mbps": 9.97,
+   "decompress_mbps": 65.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 9.9,
+   "decompress_mbps": 68.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 12.58,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8988,
+   "ratio": 0.3653,
+   "compress_mbps": 36.94,
+   "decompress_mbps": 103.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8564,
+   "ratio": 0.3481,
+   "compress_mbps": 43.51,
+   "decompress_mbps": 102.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8390,
+   "ratio": 0.341,
+   "compress_mbps": 28.97,
+   "decompress_mbps": 97.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8167,
+   "ratio": 0.332,
+   "compress_mbps": 37.49,
+   "decompress_mbps": 98.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 88.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 22.76,
+   "decompress_mbps": 104.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 21.67,
+   "decompress_mbps": 85.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 20.13,
+   "decompress_mbps": 105.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 92.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3731,
+   "ratio": 0.3346,
+   "compress_mbps": 18.9,
+   "decompress_mbps": 80.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3491,
+   "ratio": 0.3131,
+   "compress_mbps": 23.63,
+   "decompress_mbps": 84.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3384,
+   "ratio": 0.3035,
+   "compress_mbps": 22.04,
+   "decompress_mbps": 89.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3220,
+   "ratio": 0.2888,
+   "compress_mbps": 21.08,
+   "decompress_mbps": 86.53
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3138,
+   "ratio": 0.2814,
+   "compress_mbps": 17.11,
+   "decompress_mbps": 93.05
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3118,
+   "ratio": 0.2796,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 100.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.26,
+   "decompress_mbps": 96.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.4,
+   "decompress_mbps": 104.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 15.81,
+   "decompress_mbps": 101.86
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1352,
+   "ratio": 0.3633,
+   "compress_mbps": 8.47,
+   "decompress_mbps": 63.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1287,
+   "ratio": 0.3459,
+   "compress_mbps": 11.63,
+   "decompress_mbps": 60.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1284,
+   "ratio": 0.3451,
+   "compress_mbps": 11.67,
+   "decompress_mbps": 62.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1226,
+   "ratio": 0.3295,
+   "compress_mbps": 11.31,
+   "decompress_mbps": 66.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 9.84,
+   "decompress_mbps": 63.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.84,
+   "decompress_mbps": 63.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.02,
+   "decompress_mbps": 64.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.74,
+   "decompress_mbps": 80.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 11.17,
+   "decompress_mbps": 63.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 245423,
+   "ratio": 0.2383,
+   "compress_mbps": 123.71,
+   "decompress_mbps": 127.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 229642,
+   "ratio": 0.223,
+   "compress_mbps": 92.84,
+   "decompress_mbps": 151.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 225678,
+   "ratio": 0.2192,
+   "compress_mbps": 109.83,
+   "decompress_mbps": 153.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 218218,
+   "ratio": 0.2119,
+   "compress_mbps": 99.82,
+   "decompress_mbps": 163.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 210550,
+   "ratio": 0.2045,
+   "compress_mbps": 48.7,
+   "decompress_mbps": 154.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 207949,
+   "ratio": 0.2019,
+   "compress_mbps": 27.88,
+   "decompress_mbps": 168.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207413,
+   "ratio": 0.2014,
+   "compress_mbps": 18.82,
+   "decompress_mbps": 151.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 207478,
+   "ratio": 0.2015,
+   "compress_mbps": 6.77,
+   "decompress_mbps": 153.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207482,
+   "ratio": 0.2015,
+   "compress_mbps": 3.56,
+   "decompress_mbps": 157.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 175980,
+   "ratio": 0.4124,
+   "compress_mbps": 43.31,
+   "decompress_mbps": 64.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 160455,
+   "ratio": 0.376,
+   "compress_mbps": 70.41,
+   "decompress_mbps": 72.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 156690,
+   "ratio": 0.3672,
+   "compress_mbps": 32.21,
+   "decompress_mbps": 74.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149064,
+   "ratio": 0.3493,
+   "compress_mbps": 36.48,
+   "decompress_mbps": 75.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145616,
+   "ratio": 0.3412,
+   "compress_mbps": 20.01,
+   "decompress_mbps": 76.95
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144773,
+   "ratio": 0.3392,
+   "compress_mbps": 17.53,
+   "decompress_mbps": 76.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144603,
+   "ratio": 0.3388,
+   "compress_mbps": 19.93,
+   "decompress_mbps": 75.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144573,
+   "ratio": 0.3388,
+   "compress_mbps": 16.49,
+   "decompress_mbps": 80.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144570,
+   "ratio": 0.3388,
+   "compress_mbps": 15.68,
+   "decompress_mbps": 75.93
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228837,
+   "ratio": 0.4749,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 54.63
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 211248,
+   "ratio": 0.4384,
+   "compress_mbps": 31.57,
+   "decompress_mbps": 61.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 205619,
+   "ratio": 0.4267,
+   "compress_mbps": 25.52,
+   "decompress_mbps": 67.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200595,
+   "ratio": 0.4163,
+   "compress_mbps": 34.86,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195418,
+   "ratio": 0.4055,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 65.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194148,
+   "ratio": 0.4029,
+   "compress_mbps": 15.2,
+   "decompress_mbps": 66.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 193994,
+   "ratio": 0.4026,
+   "compress_mbps": 16.61,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.97,
+   "decompress_mbps": 65.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.75,
+   "decompress_mbps": 80.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60990,
+   "ratio": 0.1188,
+   "compress_mbps": 240.46,
+   "decompress_mbps": 173.43
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 61650,
+   "ratio": 0.1201,
+   "compress_mbps": 103.12,
+   "decompress_mbps": 188.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 60035,
+   "ratio": 0.117,
+   "compress_mbps": 90.48,
+   "decompress_mbps": 205.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57005,
+   "ratio": 0.1111,
+   "compress_mbps": 91.56,
+   "decompress_mbps": 195.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55779,
+   "ratio": 0.1087,
+   "compress_mbps": 81.64,
+   "decompress_mbps": 263.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 54970,
+   "ratio": 0.1071,
+   "compress_mbps": 69.16,
+   "decompress_mbps": 204.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53922,
+   "ratio": 0.1051,
+   "compress_mbps": 76.91,
+   "decompress_mbps": 217.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 51977,
+   "ratio": 0.1013,
+   "compress_mbps": 17.63,
+   "decompress_mbps": 275.85
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51474,
+   "ratio": 0.1003,
+   "compress_mbps": 6.71,
+   "decompress_mbps": 239.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14783,
+   "ratio": 0.3866,
+   "compress_mbps": 32.71,
+   "decompress_mbps": 70.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14101,
+   "ratio": 0.3688,
+   "compress_mbps": 33.16,
+   "decompress_mbps": 78.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13975,
+   "ratio": 0.3655,
+   "compress_mbps": 28.17,
+   "decompress_mbps": 75.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13632,
+   "ratio": 0.3565,
+   "compress_mbps": 30.93,
+   "decompress_mbps": 100.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13302,
+   "ratio": 0.3479,
+   "compress_mbps": 25.78,
+   "decompress_mbps": 79.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13279,
+   "ratio": 0.3473,
+   "compress_mbps": 21.9,
+   "decompress_mbps": 77.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13274,
+   "ratio": 0.3471,
+   "compress_mbps": 19.14,
+   "decompress_mbps": 84.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 7.15,
+   "decompress_mbps": 80.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 4.57,
+   "decompress_mbps": 79.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1862,
+   "ratio": 0.4405,
+   "compress_mbps": 9.05,
+   "decompress_mbps": 61.67
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1803,
+   "ratio": 0.4265,
+   "compress_mbps": 12.61,
+   "decompress_mbps": 58.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1791,
+   "ratio": 0.4237,
+   "compress_mbps": 12.87,
+   "decompress_mbps": 60.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 60.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.95,
+   "decompress_mbps": 59.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 59.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.98,
+   "decompress_mbps": 65.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.09,
+   "decompress_mbps": 61.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.55,
+   "decompress_mbps": 61.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4623589,
+   "ratio": 0.4536,
+   "compress_mbps": 87.88,
+   "decompress_mbps": 121.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4241525,
+   "ratio": 0.4161,
+   "compress_mbps": 59.05,
+   "decompress_mbps": 124.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4123202,
+   "ratio": 0.4045,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 116.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3985937,
+   "ratio": 0.3911,
+   "compress_mbps": 60.91,
+   "decompress_mbps": 204.23
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3883839,
+   "ratio": 0.3811,
+   "compress_mbps": 35.59,
+   "decompress_mbps": 119.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3860437,
+   "ratio": 0.3788,
+   "compress_mbps": 27.93,
+   "decompress_mbps": 202.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3857076,
+   "ratio": 0.3784,
+   "compress_mbps": 25.13,
+   "decompress_mbps": 126.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.66,
+   "decompress_mbps": 202.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.68,
+   "decompress_mbps": 116.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21508211,
+   "ratio": 0.4199,
+   "compress_mbps": 143.1,
+   "decompress_mbps": 239.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20538783,
+   "ratio": 0.401,
+   "compress_mbps": 103.18,
+   "decompress_mbps": 229.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20334352,
+   "ratio": 0.397,
+   "compress_mbps": 88.51,
+   "decompress_mbps": 208.07
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19886937,
+   "ratio": 0.3883,
+   "compress_mbps": 86.76,
+   "decompress_mbps": 244.41
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19582363,
+   "ratio": 0.3823,
+   "compress_mbps": 65.59,
+   "decompress_mbps": 239.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19512479,
+   "ratio": 0.381,
+   "compress_mbps": 43.56,
+   "decompress_mbps": 220.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19489160,
+   "ratio": 0.3805,
+   "compress_mbps": 32.93,
+   "decompress_mbps": 227.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19475109,
+   "ratio": 0.3802,
+   "compress_mbps": 18.63,
+   "decompress_mbps": 225.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19476276,
+   "ratio": 0.3802,
+   "compress_mbps": 10.28,
+   "decompress_mbps": 247.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3967718,
+   "ratio": 0.3979,
+   "compress_mbps": 146.76,
+   "decompress_mbps": 172.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3773274,
+   "ratio": 0.3784,
+   "compress_mbps": 105.47,
+   "decompress_mbps": 124.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3670460,
+   "ratio": 0.3681,
+   "compress_mbps": 77.56,
+   "decompress_mbps": 182.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3655100,
+   "ratio": 0.3666,
+   "compress_mbps": 87.36,
+   "decompress_mbps": 107.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3620881,
+   "ratio": 0.3632,
+   "compress_mbps": 51.01,
+   "decompress_mbps": 125.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3606626,
+   "ratio": 0.3617,
+   "compress_mbps": 33.83,
+   "decompress_mbps": 183.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3605405,
+   "ratio": 0.3616,
+   "compress_mbps": 31.23,
+   "decompress_mbps": 130.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3601635,
+   "ratio": 0.3612,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 133.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3601151,
+   "ratio": 0.3612,
+   "compress_mbps": 19.51,
+   "decompress_mbps": 120.72
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4501482,
+   "ratio": 0.1342,
+   "compress_mbps": 294.72,
+   "decompress_mbps": 451.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3875891,
+   "ratio": 0.1155,
+   "compress_mbps": 315.51,
+   "decompress_mbps": 356.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3731525,
+   "ratio": 0.1112,
+   "compress_mbps": 288.4,
+   "decompress_mbps": 372.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3542242,
+   "ratio": 0.1056,
+   "compress_mbps": 236.86,
+   "decompress_mbps": 484.44
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3239184,
+   "ratio": 0.0965,
+   "compress_mbps": 175.14,
+   "decompress_mbps": 539.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3113927,
+   "ratio": 0.0928,
+   "compress_mbps": 120.53,
+   "decompress_mbps": 330.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3063520,
+   "ratio": 0.0913,
+   "compress_mbps": 84.76,
+   "decompress_mbps": 331.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2961320,
+   "ratio": 0.0883,
+   "compress_mbps": 29.61,
+   "decompress_mbps": 401.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2940087,
+   "ratio": 0.0876,
+   "compress_mbps": 20.54,
+   "decompress_mbps": 474.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3462708,
+   "ratio": 0.5628,
+   "compress_mbps": 65.77,
+   "decompress_mbps": 109.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3327399,
+   "ratio": 0.5408,
+   "compress_mbps": 71.78,
+   "decompress_mbps": 84.48
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3297422,
+   "ratio": 0.536,
+   "compress_mbps": 66.06,
+   "decompress_mbps": 89.69
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3249485,
+   "ratio": 0.5282,
+   "compress_mbps": 64.02,
+   "decompress_mbps": 122.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3220046,
+   "ratio": 0.5234,
+   "compress_mbps": 49.81,
+   "decompress_mbps": 90.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3213239,
+   "ratio": 0.5223,
+   "compress_mbps": 43.12,
+   "decompress_mbps": 91.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3212009,
+   "ratio": 0.5221,
+   "compress_mbps": 39.44,
+   "decompress_mbps": 177.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3211575,
+   "ratio": 0.522,
+   "compress_mbps": 27.92,
+   "decompress_mbps": 92.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3211561,
+   "ratio": 0.522,
+   "compress_mbps": 29.68,
+   "decompress_mbps": 92.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4334497,
+   "ratio": 0.4298,
+   "compress_mbps": 130.93,
+   "decompress_mbps": 133.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3900156,
+   "ratio": 0.3867,
+   "compress_mbps": 131.77,
+   "decompress_mbps": 116.9
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3876099,
+   "ratio": 0.3843,
+   "compress_mbps": 122.94,
+   "decompress_mbps": 133.81
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3782364,
+   "ratio": 0.375,
+   "compress_mbps": 110.84,
+   "decompress_mbps": 135.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3679310,
+   "ratio": 0.3648,
+   "compress_mbps": 89.42,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3679424,
+   "ratio": 0.3648,
+   "compress_mbps": 87.41,
+   "decompress_mbps": 128.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3679163,
+   "ratio": 0.3648,
+   "compress_mbps": 83.39,
+   "decompress_mbps": 141.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 82.21,
+   "decompress_mbps": 140.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 81.84,
+   "decompress_mbps": 196.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2496363,
+   "ratio": 0.3767,
+   "compress_mbps": 96.93,
+   "decompress_mbps": 111.19
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2202601,
+   "ratio": 0.3324,
+   "compress_mbps": 92.65,
+   "decompress_mbps": 102.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2103089,
+   "ratio": 0.3173,
+   "compress_mbps": 49.73,
+   "decompress_mbps": 242.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1999697,
+   "ratio": 0.3017,
+   "compress_mbps": 75.29,
+   "decompress_mbps": 121.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892143,
+   "ratio": 0.2855,
+   "compress_mbps": 37.29,
+   "decompress_mbps": 108.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1838372,
+   "ratio": 0.2774,
+   "compress_mbps": 20.3,
+   "decompress_mbps": 108.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1828850,
+   "ratio": 0.276,
+   "compress_mbps": 15.87,
+   "decompress_mbps": 115.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.46,
+   "decompress_mbps": 114.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.53,
+   "decompress_mbps": 97.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6447290,
+   "ratio": 0.2984,
+   "compress_mbps": 187.76,
+   "decompress_mbps": 292.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6030257,
+   "ratio": 0.2791,
+   "compress_mbps": 147.85,
+   "decompress_mbps": 241.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5928121,
+   "ratio": 0.2744,
+   "compress_mbps": 128.5,
+   "decompress_mbps": 269.87
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5615804,
+   "ratio": 0.2599,
+   "compress_mbps": 121.57,
+   "decompress_mbps": 280.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5496738,
+   "ratio": 0.2544,
+   "compress_mbps": 80.22,
+   "decompress_mbps": 336.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464184,
+   "ratio": 0.2529,
+   "compress_mbps": 62.73,
+   "decompress_mbps": 195.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429645,
+   "ratio": 0.2513,
+   "compress_mbps": 47.93,
+   "decompress_mbps": 214.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5418135,
+   "ratio": 0.2508,
+   "compress_mbps": 36.65,
+   "decompress_mbps": 241.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5416628,
+   "ratio": 0.2507,
+   "compress_mbps": 33.67,
+   "decompress_mbps": 233.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5759187,
+   "ratio": 0.7942,
+   "compress_mbps": 91.27,
+   "decompress_mbps": 158.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5619390,
+   "ratio": 0.7749,
+   "compress_mbps": 49.54,
+   "decompress_mbps": 94.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5560914,
+   "ratio": 0.7668,
+   "compress_mbps": 43.81,
+   "decompress_mbps": 115.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5544069,
+   "ratio": 0.7645,
+   "compress_mbps": 44.58,
+   "decompress_mbps": 94.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5518257,
+   "ratio": 0.7609,
+   "compress_mbps": 36.73,
+   "decompress_mbps": 163.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5508662,
+   "ratio": 0.7596,
+   "compress_mbps": 33.77,
+   "decompress_mbps": 95.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5507534,
+   "ratio": 0.7595,
+   "compress_mbps": 35.09,
+   "decompress_mbps": 95.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.41,
+   "decompress_mbps": 94.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.5,
+   "decompress_mbps": 117.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 15230651,
+   "ratio": 0.3674,
+   "compress_mbps": 123.36,
+   "decompress_mbps": 184.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13822040,
+   "ratio": 0.3334,
+   "compress_mbps": 96.36,
+   "decompress_mbps": 194.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13397592,
+   "ratio": 0.3232,
+   "compress_mbps": 83.62,
+   "decompress_mbps": 202.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12759940,
+   "ratio": 0.3078,
+   "compress_mbps": 80.4,
+   "decompress_mbps": 223.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12274278,
+   "ratio": 0.2961,
+   "compress_mbps": 54.6,
+   "decompress_mbps": 216.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12131738,
+   "ratio": 0.2926,
+   "compress_mbps": 40.41,
+   "decompress_mbps": 218.2
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12060450,
+   "ratio": 0.2909,
+   "compress_mbps": 33.43,
+   "decompress_mbps": 203.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 206.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 30.01,
+   "decompress_mbps": 223.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6653052,
+   "ratio": 0.7851,
+   "compress_mbps": 124.38,
+   "decompress_mbps": 152.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6305035,
+   "ratio": 0.744,
+   "compress_mbps": 53.84,
+   "decompress_mbps": 154.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6302730,
+   "ratio": 0.7438,
+   "compress_mbps": 52.94,
+   "decompress_mbps": 119.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6299134,
+   "ratio": 0.7433,
+   "compress_mbps": 52.14,
+   "decompress_mbps": 156.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6289022,
+   "ratio": 0.7421,
+   "compress_mbps": 64.63,
+   "decompress_mbps": 159.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.64,
+   "decompress_mbps": 156.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.91,
+   "decompress_mbps": 165.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.4,
+   "decompress_mbps": 157.39
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.37,
+   "decompress_mbps": 98.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 989456,
+   "ratio": 0.1851,
+   "compress_mbps": 243.16,
+   "decompress_mbps": 153.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 839766,
+   "ratio": 0.1571,
+   "compress_mbps": 178.46,
+   "decompress_mbps": 169.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 800619,
+   "ratio": 0.1498,
+   "compress_mbps": 181.16,
+   "decompress_mbps": 178.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 776397,
+   "ratio": 0.1452,
+   "compress_mbps": 149.67,
+   "decompress_mbps": 185.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 712679,
+   "ratio": 0.1333,
+   "compress_mbps": 103.54,
+   "decompress_mbps": 199.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 683707,
+   "ratio": 0.1279,
+   "compress_mbps": 93.5,
+   "decompress_mbps": 512.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668601,
+   "ratio": 0.1251,
+   "compress_mbps": 70.7,
+   "decompress_mbps": 209.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659106,
+   "ratio": 0.1233,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 216.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658920,
+   "ratio": 0.1233,
+   "compress_mbps": 42.13,
+   "decompress_mbps": 256.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 62797,
+   "ratio": 0.4129,
+   "compress_mbps": 75.96,
+   "decompress_mbps": 132.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 59605,
+   "ratio": 0.3919,
+   "compress_mbps": 62.87,
+   "decompress_mbps": 131.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57675,
+   "ratio": 0.3792,
+   "compress_mbps": 53.89,
+   "decompress_mbps": 124.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56500,
+   "ratio": 0.3715,
+   "compress_mbps": 38.93,
+   "decompress_mbps": 131.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 56440,
+   "ratio": 0.3711,
+   "compress_mbps": 38.82,
+   "decompress_mbps": 130.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55443,
+   "ratio": 0.3645,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 146.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55373,
+   "ratio": 0.3641,
+   "compress_mbps": 31.65,
+   "decompress_mbps": 130.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.32,
+   "decompress_mbps": 136.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.37,
+   "decompress_mbps": 135.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 55063,
+   "ratio": 0.4399,
+   "compress_mbps": 74.97,
+   "decompress_mbps": 117.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52932,
+   "ratio": 0.4229,
+   "compress_mbps": 60.75,
+   "decompress_mbps": 116.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51597,
+   "ratio": 0.4122,
+   "compress_mbps": 44.1,
+   "decompress_mbps": 116.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50780,
+   "ratio": 0.4057,
+   "compress_mbps": 43.18,
+   "decompress_mbps": 120.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 50767,
+   "ratio": 0.4056,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 122.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50160,
+   "ratio": 0.4007,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 128.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 31.52,
+   "decompress_mbps": 124.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 125.83
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 35.79,
+   "decompress_mbps": 124.35
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8730,
+   "ratio": 0.3548,
+   "compress_mbps": 46.94,
+   "decompress_mbps": 123.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8457,
+   "ratio": 0.3437,
+   "compress_mbps": 43.65,
+   "decompress_mbps": 119.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8353,
+   "ratio": 0.3395,
+   "compress_mbps": 64.98,
+   "decompress_mbps": 109.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8301,
+   "ratio": 0.3374,
+   "compress_mbps": 42.45,
+   "decompress_mbps": 124.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8212,
+   "ratio": 0.3338,
+   "compress_mbps": 58.84,
+   "decompress_mbps": 103.81
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8172,
+   "ratio": 0.3322,
+   "compress_mbps": 48.55,
+   "decompress_mbps": 108.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 50.28,
+   "decompress_mbps": 109.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 109.09
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 53.75,
+   "decompress_mbps": 109.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3475,
+   "ratio": 0.3117,
+   "compress_mbps": 109.11,
+   "decompress_mbps": 96.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3305,
+   "ratio": 0.2964,
+   "compress_mbps": 102.67,
+   "decompress_mbps": 101.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3225,
+   "ratio": 0.2892,
+   "compress_mbps": 91.21,
+   "decompress_mbps": 104.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3192,
+   "ratio": 0.2863,
+   "compress_mbps": 100.3,
+   "decompress_mbps": 104.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3180,
+   "ratio": 0.2852,
+   "compress_mbps": 100.47,
+   "decompress_mbps": 98.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 94.55,
+   "decompress_mbps": 99.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 95.62,
+   "decompress_mbps": 95.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 91.52,
+   "decompress_mbps": 121.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 83.09,
+   "decompress_mbps": 95.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1275,
+   "ratio": 0.3426,
+   "compress_mbps": 59.58,
+   "decompress_mbps": 44.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1247,
+   "ratio": 0.3351,
+   "compress_mbps": 59.47,
+   "decompress_mbps": 52.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 56.69,
+   "decompress_mbps": 51.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 58.55,
+   "decompress_mbps": 50.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 48.99,
+   "decompress_mbps": 51.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 56.51,
+   "decompress_mbps": 50.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.71,
+   "decompress_mbps": 51.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 50.22,
+   "decompress_mbps": 48.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.39,
+   "decompress_mbps": 48.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 226284,
+   "ratio": 0.2197,
+   "compress_mbps": 113.28,
+   "decompress_mbps": 183.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 221369,
+   "ratio": 0.215,
+   "compress_mbps": 90.24,
+   "decompress_mbps": 255.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 218607,
+   "ratio": 0.2123,
+   "compress_mbps": 78.67,
+   "decompress_mbps": 187.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 69.94,
+   "decompress_mbps": 195.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 70.92,
+   "decompress_mbps": 195.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217312,
+   "ratio": 0.211,
+   "compress_mbps": 44.09,
+   "decompress_mbps": 191.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 215966,
+   "ratio": 0.2097,
+   "compress_mbps": 31.15,
+   "decompress_mbps": 191.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 215930,
+   "ratio": 0.2097,
+   "compress_mbps": 14.32,
+   "decompress_mbps": 194.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 215912,
+   "ratio": 0.2097,
+   "compress_mbps": 11.1,
+   "decompress_mbps": 210.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 167622,
+   "ratio": 0.3928,
+   "compress_mbps": 64.39,
+   "decompress_mbps": 116.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 158003,
+   "ratio": 0.3702,
+   "compress_mbps": 64.34,
+   "decompress_mbps": 139.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 152928,
+   "ratio": 0.3584,
+   "compress_mbps": 46.67,
+   "decompress_mbps": 141.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149886,
+   "ratio": 0.3512,
+   "compress_mbps": 33.71,
+   "decompress_mbps": 136.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 149767,
+   "ratio": 0.3509,
+   "compress_mbps": 39.31,
+   "decompress_mbps": 138
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147818,
+   "ratio": 0.3464,
+   "compress_mbps": 33.18,
+   "decompress_mbps": 150.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147733,
+   "ratio": 0.3462,
+   "compress_mbps": 32.42,
+   "decompress_mbps": 154.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147709,
+   "ratio": 0.3461,
+   "compress_mbps": 32.15,
+   "decompress_mbps": 151.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147705,
+   "ratio": 0.3461,
+   "compress_mbps": 32.65,
+   "decompress_mbps": 138.19
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 222866,
+   "ratio": 0.4625,
+   "compress_mbps": 58.92,
+   "decompress_mbps": 105.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 212925,
+   "ratio": 0.4419,
+   "compress_mbps": 49.52,
+   "decompress_mbps": 118.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 206913,
+   "ratio": 0.4294,
+   "compress_mbps": 40.5,
+   "decompress_mbps": 116.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 202875,
+   "ratio": 0.421,
+   "compress_mbps": 33.54,
+   "decompress_mbps": 111.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 202867,
+   "ratio": 0.421,
+   "compress_mbps": 33.57,
+   "decompress_mbps": 117.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199818,
+   "ratio": 0.4147,
+   "compress_mbps": 28.4,
+   "decompress_mbps": 114.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 199664,
+   "ratio": 0.4144,
+   "compress_mbps": 27.76,
+   "decompress_mbps": 105.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 28.19,
+   "decompress_mbps": 106.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 27.99,
+   "decompress_mbps": 121
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60580,
+   "ratio": 0.118,
+   "compress_mbps": 118.15,
+   "decompress_mbps": 253.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59663,
+   "ratio": 0.1163,
+   "compress_mbps": 131.11,
+   "decompress_mbps": 295.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 59465,
+   "ratio": 0.1159,
+   "compress_mbps": 100.74,
+   "decompress_mbps": 295.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 59353,
+   "ratio": 0.1156,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 302.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 58830,
+   "ratio": 0.1146,
+   "compress_mbps": 107.76,
+   "decompress_mbps": 221.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 57884,
+   "ratio": 0.1128,
+   "compress_mbps": 56.85,
+   "decompress_mbps": 285.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 57206,
+   "ratio": 0.1115,
+   "compress_mbps": 46.17,
+   "decompress_mbps": 299.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 56545,
+   "ratio": 0.1102,
+   "compress_mbps": 23.09,
+   "decompress_mbps": 280.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 56454,
+   "ratio": 0.11,
+   "compress_mbps": 9.11,
+   "decompress_mbps": 300.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14194,
+   "ratio": 0.3712,
+   "compress_mbps": 83.27,
+   "decompress_mbps": 134.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13770,
+   "ratio": 0.3601,
+   "compress_mbps": 74.14,
+   "decompress_mbps": 116.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13611,
+   "ratio": 0.3559,
+   "compress_mbps": 66.24,
+   "decompress_mbps": 115.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13534,
+   "ratio": 0.3539,
+   "compress_mbps": 61.31,
+   "decompress_mbps": 117.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13527,
+   "ratio": 0.3537,
+   "compress_mbps": 61.97,
+   "decompress_mbps": 148.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13438,
+   "ratio": 0.3514,
+   "compress_mbps": 51.17,
+   "decompress_mbps": 142.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13419,
+   "ratio": 0.3509,
+   "compress_mbps": 47.83,
+   "decompress_mbps": 125.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13404,
+   "ratio": 0.3505,
+   "compress_mbps": 41.2,
+   "decompress_mbps": 118.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13390,
+   "ratio": 0.3502,
+   "compress_mbps": 35.78,
+   "decompress_mbps": 116.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1832,
+   "ratio": 0.4334,
+   "compress_mbps": 41.01,
+   "decompress_mbps": 45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1776,
+   "ratio": 0.4202,
+   "compress_mbps": 58.71,
+   "decompress_mbps": 64.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1764,
+   "ratio": 0.4173,
+   "compress_mbps": 57.37,
+   "decompress_mbps": 62.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1763,
+   "ratio": 0.4171,
+   "compress_mbps": 56.88,
+   "decompress_mbps": 53.28
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 59.36,
+   "decompress_mbps": 48.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 40.25,
+   "decompress_mbps": 47.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 57.06,
+   "decompress_mbps": 48.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.67,
+   "decompress_mbps": 52.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.3,
+   "decompress_mbps": 62.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4462632,
+   "ratio": 0.4378,
+   "compress_mbps": 61.62,
+   "decompress_mbps": 170.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4244833,
+   "ratio": 0.4165,
+   "compress_mbps": 50.24,
+   "decompress_mbps": 201.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4112285,
+   "ratio": 0.4035,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 178.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4020435,
+   "ratio": 0.3945,
+   "compress_mbps": 35.5,
+   "decompress_mbps": 142.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4019177,
+   "ratio": 0.3943,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 170.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3956464,
+   "ratio": 0.3882,
+   "compress_mbps": 28.75,
+   "decompress_mbps": 164.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3953310,
+   "ratio": 0.3879,
+   "compress_mbps": 28.47,
+   "decompress_mbps": 198.87
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 220.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.21,
+   "decompress_mbps": 218.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20177423,
+   "ratio": 0.3939,
+   "compress_mbps": 72.68,
+   "decompress_mbps": 209.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19759467,
+   "ratio": 0.3858,
+   "compress_mbps": 63.85,
+   "decompress_mbps": 193.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19583171,
+   "ratio": 0.3823,
+   "compress_mbps": 57.14,
+   "decompress_mbps": 206.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19479125,
+   "ratio": 0.3803,
+   "compress_mbps": 51.03,
+   "decompress_mbps": 205.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19423693,
+   "ratio": 0.3792,
+   "compress_mbps": 49.13,
+   "decompress_mbps": 200.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19337683,
+   "ratio": 0.3775,
+   "compress_mbps": 36.05,
+   "decompress_mbps": 188.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19323922,
+   "ratio": 0.3773,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 193.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19314797,
+   "ratio": 0.3771,
+   "compress_mbps": 19.5,
+   "decompress_mbps": 225.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19312663,
+   "ratio": 0.377,
+   "compress_mbps": 11.12,
+   "decompress_mbps": 219.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3762978,
+   "ratio": 0.3774,
+   "compress_mbps": 78.68,
+   "decompress_mbps": 163.86
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3711615,
+   "ratio": 0.3723,
+   "compress_mbps": 68.1,
+   "decompress_mbps": 196.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3663131,
+   "ratio": 0.3674,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 241.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3631512,
+   "ratio": 0.3642,
+   "compress_mbps": 49.21,
+   "decompress_mbps": 221.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3630867,
+   "ratio": 0.3642,
+   "compress_mbps": 48.78,
+   "decompress_mbps": 216.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3615953,
+   "ratio": 0.3627,
+   "compress_mbps": 37.72,
+   "decompress_mbps": 247.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3615518,
+   "ratio": 0.3626,
+   "compress_mbps": 35.3,
+   "decompress_mbps": 189.82
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3613845,
+   "ratio": 0.3625,
+   "compress_mbps": 30.03,
+   "decompress_mbps": 255.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3614283,
+   "ratio": 0.3625,
+   "compress_mbps": 26.24,
+   "decompress_mbps": 222.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4418800,
+   "ratio": 0.1317,
+   "compress_mbps": 133,
+   "decompress_mbps": 338.57
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4026774,
+   "ratio": 0.12,
+   "compress_mbps": 123.44,
+   "decompress_mbps": 339.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3837798,
+   "ratio": 0.1144,
+   "compress_mbps": 116.34,
+   "decompress_mbps": 370.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3751023,
+   "ratio": 0.1118,
+   "compress_mbps": 110.1,
+   "decompress_mbps": 361.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3643468,
+   "ratio": 0.1086,
+   "compress_mbps": 101.98,
+   "decompress_mbps": 371.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3379481,
+   "ratio": 0.1007,
+   "compress_mbps": 68.99,
+   "decompress_mbps": 366.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3354082,
+   "ratio": 0.1,
+   "compress_mbps": 61.49,
+   "decompress_mbps": 366.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3330028,
+   "ratio": 0.0992,
+   "compress_mbps": 49.65,
+   "decompress_mbps": 396.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3327482,
+   "ratio": 0.0992,
+   "compress_mbps": 37.41,
+   "decompress_mbps": 367.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3233790,
+   "ratio": 0.5256,
+   "compress_mbps": 52.65,
+   "decompress_mbps": 141.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3184644,
+   "ratio": 0.5176,
+   "compress_mbps": 48.35,
+   "decompress_mbps": 141.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3160521,
+   "ratio": 0.5137,
+   "compress_mbps": 44.16,
+   "decompress_mbps": 134.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3141929,
+   "ratio": 0.5107,
+   "compress_mbps": 40.04,
+   "decompress_mbps": 150.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3138514,
+   "ratio": 0.5101,
+   "compress_mbps": 39.11,
+   "decompress_mbps": 134.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3126843,
+   "ratio": 0.5082,
+   "compress_mbps": 32.81,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3126796,
+   "ratio": 0.5082,
+   "compress_mbps": 30.63,
+   "decompress_mbps": 145.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3126322,
+   "ratio": 0.5082,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 153.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3126286,
+   "ratio": 0.5082,
+   "compress_mbps": 23.43,
+   "decompress_mbps": 154.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076349,
+   "ratio": 0.4042,
+   "compress_mbps": 79.56,
+   "decompress_mbps": 217.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3914739,
+   "ratio": 0.3881,
+   "compress_mbps": 72.11,
+   "decompress_mbps": 235.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3845160,
+   "ratio": 0.3812,
+   "compress_mbps": 68.92,
+   "decompress_mbps": 265.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3822047,
+   "ratio": 0.379,
+   "compress_mbps": 65.9,
+   "decompress_mbps": 249.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3799472,
+   "ratio": 0.3767,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 196.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3783861,
+   "ratio": 0.3752,
+   "compress_mbps": 59.24,
+   "decompress_mbps": 206.2
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3783432,
+   "ratio": 0.3751,
+   "compress_mbps": 57.5,
+   "decompress_mbps": 276.55
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.79,
+   "decompress_mbps": 278.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.86,
+   "decompress_mbps": 279.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2261112,
+   "ratio": 0.3412,
+   "compress_mbps": 71.4,
+   "decompress_mbps": 216.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2128691,
+   "ratio": 0.3212,
+   "compress_mbps": 58.57,
+   "decompress_mbps": 197.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2049023,
+   "ratio": 0.3092,
+   "compress_mbps": 48.53,
+   "decompress_mbps": 209.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990249,
+   "ratio": 0.3003,
+   "compress_mbps": 41.12,
+   "decompress_mbps": 207.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1975224,
+   "ratio": 0.298,
+   "compress_mbps": 39.61,
+   "decompress_mbps": 151.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1910262,
+   "ratio": 0.2882,
+   "compress_mbps": 28.21,
+   "decompress_mbps": 164.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1902923,
+   "ratio": 0.2871,
+   "compress_mbps": 25.04,
+   "decompress_mbps": 221.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1900964,
+   "ratio": 0.2868,
+   "compress_mbps": 23.45,
+   "decompress_mbps": 227.66
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1900958,
+   "ratio": 0.2868,
+   "compress_mbps": 24.4,
+   "decompress_mbps": 207.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6016919,
+   "ratio": 0.2785,
+   "compress_mbps": 92.31,
+   "decompress_mbps": 250.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5767272,
+   "ratio": 0.2669,
+   "compress_mbps": 81.02,
+   "decompress_mbps": 287.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5669548,
+   "ratio": 0.2624,
+   "compress_mbps": 75.87,
+   "decompress_mbps": 211.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5619947,
+   "ratio": 0.2601,
+   "compress_mbps": 68.8,
+   "decompress_mbps": 271.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5586034,
+   "ratio": 0.2585,
+   "compress_mbps": 64.77,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5540130,
+   "ratio": 0.2564,
+   "compress_mbps": 50.72,
+   "decompress_mbps": 269.04
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5537271,
+   "ratio": 0.2563,
+   "compress_mbps": 45.58,
+   "decompress_mbps": 209.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5530686,
+   "ratio": 0.256,
+   "compress_mbps": 35.75,
+   "decompress_mbps": 303.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5529823,
+   "ratio": 0.2559,
+   "compress_mbps": 31.59,
+   "decompress_mbps": 227.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5602819,
+   "ratio": 0.7726,
+   "compress_mbps": 47.72,
+   "decompress_mbps": 166.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504019,
+   "ratio": 0.759,
+   "compress_mbps": 42.76,
+   "decompress_mbps": 153.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5452816,
+   "ratio": 0.7519,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 153.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 35.6,
+   "decompress_mbps": 177.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 36.17,
+   "decompress_mbps": 176.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5407602,
+   "ratio": 0.7457,
+   "compress_mbps": 30.72,
+   "decompress_mbps": 153.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5406417,
+   "ratio": 0.7455,
+   "compress_mbps": 30.08,
+   "decompress_mbps": 155.44
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.76,
+   "decompress_mbps": 154.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.68,
+   "decompress_mbps": 117.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14342407,
+   "ratio": 0.3459,
+   "compress_mbps": 73.52,
+   "decompress_mbps": 197.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13424966,
+   "ratio": 0.3238,
+   "compress_mbps": 63.27,
+   "decompress_mbps": 213.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13061399,
+   "ratio": 0.315,
+   "compress_mbps": 56.27,
+   "decompress_mbps": 222.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12877207,
+   "ratio": 0.3106,
+   "compress_mbps": 49.84,
+   "decompress_mbps": 208.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12671090,
+   "ratio": 0.3056,
+   "compress_mbps": 47.71,
+   "decompress_mbps": 209.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12511088,
+   "ratio": 0.3018,
+   "compress_mbps": 40.67,
+   "decompress_mbps": 235.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12503313,
+   "ratio": 0.3016,
+   "compress_mbps": 39.02,
+   "decompress_mbps": 224.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 227.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 225.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6022390,
+   "ratio": 0.7107,
+   "compress_mbps": 54.31,
+   "decompress_mbps": 145.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997124,
+   "ratio": 0.7077,
+   "compress_mbps": 48.84,
+   "decompress_mbps": 145.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5979254,
+   "ratio": 0.7056,
+   "compress_mbps": 43.2,
+   "decompress_mbps": 149.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 5967955,
+   "ratio": 0.7042,
+   "compress_mbps": 42.03,
+   "decompress_mbps": 178.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5967953,
+   "ratio": 0.7042,
+   "compress_mbps": 42.1,
+   "decompress_mbps": 155.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5965386,
+   "ratio": 0.7039,
+   "compress_mbps": 41.26,
+   "decompress_mbps": 150.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41,
+   "decompress_mbps": 152.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 151.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41.86,
+   "decompress_mbps": 155
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 985606,
+   "ratio": 0.1844,
+   "compress_mbps": 111.12,
+   "decompress_mbps": 305.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 852636,
+   "ratio": 0.1595,
+   "compress_mbps": 102.74,
+   "decompress_mbps": 250.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 814293,
+   "ratio": 0.1523,
+   "compress_mbps": 96.19,
+   "decompress_mbps": 221.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 788388,
+   "ratio": 0.1475,
+   "compress_mbps": 89.39,
+   "decompress_mbps": 250.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 749390,
+   "ratio": 0.1402,
+   "compress_mbps": 83.47,
+   "decompress_mbps": 304.92
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 706892,
+   "ratio": 0.1322,
+   "compress_mbps": 64.12,
+   "decompress_mbps": 266.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 705695,
+   "ratio": 0.132,
+   "compress_mbps": 64.27,
+   "decompress_mbps": 329.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 703904,
+   "ratio": 0.1317,
+   "compress_mbps": 61.16,
+   "decompress_mbps": 268.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 703900,
+   "ratio": 0.1317,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 396.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.44,
+   "decompress_mbps": 310.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 87.92,
+   "decompress_mbps": 310.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.84,
+   "decompress_mbps": 310.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.64,
+   "decompress_mbps": 314.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54531,
+   "ratio": 0.3585,
+   "compress_mbps": 55.46,
+   "decompress_mbps": 303.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54068,
+   "ratio": 0.3555,
+   "compress_mbps": 42.11,
+   "decompress_mbps": 310.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54003,
+   "ratio": 0.3551,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 307.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.15,
+   "decompress_mbps": 306.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 307.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 82.91,
+   "decompress_mbps": 273.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.46,
+   "decompress_mbps": 272.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 84.13,
+   "decompress_mbps": 272.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.95,
+   "decompress_mbps": 268.75
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48753,
+   "ratio": 0.3895,
+   "compress_mbps": 50.79,
+   "decompress_mbps": 277.44
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48557,
+   "ratio": 0.3879,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 274.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48523,
+   "ratio": 0.3876,
+   "compress_mbps": 38.65,
+   "decompress_mbps": 273.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.86,
+   "decompress_mbps": 276.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.9,
+   "decompress_mbps": 276.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 164.27,
+   "decompress_mbps": 279.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 172.17,
+   "decompress_mbps": 279.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 171.79,
+   "decompress_mbps": 279.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 170.54,
+   "decompress_mbps": 279.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 110.55,
+   "decompress_mbps": 288.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7914,
+   "ratio": 0.3217,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 290.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7895,
+   "ratio": 0.3209,
+   "compress_mbps": 80.21,
+   "decompress_mbps": 290.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 73.83,
+   "decompress_mbps": 287.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 74.8,
+   "decompress_mbps": 285.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 167.43,
+   "decompress_mbps": 252.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.07,
+   "decompress_mbps": 257.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.82,
+   "decompress_mbps": 258.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 166.85,
+   "decompress_mbps": 256.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3136,
+   "ratio": 0.2813,
+   "compress_mbps": 143.33,
+   "decompress_mbps": 259.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 126.88,
+   "decompress_mbps": 263.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 116.0,
+   "decompress_mbps": 266.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 105.81,
+   "decompress_mbps": 262.03
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 108.16,
+   "decompress_mbps": 263.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 119.04,
+   "decompress_mbps": 119.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 114.29,
+   "decompress_mbps": 121.57
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 111.93,
+   "decompress_mbps": 114.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 113.37,
+   "decompress_mbps": 116.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 104.47,
+   "decompress_mbps": 117.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 101.17,
+   "decompress_mbps": 116.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 99.01,
+   "decompress_mbps": 115.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.66,
+   "decompress_mbps": 116.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.75,
+   "decompress_mbps": 117.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.33,
+   "decompress_mbps": 462.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 232.22,
+   "decompress_mbps": 461.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.95,
+   "decompress_mbps": 462.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 231.82,
+   "decompress_mbps": 462.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218313,
+   "ratio": 0.212,
+   "compress_mbps": 163.75,
+   "decompress_mbps": 447.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 215095,
+   "ratio": 0.2089,
+   "compress_mbps": 107.22,
+   "decompress_mbps": 448.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 213213,
+   "ratio": 0.2071,
+   "compress_mbps": 73.07,
+   "decompress_mbps": 450.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 210955,
+   "ratio": 0.2049,
+   "compress_mbps": 9.42,
+   "decompress_mbps": 452.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 210981,
+   "ratio": 0.2049,
+   "compress_mbps": 4.64,
+   "decompress_mbps": 454.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.55,
+   "decompress_mbps": 304.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.89,
+   "decompress_mbps": 306.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.22,
+   "decompress_mbps": 306.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.33,
+   "decompress_mbps": 304.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145024,
+   "ratio": 0.3398,
+   "compress_mbps": 57.83,
+   "decompress_mbps": 305.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144159,
+   "ratio": 0.3378,
+   "compress_mbps": 44.56,
+   "decompress_mbps": 304.1
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143991,
+   "ratio": 0.3374,
+   "compress_mbps": 40.14,
+   "decompress_mbps": 306.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 143941,
+   "ratio": 0.3373,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 306.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 143939,
+   "ratio": 0.3373,
+   "compress_mbps": 37.03,
+   "decompress_mbps": 305.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.26,
+   "decompress_mbps": 255.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 80.9,
+   "decompress_mbps": 255.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.21,
+   "decompress_mbps": 255.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.07,
+   "decompress_mbps": 256.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194496,
+   "ratio": 0.4036,
+   "compress_mbps": 46.0,
+   "decompress_mbps": 247.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 193176,
+   "ratio": 0.4009,
+   "compress_mbps": 34.56,
+   "decompress_mbps": 253.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192991,
+   "ratio": 0.4005,
+   "compress_mbps": 31.43,
+   "decompress_mbps": 250.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 251.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.82,
+   "decompress_mbps": 253.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.39,
+   "decompress_mbps": 724.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.6,
+   "decompress_mbps": 721.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.93,
+   "decompress_mbps": 721.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 295.58,
+   "decompress_mbps": 727.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56050,
+   "ratio": 0.1092,
+   "compress_mbps": 229.82,
+   "decompress_mbps": 759.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55292,
+   "ratio": 0.1077,
+   "compress_mbps": 153.4,
+   "decompress_mbps": 778.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54651,
+   "ratio": 0.1065,
+   "compress_mbps": 124.47,
+   "decompress_mbps": 790.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52583,
+   "ratio": 0.1025,
+   "compress_mbps": 46.92,
+   "decompress_mbps": 823.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51816,
+   "ratio": 0.101,
+   "compress_mbps": 15.63,
+   "decompress_mbps": 833.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 119.63,
+   "decompress_mbps": 301.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.87,
+   "decompress_mbps": 304.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 120.64,
+   "decompress_mbps": 303.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.25,
+   "decompress_mbps": 303.27
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13290,
+   "ratio": 0.3475,
+   "compress_mbps": 89.99,
+   "decompress_mbps": 316.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13258,
+   "ratio": 0.3467,
+   "compress_mbps": 68.72,
+   "decompress_mbps": 317.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13246,
+   "ratio": 0.3464,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 319.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13236,
+   "ratio": 0.3461,
+   "compress_mbps": 25.4,
+   "decompress_mbps": 320.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13233,
+   "ratio": 0.3461,
+   "compress_mbps": 16.12,
+   "decompress_mbps": 322.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 95.7,
+   "decompress_mbps": 132.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 98.31,
+   "decompress_mbps": 133.01
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 97.54,
+   "decompress_mbps": 132.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 100.39,
+   "decompress_mbps": 132.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.29,
+   "decompress_mbps": 132.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.54,
+   "decompress_mbps": 134.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 93.18,
+   "decompress_mbps": 133.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 134.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 92.21,
+   "decompress_mbps": 134.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.07,
+   "decompress_mbps": 273.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.3,
+   "decompress_mbps": 273.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.99,
+   "decompress_mbps": 274.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.24,
+   "decompress_mbps": 272.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3863846,
+   "ratio": 0.3791,
+   "compress_mbps": 49.03,
+   "decompress_mbps": 267.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3838854,
+   "ratio": 0.3766,
+   "compress_mbps": 37.71,
+   "decompress_mbps": 272.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3835182,
+   "ratio": 0.3763,
+   "compress_mbps": 33.64,
+   "decompress_mbps": 271.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.63,
+   "decompress_mbps": 269.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.46,
+   "decompress_mbps": 270.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.55,
+   "decompress_mbps": 250.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.76,
+   "decompress_mbps": 251.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.86,
+   "decompress_mbps": 251.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.63,
+   "decompress_mbps": 251.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19578840,
+   "ratio": 0.3822,
+   "compress_mbps": 78.52,
+   "decompress_mbps": 258.92
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19492445,
+   "ratio": 0.3806,
+   "compress_mbps": 58.0,
+   "decompress_mbps": 261.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19463481,
+   "ratio": 0.38,
+   "compress_mbps": 46.5,
+   "decompress_mbps": 263.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19444704,
+   "ratio": 0.3796,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 262.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19440748,
+   "ratio": 0.3796,
+   "compress_mbps": 13.07,
+   "decompress_mbps": 263.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.24,
+   "decompress_mbps": 259.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.65,
+   "decompress_mbps": 260.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 111.43,
+   "decompress_mbps": 257.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.43,
+   "decompress_mbps": 258.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3637736,
+   "ratio": 0.3648,
+   "compress_mbps": 65.79,
+   "decompress_mbps": 267.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3621530,
+   "ratio": 0.3632,
+   "compress_mbps": 46.42,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3623924,
+   "ratio": 0.3635,
+   "compress_mbps": 42.48,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3623112,
+   "ratio": 0.3634,
+   "compress_mbps": 33.07,
+   "decompress_mbps": 270.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3623382,
+   "ratio": 0.3634,
+   "compress_mbps": 24.87,
+   "decompress_mbps": 268.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.93,
+   "decompress_mbps": 882.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.49,
+   "decompress_mbps": 879.51
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.65,
+   "decompress_mbps": 865.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.44,
+   "decompress_mbps": 876.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268887,
+   "ratio": 0.0974,
+   "compress_mbps": 229.13,
+   "decompress_mbps": 923.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3131445,
+   "ratio": 0.0933,
+   "compress_mbps": 163.5,
+   "decompress_mbps": 955.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3080217,
+   "ratio": 0.0918,
+   "compress_mbps": 129.46,
+   "decompress_mbps": 960.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2978354,
+   "ratio": 0.0888,
+   "compress_mbps": 57.16,
+   "decompress_mbps": 973.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2947971,
+   "ratio": 0.0879,
+   "compress_mbps": 34.51,
+   "decompress_mbps": 973.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.44,
+   "decompress_mbps": 182.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.2,
+   "decompress_mbps": 182.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.32,
+   "decompress_mbps": 182.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.36,
+   "decompress_mbps": 183.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3178914,
+   "ratio": 0.5167,
+   "compress_mbps": 55.82,
+   "decompress_mbps": 189.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3174170,
+   "ratio": 0.5159,
+   "compress_mbps": 49.39,
+   "decompress_mbps": 191.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3172734,
+   "ratio": 0.5157,
+   "compress_mbps": 45.82,
+   "decompress_mbps": 191.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3171353,
+   "ratio": 0.5155,
+   "compress_mbps": 38.64,
+   "decompress_mbps": 191.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3171299,
+   "ratio": 0.5155,
+   "compress_mbps": 34.82,
+   "decompress_mbps": 191.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.34,
+   "decompress_mbps": 273.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.2,
+   "decompress_mbps": 272.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 121.33,
+   "decompress_mbps": 269.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.45,
+   "decompress_mbps": 274.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3654027,
+   "ratio": 0.3623,
+   "compress_mbps": 95.52,
+   "decompress_mbps": 276.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3652732,
+   "ratio": 0.3622,
+   "compress_mbps": 91.8,
+   "decompress_mbps": 276.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3652496,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 275.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.05,
+   "decompress_mbps": 277.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 276.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.62,
+   "decompress_mbps": 354.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.0,
+   "decompress_mbps": 353.82
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.59,
+   "decompress_mbps": 351.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.81,
+   "decompress_mbps": 354.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892183,
+   "ratio": 0.2855,
+   "compress_mbps": 53.63,
+   "decompress_mbps": 353.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1837957,
+   "ratio": 0.2773,
+   "compress_mbps": 30.64,
+   "decompress_mbps": 360.81
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1826603,
+   "ratio": 0.2756,
+   "compress_mbps": 24.41,
+   "decompress_mbps": 362.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 16.09,
+   "decompress_mbps": 362.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 359.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.11,
+   "decompress_mbps": 399.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 145.88,
+   "decompress_mbps": 400.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.06,
+   "decompress_mbps": 396.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.39,
+   "decompress_mbps": 379.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5501344,
+   "ratio": 0.2546,
+   "compress_mbps": 103.33,
+   "decompress_mbps": 402.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464646,
+   "ratio": 0.2529,
+   "compress_mbps": 79.54,
+   "decompress_mbps": 407.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429975,
+   "ratio": 0.2513,
+   "compress_mbps": 66.81,
+   "decompress_mbps": 408.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5419566,
+   "ratio": 0.2508,
+   "compress_mbps": 49.41,
+   "decompress_mbps": 410.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5417952,
+   "ratio": 0.2508,
+   "compress_mbps": 45.54,
+   "decompress_mbps": 407.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 161.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.25,
+   "decompress_mbps": 161.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.34,
+   "decompress_mbps": 161.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.28,
+   "decompress_mbps": 159.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5450496,
+   "ratio": 0.7516,
+   "compress_mbps": 46.56,
+   "decompress_mbps": 163.89
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5440281,
+   "ratio": 0.7502,
+   "compress_mbps": 42.07,
+   "decompress_mbps": 164.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5439077,
+   "ratio": 0.75,
+   "compress_mbps": 40.6,
+   "decompress_mbps": 164.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.98,
+   "decompress_mbps": 163.79
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.92,
+   "decompress_mbps": 165.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.43,
+   "decompress_mbps": 313.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.96,
+   "decompress_mbps": 316.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.45,
+   "decompress_mbps": 312.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.89,
+   "decompress_mbps": 315.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12238874,
+   "ratio": 0.2952,
+   "compress_mbps": 72.34,
+   "decompress_mbps": 317.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12086531,
+   "ratio": 0.2915,
+   "compress_mbps": 53.58,
+   "decompress_mbps": 323.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12020742,
+   "ratio": 0.2899,
+   "compress_mbps": 46.37,
+   "decompress_mbps": 319.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11987253,
+   "ratio": 0.2891,
+   "compress_mbps": 38.17,
+   "decompress_mbps": 322.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11987245,
+   "ratio": 0.2891,
+   "compress_mbps": 38.15,
+   "decompress_mbps": 319.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.53,
+   "decompress_mbps": 146.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.39,
+   "decompress_mbps": 146.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.11,
+   "decompress_mbps": 146.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.42,
+   "decompress_mbps": 146.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6244483,
+   "ratio": 0.7369,
+   "compress_mbps": 55.4,
+   "decompress_mbps": 148.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.47,
+   "decompress_mbps": 148.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.08,
+   "decompress_mbps": 147.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.49,
+   "decompress_mbps": 148.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.43,
+   "decompress_mbps": 147.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.66,
+   "decompress_mbps": 673.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.52,
+   "decompress_mbps": 670.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.93,
+   "decompress_mbps": 669.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.28,
+   "decompress_mbps": 671.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 716461,
+   "ratio": 0.134,
+   "compress_mbps": 166.09,
+   "decompress_mbps": 710.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687053,
+   "ratio": 0.1285,
+   "compress_mbps": 124.29,
+   "decompress_mbps": 733.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673597,
+   "ratio": 0.126,
+   "compress_mbps": 100.95,
+   "decompress_mbps": 744.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 662156,
+   "ratio": 0.1239,
+   "compress_mbps": 65.08,
+   "decompress_mbps": 750.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 661610,
+   "ratio": 0.1238,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 754.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 73589,
+   "ratio": 0.4839,
+   "compress_mbps": 33.76,
+   "decompress_mbps": 57.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 69878,
+   "ratio": 0.4595,
+   "compress_mbps": 32.08,
+   "decompress_mbps": 58.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 66917,
+   "ratio": 0.44,
+   "compress_mbps": 26.68,
+   "decompress_mbps": 66.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 59388,
+   "ratio": 0.3905,
+   "compress_mbps": 31.26,
+   "decompress_mbps": 80.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 57062,
+   "ratio": 0.3752,
+   "compress_mbps": 22.77,
+   "decompress_mbps": 80.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55472,
+   "ratio": 0.3647,
+   "compress_mbps": 16.23,
+   "decompress_mbps": 79.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55265,
+   "ratio": 0.3634,
+   "compress_mbps": 14.29,
+   "decompress_mbps": 79.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.91,
+   "decompress_mbps": 78.92
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.93,
+   "decompress_mbps": 78.52
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64551,
+   "ratio": 0.5157,
+   "compress_mbps": 31.89,
+   "decompress_mbps": 53.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 62089,
+   "ratio": 0.496,
+   "compress_mbps": 30.15,
+   "decompress_mbps": 57.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 58690,
+   "ratio": 0.4688,
+   "compress_mbps": 24.34,
+   "decompress_mbps": 59.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 53521,
+   "ratio": 0.4276,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 79.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 51677,
+   "ratio": 0.4128,
+   "compress_mbps": 20.89,
+   "decompress_mbps": 78.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50638,
+   "ratio": 0.4045,
+   "compress_mbps": 14.85,
+   "decompress_mbps": 82.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50501,
+   "ratio": 0.4034,
+   "compress_mbps": 13.53,
+   "decompress_mbps": 79.57
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9859,
+   "ratio": 0.4007,
+   "compress_mbps": 43.03,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 10473,
+   "ratio": 0.4257,
+   "compress_mbps": 47.23,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 10172,
+   "ratio": 0.4134,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 148.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8692,
+   "ratio": 0.3533,
+   "compress_mbps": 40.47,
+   "decompress_mbps": 152.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8440,
+   "ratio": 0.343,
+   "compress_mbps": 36.18,
+   "decompress_mbps": 157.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 31.88,
+   "decompress_mbps": 158.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8366,
+   "ratio": 0.34,
+   "compress_mbps": 29.95,
+   "decompress_mbps": 158.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.71,
+   "decompress_mbps": 157.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 156.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4822,
+   "ratio": 0.4325,
+   "compress_mbps": 54.35,
+   "decompress_mbps": 187.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 4593,
+   "ratio": 0.4119,
+   "compress_mbps": 52.8,
+   "decompress_mbps": 193.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 4381,
+   "ratio": 0.3929,
+   "compress_mbps": 49.8,
+   "decompress_mbps": 200.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3725,
+   "ratio": 0.3341,
+   "compress_mbps": 51.8,
+   "decompress_mbps": 202.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3614,
+   "ratio": 0.3241,
+   "compress_mbps": 43.83,
+   "decompress_mbps": 208.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3578,
+   "ratio": 0.3209,
+   "compress_mbps": 39.35,
+   "decompress_mbps": 209.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3572,
+   "ratio": 0.3204,
+   "compress_mbps": 36.83,
+   "decompress_mbps": 210.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 34.7,
+   "decompress_mbps": 208.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 33.66,
+   "decompress_mbps": 206.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1738,
+   "ratio": 0.4671,
+   "compress_mbps": 30.09,
+   "decompress_mbps": 176.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1709,
+   "ratio": 0.4593,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 174.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1694,
+   "ratio": 0.4553,
+   "compress_mbps": 31.7,
+   "decompress_mbps": 180.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1458,
+   "ratio": 0.3918,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 187.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1441,
+   "ratio": 0.3873,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 189.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.18,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.68,
+   "decompress_mbps": 190.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 26.12,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 191.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 260073,
+   "ratio": 0.2526,
+   "compress_mbps": 52.45,
+   "decompress_mbps": 56.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 296764,
+   "ratio": 0.2882,
+   "compress_mbps": 48.94,
+   "decompress_mbps": 76.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 288989,
+   "ratio": 0.2806,
+   "compress_mbps": 37.59,
+   "decompress_mbps": 77.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 246442,
+   "ratio": 0.2393,
+   "compress_mbps": 54.71,
+   "decompress_mbps": 83.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218888,
+   "ratio": 0.2126,
+   "compress_mbps": 40.79,
+   "decompress_mbps": 76.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217830,
+   "ratio": 0.2115,
+   "compress_mbps": 24.16,
+   "decompress_mbps": 88.24
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 221437,
+   "ratio": 0.215,
+   "compress_mbps": 19.26,
+   "decompress_mbps": 86.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 219666,
+   "ratio": 0.2133,
+   "compress_mbps": 5.49,
+   "decompress_mbps": 86.51
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 219921,
+   "ratio": 0.2136,
+   "compress_mbps": 2.77,
+   "decompress_mbps": 85.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 194588,
+   "ratio": 0.456,
+   "compress_mbps": 34.47,
+   "decompress_mbps": 51.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 185757,
+   "ratio": 0.4353,
+   "compress_mbps": 32.92,
+   "decompress_mbps": 49.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 175850,
+   "ratio": 0.4121,
+   "compress_mbps": 27.11,
+   "decompress_mbps": 59.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 155951,
+   "ratio": 0.3654,
+   "compress_mbps": 31.95,
+   "decompress_mbps": 73.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 150274,
+   "ratio": 0.3521,
+   "compress_mbps": 23.12,
+   "decompress_mbps": 71.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147958,
+   "ratio": 0.3467,
+   "compress_mbps": 16.73,
+   "decompress_mbps": 72.74
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147522,
+   "ratio": 0.3457,
+   "compress_mbps": 14.93,
+   "decompress_mbps": 70.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147331,
+   "ratio": 0.3452,
+   "compress_mbps": 13.5,
+   "decompress_mbps": 68.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147328,
+   "ratio": 0.3452,
+   "compress_mbps": 13.48,
+   "decompress_mbps": 70.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 256904,
+   "ratio": 0.5331,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 46.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 245675,
+   "ratio": 0.5098,
+   "compress_mbps": 28.42,
+   "decompress_mbps": 50.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 231519,
+   "ratio": 0.4805,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 56.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 210028,
+   "ratio": 0.4359,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 64.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 203312,
+   "ratio": 0.4219,
+   "compress_mbps": 18.52,
+   "decompress_mbps": 61.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199287,
+   "ratio": 0.4136,
+   "compress_mbps": 12.88,
+   "decompress_mbps": 65.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 198474,
+   "ratio": 0.4119,
+   "compress_mbps": 11.21,
+   "decompress_mbps": 66.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.88,
+   "decompress_mbps": 65.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.84,
+   "decompress_mbps": 65.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 71229,
+   "ratio": 0.1388,
+   "compress_mbps": 82.96,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 69946,
+   "ratio": 0.1363,
+   "compress_mbps": 78.92,
+   "decompress_mbps": 137.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 68538,
+   "ratio": 0.1335,
+   "compress_mbps": 69.23,
+   "decompress_mbps": 151.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 61320,
+   "ratio": 0.1195,
+   "compress_mbps": 65.87,
+   "decompress_mbps": 164.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 59993,
+   "ratio": 0.1169,
+   "compress_mbps": 57.15,
+   "decompress_mbps": 169.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 58637,
+   "ratio": 0.1143,
+   "compress_mbps": 41.42,
+   "decompress_mbps": 166.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 58209,
+   "ratio": 0.1134,
+   "compress_mbps": 35.38,
+   "decompress_mbps": 173.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 55749,
+   "ratio": 0.1086,
+   "compress_mbps": 19.35,
+   "decompress_mbps": 176.71
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 54927,
+   "ratio": 0.107,
+   "compress_mbps": 7.52,
+   "decompress_mbps": 176.17
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 16399,
+   "ratio": 0.4288,
+   "compress_mbps": 36.37,
+   "decompress_mbps": 86.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 15933,
+   "ratio": 0.4167,
+   "compress_mbps": 33.72,
+   "decompress_mbps": 88.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 15739,
+   "ratio": 0.4116,
+   "compress_mbps": 28.05,
+   "decompress_mbps": 87.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13834,
+   "ratio": 0.3618,
+   "compress_mbps": 31.73,
+   "decompress_mbps": 108.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13463,
+   "ratio": 0.3521,
+   "compress_mbps": 25.96,
+   "decompress_mbps": 111.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13353,
+   "ratio": 0.3492,
+   "compress_mbps": 18.86,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13317,
+   "ratio": 0.3482,
+   "compress_mbps": 15.93,
+   "decompress_mbps": 113.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13255,
+   "ratio": 0.3466,
+   "compress_mbps": 8.38,
+   "decompress_mbps": 110.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13171,
+   "ratio": 0.3444,
+   "compress_mbps": 4.16,
+   "decompress_mbps": 114.39
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 2512,
+   "ratio": 0.5943,
+   "compress_mbps": 29.63,
+   "decompress_mbps": 155.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 2477,
+   "ratio": 0.586,
+   "compress_mbps": 29.51,
+   "decompress_mbps": 158.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 2452,
+   "ratio": 0.5801,
+   "compress_mbps": 30.37,
+   "decompress_mbps": 157.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 2110,
+   "ratio": 0.4992,
+   "compress_mbps": 29.99,
+   "decompress_mbps": 162.81
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.87,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.86,
+   "decompress_mbps": 167.98
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.5,
+   "decompress_mbps": 169.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 169.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.63,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5183792,
+   "ratio": 0.5086,
+   "compress_mbps": 31.31,
+   "decompress_mbps": 40.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4956750,
+   "ratio": 0.4863,
+   "compress_mbps": 29.97,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4644095,
+   "ratio": 0.4556,
+   "compress_mbps": 24.06,
+   "decompress_mbps": 47.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4178564,
+   "ratio": 0.41,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 61.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4034632,
+   "ratio": 0.3958,
+   "compress_mbps": 19.92,
+   "decompress_mbps": 61.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3952244,
+   "ratio": 0.3878,
+   "compress_mbps": 13.83,
+   "decompress_mbps": 61.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3938822,
+   "ratio": 0.3864,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 62.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.76,
+   "decompress_mbps": 60.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.72,
+   "decompress_mbps": 60.89
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 25320013,
+   "ratio": 0.4943,
+   "compress_mbps": 31.71,
+   "decompress_mbps": 34.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 24804084,
+   "ratio": 0.4843,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 36.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 24241121,
+   "ratio": 0.4733,
+   "compress_mbps": 25.73,
+   "decompress_mbps": 37.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20950547,
+   "ratio": 0.409,
+   "compress_mbps": 28.84,
+   "decompress_mbps": 44.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20592289,
+   "ratio": 0.402,
+   "compress_mbps": 24.29,
+   "decompress_mbps": 46.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 20445232,
+   "ratio": 0.3992,
+   "compress_mbps": 18.69,
+   "decompress_mbps": 46.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 20407676,
+   "ratio": 0.3984,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 46.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 20389473,
+   "ratio": 0.3981,
+   "compress_mbps": 10.13,
+   "decompress_mbps": 45.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 20386824,
+   "ratio": 0.398,
+   "compress_mbps": 6.82,
+   "decompress_mbps": 46.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3964698,
+   "ratio": 0.3976,
+   "compress_mbps": 37.98,
+   "decompress_mbps": 48.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3936391,
+   "ratio": 0.3948,
+   "compress_mbps": 35.52,
+   "decompress_mbps": 47.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3823540,
+   "ratio": 0.3835,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 51.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3799601,
+   "ratio": 0.3811,
+   "compress_mbps": 33.02,
+   "decompress_mbps": 63.69
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3830938,
+   "ratio": 0.3842,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 58.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3808303,
+   "ratio": 0.382,
+   "compress_mbps": 14.79,
+   "decompress_mbps": 57.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3802814,
+   "ratio": 0.3814,
+   "compress_mbps": 12.14,
+   "decompress_mbps": 57.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3800355,
+   "ratio": 0.3812,
+   "compress_mbps": 6.76,
+   "decompress_mbps": 59.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3799676,
+   "ratio": 0.3811,
+   "compress_mbps": 6.05,
+   "decompress_mbps": 59.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4899547,
+   "ratio": 0.146,
+   "compress_mbps": 95.3,
+   "decompress_mbps": 131.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4587004,
+   "ratio": 0.1367,
+   "compress_mbps": 94.92,
+   "decompress_mbps": 142.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4229035,
+   "ratio": 0.126,
+   "compress_mbps": 90.43,
+   "decompress_mbps": 152.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3791322,
+   "ratio": 0.113,
+   "compress_mbps": 81.61,
+   "decompress_mbps": 160.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3449193,
+   "ratio": 0.1028,
+   "compress_mbps": 72.81,
+   "decompress_mbps": 168.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3269452,
+   "ratio": 0.0974,
+   "compress_mbps": 58.66,
+   "decompress_mbps": 173.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3211286,
+   "ratio": 0.0957,
+   "compress_mbps": 50.59,
+   "decompress_mbps": 173.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3101534,
+   "ratio": 0.0924,
+   "compress_mbps": 27.5,
+   "decompress_mbps": 174.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3058177,
+   "ratio": 0.0911,
+   "compress_mbps": 16.6,
+   "decompress_mbps": 177.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 4024327,
+   "ratio": 0.6541,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 29.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3953722,
+   "ratio": 0.6427,
+   "compress_mbps": 21.66,
+   "decompress_mbps": 30.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3887921,
+   "ratio": 0.632,
+   "compress_mbps": 18.47,
+   "decompress_mbps": 31.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3320440,
+   "ratio": 0.5397,
+   "compress_mbps": 21.3,
+   "decompress_mbps": 37.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3279338,
+   "ratio": 0.533,
+   "compress_mbps": 17.83,
+   "decompress_mbps": 38.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3254309,
+   "ratio": 0.529,
+   "compress_mbps": 14.0,
+   "decompress_mbps": 37.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3250139,
+   "ratio": 0.5283,
+   "compress_mbps": 12.22,
+   "decompress_mbps": 38.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3247018,
+   "ratio": 0.5278,
+   "compress_mbps": 10.17,
+   "decompress_mbps": 38.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3246865,
+   "ratio": 0.5278,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 38.0
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4471091,
+   "ratio": 0.4433,
+   "compress_mbps": 34.91,
+   "decompress_mbps": 69.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 4372105,
+   "ratio": 0.4335,
+   "compress_mbps": 33.82,
+   "decompress_mbps": 71.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 4305270,
+   "ratio": 0.4269,
+   "compress_mbps": 30.7,
+   "decompress_mbps": 73.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3920495,
+   "ratio": 0.3887,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 64.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3853177,
+   "ratio": 0.382,
+   "compress_mbps": 26.63,
+   "decompress_mbps": 63.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3780878,
+   "ratio": 0.3749,
+   "compress_mbps": 23.38,
+   "decompress_mbps": 64.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3763880,
+   "ratio": 0.3732,
+   "compress_mbps": 20.2,
+   "decompress_mbps": 72.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.3,
+   "decompress_mbps": 73.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.25,
+   "decompress_mbps": 72.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2722387,
+   "ratio": 0.4108,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2572544,
+   "ratio": 0.3882,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 70.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2384328,
+   "ratio": 0.3598,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 78.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2112060,
+   "ratio": 0.3187,
+   "compress_mbps": 36.42,
+   "decompress_mbps": 85.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1991581,
+   "ratio": 0.3005,
+   "compress_mbps": 25.34,
+   "decompress_mbps": 91.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1917866,
+   "ratio": 0.2894,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 90.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1895353,
+   "ratio": 0.286,
+   "compress_mbps": 11.08,
+   "decompress_mbps": 90.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1880740,
+   "ratio": 0.2838,
+   "compress_mbps": 5.59,
+   "decompress_mbps": 90.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1880711,
+   "ratio": 0.2838,
+   "compress_mbps": 5.56,
+   "decompress_mbps": 92.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7441483,
+   "ratio": 0.3444,
+   "compress_mbps": 43.78,
+   "decompress_mbps": 66.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 7229248,
+   "ratio": 0.3346,
+   "compress_mbps": 43.14,
+   "decompress_mbps": 69.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 7083451,
+   "ratio": 0.3278,
+   "compress_mbps": 38.92,
+   "decompress_mbps": 71.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 6189639,
+   "ratio": 0.2865,
+   "compress_mbps": 42.2,
+   "decompress_mbps": 92.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 6053058,
+   "ratio": 0.2802,
+   "compress_mbps": 35.08,
+   "decompress_mbps": 96.18
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5988137,
+   "ratio": 0.2771,
+   "compress_mbps": 28.51,
+   "decompress_mbps": 101.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5949908,
+   "ratio": 0.2754,
+   "compress_mbps": 25.19,
+   "decompress_mbps": 103.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5936656,
+   "ratio": 0.2748,
+   "compress_mbps": 19.22,
+   "decompress_mbps": 106.46
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5934701,
+   "ratio": 0.2747,
+   "compress_mbps": 17.98,
+   "decompress_mbps": 105.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 6335542,
+   "ratio": 0.8736,
+   "compress_mbps": 18.44,
+   "decompress_mbps": 31.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 6247260,
+   "ratio": 0.8615,
+   "compress_mbps": 17.59,
+   "decompress_mbps": 48.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 6064713,
+   "ratio": 0.8363,
+   "compress_mbps": 15.15,
+   "decompress_mbps": 56.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5568111,
+   "ratio": 0.7678,
+   "compress_mbps": 17.55,
+   "decompress_mbps": 58.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5544524,
+   "ratio": 0.7646,
+   "compress_mbps": 14.42,
+   "decompress_mbps": 64.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5513056,
+   "ratio": 0.7602,
+   "compress_mbps": 11.94,
+   "decompress_mbps": 62.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5508915,
+   "ratio": 0.7596,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 64.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.52,
+   "decompress_mbps": 65.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.57,
+   "decompress_mbps": 64.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 16776095,
+   "ratio": 0.4046,
+   "compress_mbps": 37.73,
+   "decompress_mbps": 50.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 16032651,
+   "ratio": 0.3867,
+   "compress_mbps": 36.24,
+   "decompress_mbps": 54.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 15180334,
+   "ratio": 0.3662,
+   "compress_mbps": 31.28,
+   "decompress_mbps": 51.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13261924,
+   "ratio": 0.3199,
+   "compress_mbps": 35.24,
+   "decompress_mbps": 68.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12706028,
+   "ratio": 0.3065,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 70.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12464158,
+   "ratio": 0.3006,
+   "compress_mbps": 21.0,
+   "decompress_mbps": 70.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12375954,
+   "ratio": 0.2985,
+   "compress_mbps": 18.31,
+   "decompress_mbps": 73.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12321552,
+   "ratio": 0.2972,
+   "compress_mbps": 14.45,
+   "decompress_mbps": 70.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12320276,
+   "ratio": 0.2972,
+   "compress_mbps": 14.41,
+   "decompress_mbps": 70.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6799201,
+   "ratio": 0.8023,
+   "compress_mbps": 18.34,
+   "decompress_mbps": 18.29
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6800500,
+   "ratio": 0.8025,
+   "compress_mbps": 16.95,
+   "decompress_mbps": 18.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6803212,
+   "ratio": 0.8028,
+   "compress_mbps": 14.91,
+   "decompress_mbps": 18.44
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6264611,
+   "ratio": 0.7393,
+   "compress_mbps": 17.32,
+   "decompress_mbps": 24.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6217901,
+   "ratio": 0.7337,
+   "compress_mbps": 15.76,
+   "decompress_mbps": 25.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6201999,
+   "ratio": 0.7319,
+   "compress_mbps": 15.32,
+   "decompress_mbps": 25.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6201883,
+   "ratio": 0.7319,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 25.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.22,
+   "decompress_mbps": 24.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.3,
+   "decompress_mbps": 24.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1081679,
+   "ratio": 0.2024,
+   "compress_mbps": 74.26,
+   "decompress_mbps": 106.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 1001890,
+   "ratio": 0.1874,
+   "compress_mbps": 74.05,
+   "decompress_mbps": 118.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 921722,
+   "ratio": 0.1724,
+   "compress_mbps": 67.22,
+   "decompress_mbps": 127.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 849263,
+   "ratio": 0.1589,
+   "compress_mbps": 64.23,
+   "decompress_mbps": 142.53
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 771964,
+   "ratio": 0.1444,
+   "compress_mbps": 54.81,
+   "decompress_mbps": 144.22
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 728098,
+   "ratio": 0.1362,
+   "compress_mbps": 43.49,
+   "decompress_mbps": 150.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 713635,
+   "ratio": 0.1335,
+   "compress_mbps": 37.23,
+   "decompress_mbps": 154.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 699093,
+   "ratio": 0.1308,
+   "compress_mbps": 27.08,
+   "decompress_mbps": 146.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 698459,
+   "ratio": 0.1307,
+   "compress_mbps": 25.17,
+   "decompress_mbps": 148.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 51721,
+   "ratio": 0.3401,
+   "compress_mbps": 12.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 11,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 8.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 12,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 5.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46657,
+   "ratio": 0.3727,
+   "compress_mbps": 13.72,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 11,
+   "out_size": 46515,
+   "ratio": 0.3716,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 12,
+   "out_size": 46469,
+   "ratio": 0.3712,
+   "compress_mbps": 7.14,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7725,
+   "ratio": 0.314,
+   "compress_mbps": 15.97,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 11,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 10.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 12,
+   "out_size": 7723,
+   "ratio": 0.3139,
+   "compress_mbps": 7.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3026,
+   "ratio": 0.2714,
+   "compress_mbps": 17.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 11,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 14.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 12,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 10.64,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 41.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 11,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 33.55,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 12,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 24.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 179347,
+   "ratio": 0.1742,
+   "compress_mbps": 30.91,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 11,
+   "out_size": 179096,
+   "ratio": 0.1739,
+   "compress_mbps": 20.04,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 12,
+   "out_size": 179049,
+   "ratio": 0.1739,
+   "compress_mbps": 15.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138116,
+   "ratio": 0.3236,
+   "compress_mbps": 12.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 11,
+   "out_size": 137923,
+   "ratio": 0.3232,
+   "compress_mbps": 8.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 12,
+   "out_size": 137921,
+   "ratio": 0.3232,
+   "compress_mbps": 7.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 185328,
+   "ratio": 0.3846,
+   "compress_mbps": 12.88,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 11,
+   "out_size": 184440,
+   "ratio": 0.3828,
+   "compress_mbps": 9.1,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 12,
+   "out_size": 184371,
+   "ratio": 0.3826,
+   "compress_mbps": 5.56,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51319,
+   "ratio": 0.1,
+   "compress_mbps": 12.87,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 11,
+   "out_size": 49675,
+   "ratio": 0.0968,
+   "compress_mbps": 6.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 12,
+   "out_size": 49194,
+   "ratio": 0.0959,
+   "compress_mbps": 3.65,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 11975,
+   "ratio": 0.3132,
+   "compress_mbps": 20.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 11,
+   "out_size": 11966,
+   "ratio": 0.3129,
+   "compress_mbps": 13.4,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 12,
+   "out_size": 11965,
+   "ratio": 0.3129,
+   "compress_mbps": 10.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1692,
+   "ratio": 0.4003,
+   "compress_mbps": 54.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 11,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 45.3,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 12,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 29.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3681797,
+   "ratio": 0.3612,
+   "compress_mbps": 12.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 11,
+   "out_size": 3679289,
+   "ratio": 0.361,
+   "compress_mbps": 9.26,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 12,
+   "out_size": 3679105,
+   "ratio": 0.361,
+   "compress_mbps": 7.67,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18268811,
+   "ratio": 0.3567,
+   "compress_mbps": 16.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 11,
+   "out_size": 18245674,
+   "ratio": 0.3562,
+   "compress_mbps": 11.71,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 12,
+   "out_size": 18241312,
+   "ratio": 0.3561,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3461494,
+   "ratio": 0.3472,
+   "compress_mbps": 18.28,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 11,
+   "out_size": 3446053,
+   "ratio": 0.3456,
+   "compress_mbps": 10.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 12,
+   "out_size": 3447985,
+   "ratio": 0.3458,
+   "compress_mbps": 5.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2782465,
+   "ratio": 0.0829,
+   "compress_mbps": 8.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 11,
+   "out_size": 2751857,
+   "ratio": 0.082,
+   "compress_mbps": 5.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 12,
+   "out_size": 2748273,
+   "ratio": 0.0819,
+   "compress_mbps": 4.07,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 2995902,
+   "ratio": 0.487,
+   "compress_mbps": 19.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 11,
+   "out_size": 2994386,
+   "ratio": 0.4867,
+   "compress_mbps": 14.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 12,
+   "out_size": 2994086,
+   "ratio": 0.4867,
+   "compress_mbps": 12.48,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3608746,
+   "ratio": 0.3578,
+   "compress_mbps": 19.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 11,
+   "out_size": 3608161,
+   "ratio": 0.3578,
+   "compress_mbps": 14.81,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 12,
+   "out_size": 3608138,
+   "ratio": 0.3577,
+   "compress_mbps": 13.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1697693,
+   "ratio": 0.2562,
+   "compress_mbps": 8.9,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 11,
+   "out_size": 1696742,
+   "ratio": 0.256,
+   "compress_mbps": 6.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 12,
+   "out_size": 1696488,
+   "ratio": 0.256,
+   "compress_mbps": 5.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5137640,
+   "ratio": 0.2378,
+   "compress_mbps": 16.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 11,
+   "out_size": 5122694,
+   "ratio": 0.2371,
+   "compress_mbps": 9.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 12,
+   "out_size": 5118130,
+   "ratio": 0.2369,
+   "compress_mbps": 7.0,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5250862,
+   "ratio": 0.7241,
+   "compress_mbps": 25.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 11,
+   "out_size": 5250747,
+   "ratio": 0.724,
+   "compress_mbps": 20.83,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 12,
+   "out_size": 5250745,
+   "ratio": 0.724,
+   "compress_mbps": 19.39,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11526846,
+   "ratio": 0.278,
+   "compress_mbps": 10.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 11,
+   "out_size": 11520969,
+   "ratio": 0.2779,
+   "compress_mbps": 7.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 12,
+   "out_size": 11520871,
+   "ratio": 0.2779,
+   "compress_mbps": 6.12,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5748096,
+   "ratio": 0.6783,
+   "compress_mbps": 38.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 11,
+   "out_size": 5747172,
+   "ratio": 0.6782,
+   "compress_mbps": 29.45,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 12,
+   "out_size": 5747146,
+   "ratio": 0.6782,
+   "compress_mbps": 26.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637425,
+   "ratio": 0.1193,
+   "compress_mbps": 12.15,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 11,
+   "out_size": 630827,
+   "ratio": 0.118,
+   "compress_mbps": 7.32,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 12,
+   "out_size": 629349,
+   "ratio": 0.1177,
+   "compress_mbps": 4.73,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 52115,
+   "ratio": 0.3427,
+   "compress_mbps": 1.82,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46881,
+   "ratio": 0.3745,
+   "compress_mbps": 2.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7730,
+   "ratio": 0.3142,
+   "compress_mbps": 2.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3030,
+   "ratio": 0.2717,
+   "compress_mbps": 2.44,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1191,
+   "ratio": 0.3201,
+   "compress_mbps": 2.14,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 178311,
+   "ratio": 0.1732,
+   "compress_mbps": 1.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138684,
+   "ratio": 0.325,
+   "compress_mbps": 1.93,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 186472,
+   "ratio": 0.387,
+   "compress_mbps": 1.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 52368,
+   "ratio": 0.102,
+   "compress_mbps": 3.12,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 12277,
+   "ratio": 0.3211,
+   "compress_mbps": 2.16,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1696,
+   "ratio": 0.4012,
+   "compress_mbps": 2.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3712353,
+   "ratio": 0.3642,
+   "compress_mbps": 1.8,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18524576,
+   "ratio": 0.3617,
+   "compress_mbps": 1.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3523172,
+   "ratio": 0.3534,
+   "compress_mbps": 1.86,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2930422,
+   "ratio": 0.0873,
+   "compress_mbps": 1.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 3017814,
+   "ratio": 0.4905,
+   "compress_mbps": 2.36,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3647718,
+   "ratio": 0.3617,
+   "compress_mbps": 2.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1724649,
+   "ratio": 0.2602,
+   "compress_mbps": 1.18,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5179097,
+   "ratio": 0.2397,
+   "compress_mbps": 2.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5261135,
+   "ratio": 0.7255,
+   "compress_mbps": 2.52,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11640134,
+   "ratio": 0.2808,
+   "compress_mbps": 1.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5825680,
+   "ratio": 0.6875,
+   "compress_mbps": 3.31,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 643958,
+   "ratio": 0.1205,
+   "compress_mbps": 2.56,
+   "decompress_mbps": null
+  }
+ ]
 }

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -318,6 +318,9 @@ lean_exe «l1-attrib» where
 lean_exe «l1-sweep» where
   root := `ZipL1Sweep
 
+lean_exe «mid-sweep» where
+  root := `ZipMidSweep
+
 lean_exe fuzz_inflate where
   root := `ZipFuzzInflate
 

--- a/progress/2026-07-02T12-47-13Z_issue-2737.md
+++ b/progress/2026-07-02T12-47-13Z_issue-2737.md
@@ -72,6 +72,28 @@ re-checked at byte parity. Silesia L4–L7 geomean ratio −2.05% (mozilla
 - Kept the swept constants (`splitMinBlockBytes = 10000` etc.) rather than
   libdeflate's 5000: they were tuned for this codebase in #2527.
 
+## Ladder remap round (2026-07-03, same PR)
+
+Kim's review of the first graphs: the all-split mid-band traded the old
+high-speed L4–L7 territory for the new ratio territory. Fix: remap L4–L8 to
+the **union** of both frontiers, knobs chosen by a new committed sweep tool
+(`ZipMidSweep` / `lake exe mid-sweep`: Silesia ratio grid over chain ×
+goodMatch × split × heuristic constants, then pinned interleaved timing).
+Findings: goodMatch-off ≈ 16bp at any chain (bigger lever than chain depth);
+heuristic constants dead; chain saturates past 256. Final ladder: L4 =
+single(64, gate on), L5 = single(128, gate off) — dominates old L7 —, L6 =
+split(64, off), L7 = split(256, off), L8 = split(512) + cadence. Split tier
+condition moved 4→6; proofs needed no statement changes.
+
+Mid-flight, #2744 (niceLen) + #2746 (countMatch) merged → rebase (dashboard
+commits dropped/re-recorded) and a niceLen re-grid per remapped role:
+L4 = 258 (at c64+gate every cutoff times identically, only costs ratio),
+L5/L6 = 65, L7 = 130, L8 = 258. Final validated graphs measure against a
+fresh merge-base BEFORE because master's committed dashboard was both stale
+(#2744 never refreshed) and depressed (#2746's refresh recorded decompress
+at 0.66x of the healthy snapshot on unchanged decoder code); this PR's
+dashboard refresh repairs it.
+
 ## What remains
 
 - perf-pr-graphs before/after on both corpora (PR step; required for merge).

--- a/progress/2026-07-02T12-47-13Z_issue-2737.md
+++ b/progress/2026-07-02T12-47-13Z_issue-2737.md
@@ -1,0 +1,67 @@
+# Observation-divergence block splitting at L4–L8 (#2737)
+
+**Date:** 2026-07-02 (UTC) · **Session type:** feature (interactive worktree
+session, branch `issue-2737`)
+
+## What was accomplished
+
+Implemented the issue's full plan in one session:
+
+1. **Packed heuristic** — `splitTokenClassP` / `splitTokenBytesP` /
+   `chooseSplitsHeuristicP` (`Zip/Native/DeflateDynamic.lean`): the
+   libdeflate-style divergence boundary check walking the `packTok` stream
+   directly, twin-shaped to the boxed `chooseSplitsHeuristic` (same constants,
+   floors, window merge) so a conformance test can pin them equal.
+2. **Packed shared-split emit pipeline** — `emitDynBlockP`,
+   `emitSharedBlockP`, `emitSharedBlocksAtP`,
+   `deflateDynamicBlocksSharedAtP`: per block `tokenFreqsP` (dense packed
+   tables) + `emitTokensWithCodesP`; the split candidate no longer
+   materializes boxed tokens and never touches the `findTableCode` linear
+   scans.
+3. **Dispatch** — `deflateRaw`'s split tier moved from `8 ≤ level` to
+   `4 ≤ level`; the split candidate is the obs-divergence partition, compared
+   to the base via `pickSmaller`; **empty cuts skip the split entirely**
+   (inputs under ~2·`splitMinBlockBytes` pay nothing). The L8
+   `chooseSplitsArbitrated` + `deflateDynamicBlocksSharedSized` sizing pass
+   is retired from the hot path (definitions and proofs kept as the
+   arbitrated reference).
+4. **Proofs** — `deflateDynamicBlocksSharedAtP_eq` (+ `emitDynBlockP_eq`,
+   `emitSharedBlockP_eq`, `emitSharedBlocksAtP_eq`, local `extract_map`) in
+   `Zip/Spec/LZ77PackedCorrect.lean` reduce the packed pipeline to
+   `deflateDynamicBlocksSharedAtTokens … (fun _ => cuts)`; the
+   `DeflateBlockSplit` quadruple is quantified over any selector, so the
+   heuristic carries no proof obligations. The three `deflateRaw` theorems in
+   `DeflateRoundtrip.lean` were rewired (one extra `split` for the
+   empty-cuts shortcut). All proofs compiled on the first attempt — the
+   any-selector quantification did exactly the work it was designed for.
+5. **Tests** — `ZipTest/PackedTokens.lean`: packed-vs-boxed heuristic
+   cut-list equality plus emitter byte-identity at adversarial cut lists;
+   `ZipTest/NativeDeflate.lean`: L4–L8 dispatch roundtrips (native + FFI
+   inflate) on a heterogeneous input with an assertion that the heuristic
+   actually cuts. Full `lake exe test` passes.
+
+## Measurements (Canterbury, this machine)
+
+- Mid-band ratio: kennedy.xls L4–L6 base 239898 → split 201155 (−16%);
+  alice29/lcet10/plrabn12 −0.2…−0.5%; ptt5 split loses → `pickSmaller`
+  keeps base (guard works); cp.html (24 KB): 0 cuts → base only.
+- **New L8 output is byte-identical to old L8 on every Canterbury file**
+  (min(base, obs-split) == min(base, arbitrated) file-for-file), so
+  retiring the sizing pass cost nothing in ratio there. Silesia validation
+  goes with the PR's perf-pr-graphs.
+
+## Decisions
+
+- Cuts are passed to the emitter as an explicit `List Nat` (constant
+  selector `fun _ => cuts` on the boxed side) rather than a selector
+  function, so the dispatch can test `cuts.isEmpty` without recomputing.
+- Kept the retired arbitrated pipeline (defs + proofs + SizeHelpers tests)
+  per the no-theorem-deletion rule; docstrings note the #2737 retirement.
+- Kept the swept constants (`splitMinBlockBytes = 10000` etc.) rather than
+  libdeflate's 5000: they were tuned for this codebase in #2527.
+
+## What remains
+
+- perf-pr-graphs before/after on both corpora (PR step; required for merge).
+- Possible follow-up: single-file checks on silesia mozilla/samba/osdb
+  (heterogeneous members) as the issue suggests.

--- a/progress/2026-07-02T12-47-13Z_issue-2737.md
+++ b/progress/2026-07-02T12-47-13Z_issue-2737.md
@@ -40,6 +40,18 @@ Implemented the issue's full plan in one session:
    inflate) on a heterogeneous input with an assertion that the heuristic
    actually cuts. Full `lake exe test` passes.
 
+## Post-review fix (same session)
+
+The first Silesia sweep showed the heuristic alone losing 0.6pp on sao at
+L8 (statistically uniform star catalog where the 8192-token cadence beats
+300 KB soft-max blocks) — the exact failure mode the Codex review flagged.
+Fixed by *emitting* the fixed-cadence partition as a third L8 `pickSmaller`
+candidate: min over emitted candidates decides by the same ⌈bits/8⌉ the
+retired sizing pass computed, so L8 is provably never worse than the old
+arbitration on any input, still with no sizing walks. sao/mozilla/xml
+re-checked at byte parity. Silesia L4–L7 geomean ratio −2.05% (mozilla
+−2.2pp, samba −2.0pp); Canterbury L4–L6 −1.9%.
+
 ## Measurements (Canterbury, this machine)
 
 - Mid-band ratio: kennedy.xls L4–L6 base 239898 → split 201155 (−16%);


### PR DESCRIPTION
This PR implements libdeflate-style observation-divergence block splitting across the mid-band (closes https://github.com/kim-em/lean-zip/issues/2737): levels 4–7, which emitted a single DEFLATE block (one Huffman tree pair for a whole Silesia member), now try a cross-block shared-window split whose boundaries come from a streaming divergence heuristic, and level 8's exact-bits sizing/arbitration pass (`chooseSplitsArbitrated` + `deflateDynamicBlocksSharedSized`, ~18% of L8 cycles in `findTableCode` linear scans and boxed `tokenFreqs`) is retired from the hot path in favour of the same mechanism.

The new pipeline runs on packed tokens end-to-end: `chooseSplitsHeuristicP` buckets each packed token into one of 10 coarse observation classes and cuts where the recent 512-token window's distribution diverges from the block's (same constants as the boxed heuristic from #2528, which stays as the conformance reference); `deflateDynamicBlocksSharedAtP` emits the blocks with `tokenFreqsP` + `emitTokensWithCodesP` (dense packed tables, no boxed tokens, no linear scans). When the heuristic proposes no cuts — every input under ~2·`splitMinBlockBytes` — the dispatch skips the split candidate entirely, so small inputs pay nothing; otherwise `pickSmaller` against the single-block base bounds any heuristic misfire at the old ratio. At level 8 the fixed-cadence partition is additionally *emitted* as a third candidate: the min over emitted candidates decides by the same quantity the retired sizing pass computed (⌈bits/8⌉), so level 8 is provably never worse than the old arbitration on any input (measured, the heuristic alone lost only silesia/sao, +0.6pp — the cadence candidate closes exactly that hole at one packed emit pass).

The heuristic carries no proof obligations: the emitter clamps every cut, the `DeflateBlockSplit` roundtrip quadruple is quantified over an arbitrary selector, and `deflateDynamicBlocksSharedAtP_eq` (plus per-token field lemmas `splitTokenClassP_eq`/`splitTokenBytesP_eq` and the emitter equalities) reduces the packed pipeline to the boxed reference, so `inflate_deflateRaw` and the padding theorems rewire with no new bit-level reasoning. The retired arbitrated pipeline keeps its definitions, proofs, and `SizeHelpers` conformance tests.

Measured on Canterbury: new L8 output is byte-identical to old L8 on every file (min(base, obs-split) = min(base, arbitrated) file-for-file, worst regression 0 bytes), so the sizing pass retires at ratio parity there. In the mid-band the split engages where it should — kennedy.xls L4–L6 drops 239898 → 201155 bytes (−16%), the large texts drop 0.2–0.5%, ptt5's losing split is caught by `pickSmaller`, and 24 KB files take the no-cuts shortcut. Codex review (second opinion) found no soundness concerns; its suggested field lemmas and above-gate comment fixes are included. Silesia before/after speed-vs-ratio graphs to follow on this PR per `perf-pr-graphs`.

🤖 Prepared with Claude Code

