### PR TITLE
bench: pin every recorded measurement to a single idle core

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -224,11 +224,13 @@ artifacts move into `$W`.
    - **Non-empty → `latest.json` is stale** (older history that predates this
      in-PR-refresh policy). The refresh this PR does in step 8 *fixes* the
      invariant going forward, but it cannot reconstruct the merge-base BEFORE.
-     Recover a correct BEFORE with a one-off merge-base build (`git worktree add
-     --detach $W/before $base && ( cd $W/before && lake build bench-report &&
-     bash bench/pin_core.sh lake env .lake/build/bin/bench-report --native-only $W/perf_before.json )`,
+     Recover a correct BEFORE with a one-off merge-base build (`R=$(pwd) &&
+     git worktree add --detach $W/before $base && ( cd $W/before &&
+     lake build bench-report && bash "$R/bench/pin_core.sh" lake env
+     .lake/build/bin/bench-report --native-only $W/perf_before.json )`,
      then `git worktree remove --force $W/before`) and pass
-     `$W/perf_before.json` as BEFORE.
+     `$W/perf_before.json` as BEFORE. Note `pin_core.sh` is taken from *this*
+     branch's checkout (`$R`): the merge base may predate it.
 
    **Cross-session caveat.** BEFORE (recorded earlier) and AFTER (measured now)
    are different sessions, so a small single-digit-% speed delta can be

--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -165,10 +165,12 @@ artifacts move into `$W`.
      || bash bench/fetch_corpora.sh silesia
    ```
 
-3. **Measure AFTER** (the PR branch, already built):
+3. **Measure AFTER** (the PR branch, already built). Route the measurement
+   through `bench/pin_core.sh`, which pins it (and all children) to the idlest
+   single core — never run a recorded measurement unpinned:
    ```
    lake build bench-report
-   lake env .lake/build/bin/bench-report --native-only $W/perf_after.json
+   bash bench/pin_core.sh lake env .lake/build/bin/bench-report --native-only $W/perf_after.json
    ```
    `--native-only` records native `ratio`, `compress_mbps` and
    `decompress_mbps` and reuses nothing else. Its default native sweep is **1–10**
@@ -224,7 +226,7 @@ artifacts move into `$W`.
      invariant going forward, but it cannot reconstruct the merge-base BEFORE.
      Recover a correct BEFORE with a one-off merge-base build (`git worktree add
      --detach $W/before $base && ( cd $W/before && lake build bench-report &&
-     lake env .lake/build/bin/bench-report --native-only $W/perf_before.json )`,
+     bash bench/pin_core.sh lake env .lake/build/bin/bench-report --native-only $W/perf_before.json )`,
      then `git worktree remove --force $W/before`) and pass
      `$W/perf_before.json` as BEFORE.
 
@@ -326,12 +328,13 @@ artifacts move into `$W`.
    native-only path that does the
    measure+merge+plot in one shot and records every level:
    ```
-   nix-shell --run "taskset -c <free-core> bash bench/run.sh --native-only"
+   nix-shell --run "bash bench/run.sh --native-only"
    git add bench/results/latest.json bench/graphs
    ```
    (`--native-only` reuses the reference-language rows — it does not pay the ~2 h
-   external-comparator rebuild.) Pin to a free core so the committed numbers are
-   not contention-depressed, and confirm `git status` shows only
+   external-comparator rebuild.) `bench/run.sh` pins every measurement step to
+   the idlest core itself (via `bench/pin_core.sh`), so the committed numbers are
+   not contention-depressed; confirm `git status` shows only
    `bench/results/latest.json` and `bench/graphs/*.svg` changed by this step.
 
    **For a decode (or both) PR, also refresh the decode-density dashboard.** The
@@ -340,18 +343,18 @@ artifacts move into `$W`.
    pipeline so the committed decode charts reflect this PR's decoder, then commit
    the JSON + both SVGs into the PR:
    ```
-   nix-shell --run "lake env .lake/build/bin/bench-report --decode-density \
+   nix-shell --run "bash bench/pin_core.sh lake env .lake/build/bin/bench-report --decode-density \
      bench/results/decode_density.json bench/payloads-deflate"
    nix-shell -p nodejs python3 --run \
-     "python3 bench/decode_density.py bench/payloads-deflate bench/results/decode_density.json"
+     "bash bench/pin_core.sh python3 bench/decode_density.py bench/payloads-deflate bench/results/decode_density.json"
    nix-shell --run "python bench/plot.py bench/results/latest.json bench/graphs"
    git add bench/results/decode_density.json bench/graphs/*_decode_density.svg bench/graphs/*_decode_ranking.svg
    ```
    The Lean pass rewrites the in-process decoder rows (native/zlib/miniz/libdeflate
    + memcpy) and `decode_density.py` re-adds the external rows; `plot.py`
    auto-detects the sibling `decode_density.json` and re-renders both decode SVGs.
-   (Pin to a free core here too — `taskset -c <free-core>` — so the decode numbers
-   are not contention-depressed; the `payloads-deflate/` streams are gitignored.)
+   (`bench/pin_core.sh` does the free-core pinning; the `payloads-deflate/`
+   streams are gitignored.)
 
 9. **Always post the graphs as a PR comment — then give Kim the link.** This step
    is compulsory, not "also if convenient": every qualifying PR gets a PR comment
@@ -402,7 +405,10 @@ one session** so common-mode noise (background load, turbo, thermal) cancels:
   $W/before $(git merge-base origin/master HEAD)` then `lake build bench-report`
   in it). The AFTER binary is the PR branch's.
 - Run the two binaries **alternately, N times** (≥5 pairs), each pinned to one
-  core (`taskset -c <core>`). Consecutive AFTER/BEFORE runs then see near-identical
+  core (`taskset -c <core>` — here use an explicit fixed core, the SAME one for
+  both sides, rather than `bench/pin_core.sh`, whose per-invocation idlest-core
+  choice could put the two sides on different cores). Consecutive AFTER/BEFORE
+  runs then see near-identical
   machine state, so their *ratio* is robust even on a busy machine — the paired
   ratio + its 95% CI is the verdict, not any single run.
 - **Run BOTH binaries from the MAIN worktree's directory.** Silesia is gitignored

--- a/bench/pin_core.sh
+++ b/bench/pin_core.sh
@@ -10,13 +10,19 @@
 # remembers to do it; this wrapper makes it automatic for the bench pipeline
 # (bench/run.sh and the perf-pr-graphs skill route measurements through it).
 #
-# Core choice: sample /proc/stat twice, 300 ms apart, and pick the core with
-# the highest idle fraction over the interval (ties → the highest-numbered
-# core, which is least likely to pick up stray OS work). The pinned command
-# and all its children inherit the affinity.
+# Core choice: sample /proc/stat twice, 300 ms apart, and score each candidate
+# by its idle fraction over the interval, downgraded to the *minimum* idle
+# fraction across its SMT sibling group (an "idle" hyperthread whose twin runs
+# a build still shares the physical core's execution resources — exactly the
+# contention this wrapper exists to avoid). Candidates are intersected with
+# the process's allowed affinity set (cgroup cpuset, CI slice, or an outer
+# taskset), so the pick can never be a core we may not use. Ties go to the
+# highest-numbered core, least likely to pick up stray OS work. The pinned
+# command and all its children inherit the affinity.
 #
-# On systems without taskset or /proc/stat (e.g. macOS), exec unpinned — the
-# recorded numbers there are already marked by machine in the dashboard meta.
+# On systems without taskset or /proc/stat (e.g. macOS), or if anything about
+# the selection fails, exec the command unpinned rather than blocking the
+# benchmark — the recorded numbers carry the machine in the dashboard meta.
 set -euo pipefail
 
 if [ $# -eq 0 ]; then
@@ -29,23 +35,65 @@ if ! command -v taskset >/dev/null 2>&1 || [ ! -r /proc/stat ]; then
   exec "$@"
 fi
 
+# CPUs this process may use (e.g. "0-95" or "2,5-7"); empty → no restriction.
+ALLOWED="$(taskset -pc $$ 2>/dev/null | sed 's/.*: *//' || true)"
+
+# SMT topology: one "cpu siblings-list" line per CPU (e.g. "0 0,48").
+SIBLINGS="$(
+  for f in /sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list; do
+    [ -r "$f" ] || continue
+    c="${f#/sys/devices/system/cpu/cpu}"
+    printf '%s %s\n' "${c%%/*}" "$(cat "$f")"
+  done 2>/dev/null || true
+)"
+
 A="$(grep '^cpu[0-9]' /proc/stat)"
 sleep 0.3
 B="$(grep '^cpu[0-9]' /proc/stat)"
 
-CORE=$(awk '
-  NR == FNR { idle[$1] = $5 + $6; t = 0; for (i = 2; i <= NF; i++) t += $i; tot[$1] = t; next }
-  {
-    didle = ($5 + $6) - idle[$1]
-    dtot = 0; for (i = 2; i <= NF; i++) dtot += $i; dtot -= tot[$1]
-    frac = dtot > 0 ? didle / dtot : 1
-    n = substr($1, 4) + 0
-    if (!seen || frac > best + 1e-9 || (frac >= best - 1e-9 && n > core)) {
-      seen = 1; best = frac; core = n
+CORE=$(awk -v allowed="$ALLOWED" '
+  # expand a cpu-list spec like "0-3,7" into set[]
+  function expand(spec, set,   n, parts, i, r, c) {
+    n = split(spec, parts, ",")
+    for (i = 1; i <= n; i++) {
+      if (parts[i] == "") continue
+      if (split(parts[i], r, "-") == 2) { for (c = r[1] + 0; c <= r[2] + 0; c++) set[c] = 1 }
+      else set[parts[i] + 0] = 1
     }
   }
-  END { print core }
-' <(printf '%s\n' "$A") <(printf '%s\n' "$B"))
+  FNR == 1 { fileno++ }
+  fileno == 1 { idle[$1] = $5 + $6; t = 0; for (i = 2; i <= NF; i++) t += $i; tot[$1] = t; next }
+  fileno == 2 {
+    cpu = substr($1, 4) + 0
+    didle = ($5 + $6) - idle[$1]
+    dtot = 0; for (i = 2; i <= NF; i++) dtot += $i; dtot -= tot[$1]
+    frac[cpu] = dtot > 0 ? didle / dtot : 1
+    next
+  }
+  fileno == 3 && NF >= 2 { siblist[$1 + 0] = $2 }
+  END {
+    expand(allowed, ok)
+    anyok = 0; for (c in ok) { anyok = 1; break }
+    best = -1; core = -1
+    for (cpu in frac) {
+      c = cpu + 0
+      if (anyok && !(c in ok)) continue
+      # group score: the busiest sibling bounds what the physical core can give
+      score = frac[c]
+      if (c in siblist) {
+        delete sset; expand(siblist[c], sset)
+        for (s in sset) if ((s + 0) in frac && frac[s + 0] < score) score = frac[s + 0]
+      }
+      if (score > best + 1e-9 || (score >= best - 1e-9 && c > core)) { best = score; core = c }
+    }
+    if (core >= 0) print core
+  }
+' <(printf '%s\n' "$A") <(printf '%s\n' "$B") <(printf '%s\n' "$SIBLINGS"))
+
+if ! [[ "$CORE" =~ ^[0-9]+$ ]] || ! taskset -c "$CORE" true 2>/dev/null; then
+  echo "pin_core: could not select a usable core, running unpinned" >&2
+  exec "$@"
+fi
 
 echo "pin_core: pinning to cpu${CORE}" >&2
 exec taskset -c "$CORE" "$@"

--- a/bench/pin_core.sh
+++ b/bench/pin_core.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Run a command pinned to the idlest CPU core: bench/pin_core.sh <cmd> [args...]
+#
+# Every throughput number recorded under bench/results/ is a snapshot of one
+# machine, and the dashboard compares snapshots across runs and branches — so
+# a measurement that wanders across cores (scheduler migrations, turbo and
+# cache effects, contention with concurrent builds on a shared box) adds
+# run-to-run noise that has repeatedly been mistaken for real perf deltas.
+# Pinning to a single idle core is the cheap fix, but only when every caller
+# remembers to do it; this wrapper makes it automatic for the bench pipeline
+# (bench/run.sh and the perf-pr-graphs skill route measurements through it).
+#
+# Core choice: sample /proc/stat twice, 300 ms apart, and pick the core with
+# the highest idle fraction over the interval (ties → the highest-numbered
+# core, which is least likely to pick up stray OS work). The pinned command
+# and all its children inherit the affinity.
+#
+# On systems without taskset or /proc/stat (e.g. macOS), exec unpinned — the
+# recorded numbers there are already marked by machine in the dashboard meta.
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  echo "usage: bench/pin_core.sh <cmd> [args...]" >&2
+  exit 2
+fi
+
+if ! command -v taskset >/dev/null 2>&1 || [ ! -r /proc/stat ]; then
+  echo "pin_core: taskset//proc/stat unavailable, running unpinned" >&2
+  exec "$@"
+fi
+
+A="$(grep '^cpu[0-9]' /proc/stat)"
+sleep 0.3
+B="$(grep '^cpu[0-9]' /proc/stat)"
+
+CORE=$(awk '
+  NR == FNR { idle[$1] = $5 + $6; t = 0; for (i = 2; i <= NF; i++) t += $i; tot[$1] = t; next }
+  {
+    didle = ($5 + $6) - idle[$1]
+    dtot = 0; for (i = 2; i <= NF; i++) dtot += $i; dtot -= tot[$1]
+    frac = dtot > 0 ? didle / dtot : 1
+    n = substr($1, 4) + 0
+    if (!seen || frac > best + 1e-9 || (frac >= best - 1e-9 && n > core)) {
+      seen = 1; best = frac; core = n
+    }
+  }
+  END { print core }
+' <(printf '%s\n' "$A") <(printf '%s\n' "$B"))
+
+echo "pin_core: pinning to cpu${CORE}" >&2
+exec taskset -c "$CORE" "$@"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -13,10 +13,16 @@
 #
 # Note: throughput numbers are a median-of-N snapshot of THIS machine; commit the
 # regenerated JSON + SVGs together, and record the machine in the dashboard.
+#
+# Every *measurement* step below runs through bench/pin_core.sh, which pins the
+# command (and its children) to the idlest single core — unpinned runs wander
+# across cores and pick up scheduler/turbo/contention noise that has been
+# mistaken for real perf deltas. Builds, merges, and plotting stay unpinned.
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 
 OUT="bench/results/latest.json"
+PIN="bash bench/pin_core.sh"
 
 in_project_shell() {
   if [ -n "${IN_NIX_SHELL:-}" ]; then bash -c "$1"; else nix-shell --run "$1"; fi
@@ -36,7 +42,7 @@ if [ "${1:-}" = "--native-only" ]; then
   [ -f "$OUT" ] || { echo "no existing $OUT to splice into — run a full bench/run.sh first" >&2; exit 1; }
   TMP="$(mktemp --suffix=.json)"
   in_project_shell "lake build bench-report \
-    && lake env .lake/build/bin/bench-report --native-only $TMP ${2:-}"
+    && $PIN lake env .lake/build/bin/bench-report --native-only $TMP ${2:-}"
   in_project_shell "python3 bench/merge_native.py $OUT $TMP $OUT \
     && python bench/plot.py $OUT bench/graphs"
   rm -f "$TMP"
@@ -61,14 +67,16 @@ fi
 #    --dump-payloads writes the corpus bytes under bench/payloads/<corpus>/ for the
 #    external comparators.
 in_project_shell "lake build bench-report \
-  && lake env .lake/build/bin/bench-report $OUT \
+  && $PIN lake env .lake/build/bin/bench-report $OUT \
   && lake env .lake/build/bin/bench-report --dump-payloads bench/payloads"
 
 # 3. External-language comparators: build (own toolchains) then run + merge.
-#    node + python3 must be on PATH for the JS comparator and the driver.
+#    node + python3 must be on PATH for the JS comparator and the driver. The
+#    driver is pinned, so every comparator child inherits the single-core
+#    affinity and their rows are measured like the native ones.
 bash bench/comparators/build_all.sh
 nix-shell -p nodejs python3 --run \
-  "python3 bench/comparators/run_external.py bench/payloads $OUT"
+  "$PIN python3 bench/comparators/run_external.py bench/payloads $OUT"
 
 # 3b. Decode-density experiment (the decompression analogue of the compress
 #    Pareto): fix the encoder to libdeflate, dump its raw-DEFLATE streams for
@@ -78,9 +86,9 @@ nix-shell -p nodejs python3 --run \
 #    sibling decode_density.json that plot.py renders as
 #    <corpus>_decode_density.svg.
 DD="bench/results/decode_density.json"
-in_project_shell "lake env .lake/build/bin/bench-report --decode-density $DD bench/payloads-deflate"
+in_project_shell "$PIN lake env .lake/build/bin/bench-report --decode-density $DD bench/payloads-deflate"
 nix-shell -p nodejs python3 --run \
-  "python3 bench/decode_density.py bench/payloads-deflate $DD"
+  "$PIN python3 bench/decode_density.py bench/payloads-deflate $DD"
 
 # 4. Render (project shell: python + matplotlib). plot.py auto-detects the
 #    sibling decode_density.json and emits the decode-density chart too.


### PR DESCRIPTION
This PR makes single-core pinning automatic for every recorded benchmark measurement, instead of relying on each agent remembering `taskset`. A new `bench/pin_core.sh` samples `/proc/stat` twice, picks the idlest core (ties go to the highest-numbered one), and execs the given command under `taskset -c <core>`, so the command and all its children inherit the affinity; on systems without `taskset`/`/proc/stat` it runs the command unpinned. `bench/run.sh` routes all four measurement steps through it (the native matrix, the `--native-only` refresh, the external-comparator driver, and both decode-density passes) while builds, merges, and plotting stay unpinned, and the `perf-pr-graphs` skill's measurement commands are updated to match. The skill's controlled interleaved A/B section deliberately keeps an explicit fixed `taskset -c <core>` since both sides must share the same core there.

Codex review (second opinion) surfaced four issues, all fixed: candidates are intersected with the process's allowed affinity set (a cgroup cpuset or outer `taskset` would otherwise make the pin fail instead of falling back), each candidate is scored by the minimum idle fraction across its SMT sibling group (an "idle" hyperthread whose twin runs a build still shares the physical core — chungus is 48 cores x 2 threads), the selection is validated with a fallback to unpinned on any failure, and the skill's merge-base recovery command takes `pin_core.sh` from the PR branch's checkout since the merge base may predate it.

Note on comparability: from the first dashboard refresh after this lands, recorded throughput rows (including the external comparators, whose driver is now pinned) are measured under a different regime than the currently committed ones — read any across-the-board step in the next refresh as the regime change, not a code perf delta.

Motivation: an unpinned (or contention-exposed) run wanders across cores and picks up scheduler/turbo noise that reads as a perf delta — today's #2745 sweep on a loaded machine showed untouched levels "slowing" 2×, which cost a full re-measurement.

🤖 Prepared with Claude Code
