### PR TITLE
feat: verified chainless 2-way match finder (ht_matchfinder), unwired from L1

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1487,6 +1487,235 @@ where
   termination_by data.size - pos
   decreasing_by all_goals omega
 
+/-! ## Chainless 2-way-bucket matcher (libdeflate `ht_matchfinder` style)
+
+`htMatch` is the libdeflate `ht_matchfinder` scheme (#2738): a single hash
+table with **two positions per bucket** (`tbl[2*h]` = most-recent, `tbl[2*h+1]`
+= second-most-recent), **minimum match length 4** (skips the marginal length-3
+matches, which greedily cost more bits than the literals they replace), and an
+early-out once a probe reaches **`niceLen = 32`**. Per position it does at most
+two bounded `countMatch` probes (versus the chain's depth-4 fuel walk over a
+`prev` array) and one bucket rotation (`lru := mru; mru := pos`). After a match
+it inserts the interior positions into the 2-way table (`htInsert`, like
+libdeflate's skip, bounded by `htInsertCap`) so they stay findable.
+
+**Measured, and NOT selected for L1.** #2738's premise was that the chain walk
+being ~47% of L1 cycles made a cheaper matcher an easy speed win. A direct A/B
+(both binaries pinned to one core, back-to-back, native compress) refutes this
+— no `htInsertCap` beats the tuned depth-4 chain. On **Silesia** (12 files, the
+representative corpus; `dickens` is #2738's own profiling target) the frontier
+is worse on *both* axes everywhere:
+
+      htInsertCap   L1 speed vs chain    L1 ratio vs chain   (Silesia geomean)
+      0 (fastest)   0.96x (slower)       +5.8% (larger)
+      258 (best r)  0.61x (much slower)  +0.4% (still larger)
+
+The bucket cannot even reach ratio *parity* on Silesia at any speed cost —
+maxed-out insertion (cap 258) is still +0.4% larger than the chain while running
+39% slower. (Canterbury is slightly kinder: cap 0 ties on speed and cap 258
+reaches −1.6% ratio, but it is small text that fits cache and is not the target.)
+Interior insertion buys ratio by spending work; the fastest point (no interior
+insertion) is already slower *and* larger. This confirms the earlier finding
+(#2726) that L1 is **emit-bound** — the token walk + `BitWriter` dominate, so
+shaving matcher microcost is diluted, and any ratio loss is paid back as extra
+emit work. So `lzMatch`/`lzMatchP` keep the chain at L1; `htMatch` stays as a
+formally-verified reference matcher so the finding is recorded in-tree and #2738
+is not re-attempted blind. `htInsertCap = 258` is the ratio-competitive setting,
+kept as the documented default.
+
+Like the chain, the table is a pure *heuristic for finding* candidates:
+validity is re-established at emission by `countMatch` + the explicit
+`cand < pos` / `pos - cand ≤ windowSize` window guards (in `htBest`), so the
+table contents never enter the correctness proof. Buckets are initialised to
+the sentinel `data.size` (≥ every real position), so an unset slot fails the
+`cand < pos` guard and contributes no match. `htMatch` (recursive, for
+proofs), `htMatchIter` (iterative boxed, `htMatchIter_eq_htMatch`) and
+`htMatchIterP` (packed, `htMatchIterP_eq`) are the greedy-matcher triple;
+correctness lives in `Zip/Spec/HtMatchCorrect.lean`. -/
+
+/-- Number of hash buckets for the chainless L1 matcher; the 2-way table holds
+    `2 * htHashSize` positions. A full 16-bit index (matching the chain
+    matcher's `hashSize`) keeps 4-gram collisions rare, so both bucket slots
+    tend to hold positions that actually share the hashed prefix. -/
+def htHashSize : Nat := 32768
+
+/-- `niceLen` early-out for the chainless L1 matcher: stop probing the second
+    bucket entry once the first already yields a match this long (libdeflate's
+    `nice_len` for its fast tier). -/
+def htNiceLen : Nat := 32
+
+/-- Consider one candidate position `cand` against the running best match
+    `(bestLen, bestPos)`: when `cand` is a valid in-window backward position,
+    count its match length against `pos` and keep it if strictly longer. The
+    table is a heuristic, so this only ever refines the best toward a
+    `countMatch`-verified real match (`htBest_spec`). -/
+@[inline] def htBest (data : ByteArray) (windowSize pos maxLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (cand bestLen bestPos : Nat) : Nat × Nat :=
+  if hc : cand < pos ∧ pos - cand ≤ windowSize then
+    have hcand : cand + maxLen ≤ data.size := by omega
+    let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+    if ml > bestLen then (ml, cand) else (bestLen, bestPos)
+  else (bestLen, bestPos)
+
+/-- Probe the two bucket entries `c0` (most-recent) then `c1`, keeping the
+    longer match; the `niceLen` early-out skips the second probe once the first
+    already reaches a "good enough" length. Returns `(bestLen, bestPos)` with
+    `bestLen = 0` when neither entry yields a match (`htProbe_spec`). -/
+@[inline] def htProbe (data : ByteArray) (windowSize pos maxLen niceLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (c0 c1 : Nat) : Nat × Nat :=
+  let r0 := htBest data windowSize pos maxLen hpm c0 0 0
+  if r0.1 ≥ niceLen then r0
+  else htBest data windowSize pos maxLen hpm c1 r0.1 r0.2
+
+/-- Interior-insertion cap for the chainless L1 matcher: after emitting a match
+    of length `L` at `pos`, insert positions `pos+1 .. pos+min(L-1, cap)` into
+    the 2-way table so those interior positions stay findable by later matches.
+    libdeflate inserts skipped positions too; without it a depth-2 bucket loses
+    the matches the chain's interior insertion keeps (measured ~5% ratio). -/
+def htInsertCap : Nat := 258
+
+/-- Insert the interior positions of a just-emitted match into the 2-way table
+    (rotate each bucket: `lru := mru; mru := p`). The table is a pure heuristic
+    — its contents never enter any correctness proof — so this is an arbitrary
+    `Array Nat → Array Nat` used identically by all three matcher twins (no
+    bridge lemma needed). The `insertCap` bound keeps it from dominating on long
+    matches. -/
+def htInsert (data : ByteArray) (hashSize : Nat) (tbl : Array Nat)
+    (pos j matchLen insertCap : Nat) : Array Nat :=
+  if j < matchLen ∧ j ≤ insertCap then
+    if h : pos + j + 2 < data.size then
+      let hsh := lz77Greedy.hash3 data (pos + j) hashSize h
+      let mru := headProbeGuarded tbl (2 * hsh)
+      let tbl := guardedSet tbl (2 * hsh + 1) mru
+      let tbl := guardedSet tbl (2 * hsh) (pos + j)
+      htInsert data hashSize tbl pos (j + 1) matchLen insertCap
+    else
+      htInsert data hashSize tbl pos (j + 1) matchLen insertCap
+  else tbl
+termination_by matchLen - j
+decreasing_by all_goals omega
+
+/-- Recursive reference form of the chainless 2-way-bucket matcher (proofs
+    only; `htMatchIter`/`htMatchIterP` are the stack-safe runtime twins).
+    `hashSize` is the number of buckets, so the table holds `2 * hashSize`
+    positions. -/
+def htMatch (data : ByteArray) (windowSize : Nat := 32768) : Array LZ77Token :=
+  if data.size < 3 then
+    (lz77Greedy.trailing data 0).toArray
+  else
+    (mainLoop data windowSize htHashSize htNiceLen (.replicate (2 * htHashSize) data.size) 0).toArray
+where
+  mainLoop (data : ByteArray) (windowSize hashSize niceLen : Nat)
+      (tbl : Array Nat) (pos : Nat) : List LZ77Token :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let c0 := tbl[2 * h]!
+      let c1 := tbl[2 * h + 1]!
+      let tbl := tbl.set! (2 * h + 1) c0
+      let tbl := tbl.set! (2 * h) pos
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let m := htProbe data windowSize pos maxLen niceLen hmaxLenP c0 c1
+      let matchLen := m.1
+      let matchPos := m.2
+      if hge : matchLen ≥ 4 then
+        if hle : pos + matchLen ≤ data.size then
+          have : data.size - (pos + matchLen) < data.size - pos := by omega
+          let tbl := htInsert data hashSize tbl pos 1 matchLen htInsertCap
+          .reference matchLen (pos - matchPos) ::
+            mainLoop data windowSize hashSize niceLen tbl (pos + matchLen)
+        else
+          .literal (data[pos]'(by omega)) ::
+            mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+      else
+        .literal (data[pos]'(by omega)) ::
+          mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+    else
+      lz77Greedy.trailing data pos
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
+/-- Iterative (tail-recursive, `Array`-accumulating) form of `htMatch`: same
+    output, stack-safe on large inputs. The hot per-position table reads/writes
+    go through `headProbeGuarded`/`guardedSet` (one runtime bounds check each,
+    provably equal to the panic-checked ops), so `htMatchIter_eq_htMatch`
+    rewrites them back and proceeds by the accumulator induction. -/
+def htMatchIter (data : ByteArray) (windowSize : Nat := 32768) : Array LZ77Token :=
+  if data.size < 3 then
+    lz77GreedyIter.trailing data 0 #[]
+  else
+    mainLoop data windowSize htHashSize htNiceLen (.replicate (2 * htHashSize) data.size) 0 #[]
+where
+  mainLoop (data : ByteArray) (windowSize hashSize niceLen : Nat)
+      (tbl : Array Nat) (pos : Nat) (acc : Array LZ77Token) : Array LZ77Token :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let c0 := headProbeGuarded tbl (2 * h)
+      let c1 := headProbeGuarded tbl (2 * h + 1)
+      let tbl := guardedSet tbl (2 * h + 1) c0
+      let tbl := guardedSet tbl (2 * h) pos
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let m := htProbe data windowSize pos maxLen niceLen hmaxLenP c0 c1
+      let matchLen := m.1
+      let matchPos := m.2
+      if hge : matchLen ≥ 4 then
+        if hle : pos + matchLen ≤ data.size then
+          have : data.size - (pos + matchLen) < data.size - pos := by omega
+          let tbl := htInsert data hashSize tbl pos 1 matchLen htInsertCap
+          mainLoop data windowSize hashSize niceLen tbl (pos + matchLen)
+            (acc.push (.reference matchLen (pos - matchPos)))
+        else
+          mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+            (acc.push (.literal (data[pos]'(by omega))))
+      else
+        mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+          (acc.push (.literal (data[pos]'(by omega))))
+    else
+      lz77GreedyIter.trailing data pos acc
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
+/-- Packed-token twin of `htMatchIter` (`Array UInt32` accumulator, `packTok`
+    at each push): identical control flow and table state. Equal to
+    `(htMatchIter ..).map packTok` (`htMatchIterP_eq`). -/
+def htMatchIterP (data : ByteArray) (windowSize : Nat := 32768) : Array UInt32 :=
+  if data.size < 3 then
+    trailingP data 0 #[]
+  else
+    mainLoop data windowSize htHashSize htNiceLen (.replicate (2 * htHashSize) data.size) 0
+      (Array.emptyWithCapacity data.size)
+where
+  mainLoop (data : ByteArray) (windowSize hashSize niceLen : Nat)
+      (tbl : Array Nat) (pos : Nat) (acc : Array UInt32) : Array UInt32 :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let c0 := headProbeGuarded tbl (2 * h)
+      let c1 := headProbeGuarded tbl (2 * h + 1)
+      let tbl := guardedSet tbl (2 * h + 1) c0
+      let tbl := guardedSet tbl (2 * h) pos
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let m := htProbe data windowSize pos maxLen niceLen hmaxLenP c0 c1
+      let matchLen := m.1
+      let matchPos := m.2
+      if hge : matchLen ≥ 4 then
+        if hle : pos + matchLen ≤ data.size then
+          have : data.size - (pos + matchLen) < data.size - pos := by omega
+          let tbl := htInsert data hashSize tbl pos 1 matchLen htInsertCap
+          mainLoop data windowSize hashSize niceLen tbl (pos + matchLen)
+            (acc.push (packTok (.reference matchLen (pos - matchPos))))
+        else
+          mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+            (acc.push (packTok (.literal (data[pos]'(by omega)))))
+      else
+        mainLoop data windowSize hashSize niceLen tbl (pos + 1)
+          (acc.push (packTok (.literal (data[pos]'(by omega)))))
+    else
+      trailingP data pos acc
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
 /-- Emit LZ77 tokens as fixed Huffman codes into a BitWriter. -/
 def emitTokens (bw : BitWriter) (tokens : Array LZ77Token) (i : Nat) : BitWriter :=
   if h : i < tokens.size then

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -624,7 +624,13 @@ def niceLen (level : UInt8) : Nat :=
     lazy variant, which improves ratio at equal window/chain depth. Both share the
     same `(chainDepth, insertCap, niceLen)` ladder and satisfy the same encoder
     contracts (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the
-    choice is transparent to the roundtrip proof. -/
+    choice is transparent to the roundtrip proof.
+
+    The chainless 2-way-bucket matcher (`htMatchIter`, #2738) is *not* selected
+    here: a direct A/B measured it strictly worse than the depth-4 chain at L1 on
+    Silesia (slower *and* larger at every insertion cap) — see the `htMatch`
+    docstring in `Zip/Native/Deflate.lean` for the frontier and why (L1 is
+    emit-bound). -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
   if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level) (niceLen level)

--- a/Zip/Spec/HtMatchCorrect.lean
+++ b/Zip/Spec/HtMatchCorrect.lean
@@ -1,0 +1,281 @@
+import Zip.Spec.LZ77ChainCorrect
+
+/-!
+# Correctness of the chainless 2-way-bucket LZ77 matcher (`htMatch`)
+
+`htMatch` (libdeflate `ht_matchfinder` style, #2738) replaces the hash-chain
+walk with two bounded probes into a 2-positions-per-bucket table, minimum match
+length 4, and a `niceLen` early-out. The table is only a heuristic for *finding*
+candidates: validity is re-established at emission by `countMatch` + the window
+guards (both in the shared `htBest`/`htProbe`), so the table contents never enter
+the proof. This file proves `ValidDecomp` (→ `htMatch_resolves`), encodability
+and emptiness for the recursive reference, transports them to the iterative twin
+`htMatchIter` (`htMatchIter_eq_htMatch`), and proves the packed twin
+`htMatchIterP` is the `packTok` image of the boxed one — the same three contracts
+`lzMatch` consumes, so the level-≤1 arm of the dispatch is transparent to the
+roundtrip proof.
+-/
+
+namespace Zip.Native.Deflate
+
+open Zip.Native.Deflate (htMatch htMatchIter htMatchIterP htBest htProbe lz77Greedy)
+
+/-! ## Probe spec: the returned match is a real in-window backward match -/
+
+/-- The `Q` invariant on a `(bestLen, bestPos)` probe result: either empty, or a
+    genuine in-window backward match whose bytes are verified equal. -/
+private def ProbeOk (data : ByteArray) (windowSize pos maxLen bestLen bestPos : Nat) : Prop :=
+  bestLen = 0 ∨ (bestPos < pos ∧ pos - bestPos ≤ windowSize ∧ bestPos + maxLen ≤ data.size ∧
+    (∀ i, i < bestLen → data[pos + i]! = data[bestPos + i]!) ∧ bestLen ≤ maxLen)
+
+/-- One candidate step preserves `ProbeOk`: `htBest` either keeps the running
+    best or replaces it with a `countMatch`-verified guarded candidate. -/
+theorem htBest_spec (data : ByteArray) (windowSize pos maxLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (cand bestLen bestPos : Nat)
+    (hb : ProbeOk data windowSize pos maxLen bestLen bestPos) :
+    let r := htBest data windowSize pos maxLen hpm cand bestLen bestPos
+    ProbeOk data windowSize pos maxLen r.1 r.2 := by
+  unfold htBest ProbeOk
+  split
+  · rename_i hc
+    have hcand : cand + maxLen ≤ data.size := by omega
+    have hcm := lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm
+    by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+    · simp only [hml, ↓reduceIte]
+      exact Or.inr ⟨hc.1, hc.2, hcand, fun i hi => (hcm.1 i hi).symm, hcm.2⟩
+    · simp only [hml, ↓reduceIte]; exact hb
+  · exact hb
+
+/-- The two-probe lookup returns a `ProbeOk` result: both probes start from the
+    empty best (`ProbeOk` with `bestLen = 0`) and each `htBest` preserves it. -/
+theorem htProbe_spec (data : ByteArray) (windowSize pos maxLen niceLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (c0 c1 : Nat) :
+    let r := htProbe data windowSize pos maxLen niceLen hpm c0 c1
+    ProbeOk data windowSize pos maxLen r.1 r.2 := by
+  have h0 := htBest_spec data windowSize pos maxLen hpm c0 0 0 (Or.inl rfl)
+  simp only [htProbe]
+  split
+  · exact h0
+  · exact htBest_spec data windowSize pos maxLen hpm c1 _ _ h0
+
+/-! ## ValidDecomp for the recursive reference -/
+
+/-- `htMatch.mainLoop` produces a valid decomposition from `pos`. Mirrors
+    `lz77Chain_mainLoop_valid`; the reference case uses `htProbe_spec` (which
+    holds for *any* table) in place of the chain walk, and the min-match gate is
+    `≥ 4` (still `≥ 3`, so `ValidDecomp.reference` applies). -/
+theorem htMatch_mainLoop_valid (data : ByteArray) (windowSize hashSize niceLen : Nat)
+    (tbl : Array Nat) (pos : Nat) (hw : windowSize > 0) :
+    ValidDecomp data pos (htMatch.mainLoop data windowSize hashSize niceLen tbl pos) := by
+  unfold htMatch.mainLoop
+  split
+  · rename_i hlt
+    dsimp only
+    have hspec := htProbe_spec data windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
+      tbl[2 * lz77Greedy.hash3 data pos hashSize hlt]!
+      tbl[2 * lz77Greedy.hash3 data pos hashSize hlt + 1]!
+    unfold ProbeOk at hspec
+    split
+    · rename_i hge
+      split
+      · rename_i hle
+        obtain h0 | hQ := hspec
+        · omega
+        · refine ValidDecomp.reference (by omega) (by omega) (by omega) hle ?_ ?_
+          · intro i hi
+            rw [Nat.sub_sub_self (Nat.le_of_lt hQ.1)]
+            exact hQ.2.2.2.1 i hi
+          · exact htMatch_mainLoop_valid _ _ _ _ _ _ hw
+      · exact .literal (by omega) (getElem!_pos data pos (by omega))
+          (htMatch_mainLoop_valid _ _ _ _ _ _ hw)
+    · exact .literal (by omega) (getElem!_pos data pos (by omega))
+        (htMatch_mainLoop_valid _ _ _ _ _ _ hw)
+  · exact trailing_valid data pos
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- `htMatch` produces a valid decomposition of the input data. -/
+theorem htMatch_valid (data : ByteArray) (windowSize : Nat) (hw : windowSize > 0) :
+    ValidDecomp data 0 (htMatch data windowSize).toList := by
+  simp only [htMatch]
+  split
+  · simp only; exact trailing_valid data 0
+  · simp only; exact htMatch_mainLoop_valid data windowSize htHashSize htNiceLen _ 0 hw
+
+/-- Resolving the LZ77 tokens produced by `htMatch` recovers the original data. -/
+theorem htMatch_resolves (data : ByteArray) (windowSize : Nat) (hw : windowSize > 0) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (htMatch data windowSize)) [] =
+      some data.data.toList :=
+  validDecomp_resolves data _ (htMatch_valid data windowSize hw)
+
+/-! ## Encodability -/
+
+/-- Inlined encoder bounds (same shape as `lz77Chain_mainLoop_encodable`). -/
+private def Enc (t : LZ77Token) : Prop :=
+  match t with
+  | .literal _ => True
+  | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
+
+theorem htMatch_mainLoop_encodable (data : ByteArray) (windowSize hashSize niceLen : Nat)
+    (tbl : Array Nat) (pos : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ htMatch.mainLoop data windowSize hashSize niceLen tbl pos, Enc t := by
+  unfold htMatch.mainLoop
+  split
+  · rename_i hlt
+    dsimp only
+    have hspec := htProbe_spec data windowSize pos (min 258 (data.size - pos)) niceLen (by omega)
+      tbl[2 * lz77Greedy.hash3 data pos hashSize hlt]!
+      tbl[2 * lz77Greedy.hash3 data pos hashSize hlt + 1]!
+    unfold ProbeOk at hspec
+    split
+    · rename_i hge
+      split
+      · rename_i hle
+        obtain h0 | ⟨hQ1, hQ2, _, _, hQ5⟩ := hspec
+        · omega
+        · intro t ht
+          cases ht with
+          | head => exact ⟨by omega, by omega, by omega, by omega⟩
+          | tail _ h => exact htMatch_mainLoop_encodable _ _ _ _ _ _ hw hws t h
+      · intro t ht
+        cases ht with
+        | head => trivial
+        | tail _ h => exact htMatch_mainLoop_encodable _ _ _ _ _ _ hw hws t h
+    · intro t ht
+      cases ht with
+      | head => trivial
+      | tail _ h => exact htMatch_mainLoop_encodable _ _ _ _ _ _ hw hws t h
+  · intro t ht
+    exact trailing_encodable data pos t ht
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- Every token `htMatch` emits satisfies the encoder bounds. -/
+theorem htMatch_encodable (data : ByteArray) (windowSize : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ (htMatch data windowSize).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  simp only [htMatch]
+  split
+  · intro t ht; exact trailing_encodable data 0 t ht
+  · intro t ht; exact htMatch_mainLoop_encodable data windowSize htHashSize htNiceLen _ 0 hw hws t ht
+
+/-- The chainless matcher emits no tokens on empty input. -/
+theorem htMatch_empty (data : ByteArray) (windowSize : Nat)
+    (hzero : data.size = 0) : htMatch data windowSize = #[] := by
+  simp only [htMatch, show data.size < 3 from by omega, ↓reduceIte]
+  have htrail : lz77Greedy.trailing data 0 = [] := by
+    unfold lz77Greedy.trailing
+    simp only [show ¬(0 < data.size) from by omega, ↓reduceDIte]
+  rw [htrail]
+
+/-! ## Iterative twin equals the reference -/
+
+/-- The iterative `mainLoop` is the accumulator form of the recursive one. The
+    guarded table reads/writes rewrite to the reference's panic-checked ops
+    (`headProbeGuarded_eq`/`guardedSet_eq`), so the only difference is push vs.
+    cons at each emission. -/
+private theorem htMatchIter_mainLoop_eq (data : ByteArray) (windowSize hashSize niceLen : Nat)
+    (tbl : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    htMatchIter.mainLoop data windowSize hashSize niceLen tbl pos acc =
+      acc ++ (htMatch.mainLoop data windowSize hashSize niceLen tbl pos).toArray := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc tbl with
+  | _ n ih =>
+    unfold htMatchIter.mainLoop htMatch.mainLoop
+    simp only [headProbeGuarded_eq, guardedSet_eq]
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      split
+      · split
+        · rw [ih _ (by omega) _ _ _ rfl, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+        · rw [ih _ (by omega) _ _ _ rfl, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+      · rw [ih _ (by omega) _ _ _ rfl, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+    · simp only [hlt, ↓reduceDIte]
+      exact trailing_eq data pos acc
+
+/-- `htMatchIter` produces exactly the same tokens as `htMatch`. -/
+theorem htMatchIter_eq_htMatch (data : ByteArray) (windowSize : Nat) :
+    htMatchIter data windowSize = htMatch data windowSize := by
+  unfold htMatchIter htMatch
+  split
+  · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
+  · rw [htMatchIter_mainLoop_eq]; simp only [List.append_toArray, List.nil_append]
+
+theorem htMatchIter_valid (data : ByteArray) (windowSize : Nat) (hw : windowSize > 0) :
+    ValidDecomp data 0 (htMatchIter data windowSize).toList := by
+  rw [htMatchIter_eq_htMatch]; exact htMatch_valid data windowSize hw
+
+theorem htMatchIter_resolves (data : ByteArray) (windowSize : Nat) (hw : windowSize > 0) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (htMatchIter data windowSize)) [] =
+      some data.data.toList := by
+  rw [htMatchIter_eq_htMatch]; exact htMatch_resolves data windowSize hw
+
+theorem htMatchIter_encodable (data : ByteArray) (windowSize : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ (htMatchIter data windowSize).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  rw [htMatchIter_eq_htMatch]; exact htMatch_encodable data windowSize hw hws
+
+theorem htMatchIter_empty (data : ByteArray) (windowSize : Nat)
+    (hzero : data.size = 0) : htMatchIter data windowSize = #[] := by
+  rw [htMatchIter_eq_htMatch]; exact htMatch_empty data windowSize hzero
+
+/-! ## Packed twin is the `packTok` image of the boxed one -/
+
+/-- `trailingP` is the packed image of the boxed trailing-literals loop (local
+    copy of the private lemma in `LZ77PackedCorrect`, to avoid an import cycle:
+    that file imports this one for the `lzMatchP` dispatch). -/
+private theorem trailingP_eq (data : ByteArray) (pos : Nat) (acc : Array LZ77Token) :
+    trailingP data pos (acc.map packTok) = (lz77GreedyIter.trailing data pos acc).map packTok := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc with
+  | _ n ih =>
+    unfold trailingP lz77GreedyIter.trailing
+    by_cases hp : pos < data.size
+    · simp only [hp, ↓reduceDIte]
+      rw [← Array.map_push, ih _ (by omega) _ _ rfl]
+    · simp only [hp, ↓reduceDIte]
+
+/-- The packed `mainLoop` is the packed image of the boxed one: identical
+    control flow and table state, `packTok` at each push. -/
+private theorem htMatchIterP_mainLoop_eq (data : ByteArray) (windowSize hashSize niceLen : Nat)
+    (tbl : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    htMatchIterP.mainLoop data windowSize hashSize niceLen tbl pos (acc.map packTok) =
+      (htMatchIter.mainLoop data windowSize hashSize niceLen tbl pos acc).map packTok := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc tbl with
+  | _ n ih =>
+    unfold htMatchIterP.mainLoop htMatchIter.mainLoop
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      split
+      · split
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ rfl]
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ rfl]
+      · rw [← Array.map_push, ih _ (by omega) _ _ _ rfl]
+    · simp only [hlt, ↓reduceDIte]
+      exact trailingP_eq data pos acc
+
+/-- `htMatchIterP` produces exactly the `packTok` image of `htMatchIter`. -/
+theorem htMatchIterP_eq (data : ByteArray) (windowSize : Nat) :
+    htMatchIterP data windowSize = (htMatchIter data windowSize).map packTok := by
+  unfold htMatchIterP htMatchIter
+  split
+  · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
+  · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
+      htMatchIterP_mainLoop_eq data windowSize htHashSize htNiceLen _ 0 #[]
+
+/-- The boxed view of the packed chainless matcher is the boxed matcher. -/
+theorem htMatchIterP_map (data : ByteArray) (windowSize : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    (htMatchIterP data windowSize).map unpackTok = htMatchIter data windowSize := by
+  have henc := htMatchIter_encodable data windowSize hw hws
+  rw [htMatchIterP_eq, Array.map_map]
+  have hcongr : Array.map (unpackTok ∘ packTok) (htMatchIter data windowSize) =
+      Array.map id (htMatchIter data windowSize) :=
+    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
+  rw [hcongr, Array.map_id]
+
+end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -1,6 +1,7 @@
 import Zip.Spec.LZ77ChainCorrect
 import Zip.Spec.LZ77ChainLazyCorrect
 import Zip.Spec.EmitPackedCorrect
+import Zip.Spec.HtMatchCorrect
 import Zip.Native.DeflateDynamic
 
 /-!

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -30,6 +30,7 @@ import ZipTest.BoundedReadTest
 import ZipTest.InflateTable
 import ZipTest.OptimalParse
 import ZipTest.PackedTokens
+import ZipTest.HtMatch
 
 def main : IO Unit := do
   unless ← System.FilePath.pathExists "testdata" do
@@ -60,6 +61,7 @@ def main : IO Unit := do
   ZipTest.NativeDeflate.tests
   ZipTest.OptimalParse.tests
   ZipTest.PackedTokens.tests
+  ZipTest.HtMatch.tests
   ZipTest.NativeCompressBench.tests
   ZipTest.Benchmark.tests
   ZipTest.FuzzInflate.tests

--- a/ZipTest/HtMatch.lean
+++ b/ZipTest/HtMatch.lean
@@ -1,0 +1,68 @@
+import ZipTest.Helpers
+import Zip.Native.DeflateDynamic
+
+/-! Conformance tests for the chainless 2-way-bucket L1 matcher (`htMatch`,
+    #2738). The roundtrip is already a theorem (`inflate_deflateRaw` covers
+    level 1) and `PackedTokens` checks `lzMatchP.map unpackTok == lzMatch` at
+    level 1, so this file targets the matcher's *distinctive* runtime
+    properties on the compiled binary:
+
+    - the three twins agree token-for-token (`htMatch = htMatchIter`,
+      `htMatchIterP.map unpackTok = htMatchIter`) on the edge shapes;
+    - every emitted reference honours **min match 4** and the encoder bounds;
+    - the token stream resolves back to the input (native inflate roundtrip),
+      including the empty / sub-3-byte / all-same / cyclic edge cases where
+      the bucket table and interior insertion behave specially. -/
+
+namespace ZipTest.HtMatch
+
+open Zip.Native.Deflate
+
+/-- The three matcher twins must agree, references must be encodable with
+    length ≥ 4, and level-1 deflate must roundtrip through native inflate. -/
+private def checkOne (label : String) (data : ByteArray) : IO Unit := do
+  -- Twin agreement: recursive reference = iterative boxed.
+  let boxed := htMatch data 32768
+  let iter := htMatchIter data 32768
+  unless boxed == iter do
+    throw (IO.userError s!"{label}: htMatch ({boxed.size}) ≠ htMatchIter ({iter.size})")
+  -- Packed twin agreement (compiled `@[inline]` packing / accumulator reuse).
+  let packed := htMatchIterP data 32768
+  unless packed.size == iter.size do
+    throw (IO.userError s!"{label}: htMatchIterP size {packed.size} ≠ htMatchIter {iter.size}")
+  for i in [0:iter.size] do
+    unless unpackTok packed[i]! == iter[i]! do
+      throw (IO.userError s!"{label}: packed token {i} ≠ boxed")
+  -- Min-match-4 and encoder bounds on every reference.
+  for tok in iter do
+    match tok with
+    | .literal _ => pure ()
+    | .reference len dist =>
+      unless 4 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 do
+        throw (IO.userError s!"{label}: reference (len={len}, dist={dist}) out of bounds")
+  -- Level-1 roundtrip through native inflate (exercises the wired dispatch).
+  let compressed := deflateRaw data 1
+  match Zip.Native.Inflate.inflate compressed with
+  | .ok result =>
+    unless result == data do
+      throw (IO.userError s!"{label}: L1 roundtrip mismatch ({result.size} vs {data.size})")
+  | .error e => throw (IO.userError s!"{label}: L1 inflate failed: {e}")
+
+def tests : IO Unit := do
+  IO.println "  HtMatch (chainless L1 matcher) tests..."
+  -- Edge cases: empty, sub-3-byte (below the hash guard), exactly the
+  -- min-match boundary, all-same (long matches → interior-insertion heavy),
+  -- cyclic (period-3 references), random (mostly literals), real text.
+  checkOne "empty" ByteArray.empty
+  checkOne "one byte" (ByteArray.mk #[65])
+  checkOne "two bytes" (ByteArray.mk #[65, 66])
+  checkOne "three bytes" (ByteArray.mk #[65, 66, 67])
+  checkOne "four same" (ByteArray.mk #[65, 65, 65, 65])
+  checkOne "all same 4KB" (mkConstantData 4096)
+  checkOne "cyclic 4KB" (mkCyclicData 4096)
+  checkOne "random 4KB" (mkRandomData 4096)
+  checkOne "text 64KB" (mkTextData 65536)
+  checkOne "prng 32KB" (mkPrngData 32768)
+  IO.println "  HtMatch tests passed."
+
+end ZipTest.HtMatch

--- a/progress/issue-2738-htmatch.md
+++ b/progress/issue-2738-htmatch.md
@@ -1,0 +1,79 @@
+# Feature: chainless 2-way-bucket L1 matcher (ht_matchfinder) — negative result
+
+- **Date**: 2026-07-02 UTC
+- **Session type**: feature
+- **Issue**: #2738
+- **PR**: #2748
+
+## What was built
+
+A formally-verified chainless 2-way-bucket match finder (libdeflate
+`ht_matchfinder` style), sorry-free:
+
+- `htBest`/`htProbe` (shared): probe ≤2 bucket entries, keep the longest
+  `countMatch`-verified in-window match, `niceLen = 32` early-out.
+- `htInsert` (shared): after a match, insert interior positions into the 2-way
+  table, bounded by `htInsertCap`. The table is a pure heuristic — it never
+  enters a proof — so `htInsert` is one shared def used identically by all three
+  twins with **zero** bridge lemmas.
+- `htMatch` (recursive ref) / `htMatchIter` (boxed) / `htMatchIterP` (packed),
+  min-match 4, in `Zip/Native/Deflate.lean`.
+- Correctness in `Zip/Spec/HtMatchCorrect.lean`: `ValidDecomp` → `resolves`,
+  `encodable`, `empty`; `htMatchIter_eq_htMatch`; `htMatchIterP_eq`/`_map`.
+  Reuses the `chainWalk_spec`-shaped interface: `htProbe_spec` (`ProbeOk`
+  postcondition) feeds a `lz77Chain_mainLoop_valid`-mirror proof.
+- Conformance test `ZipTest/HtMatch.lean` (twin agreement, min-match-4 bounds,
+  L1 roundtrip on edge shapes).
+
+## Why it is NOT wired into L1
+
+Direct A/B (both binaries `taskset`-pinned to one core, back-to-back so
+contention is common-mode, native compress). **Silesia** (12 files, the
+representative corpus; `dickens` is #2738's own profiling target), master drift
+1.005x:
+
+    htInsertCap   L1 speed vs chain    L1 ratio vs chain   (Silesia geomean)
+    0 (fastest)   0.96x (slower)       +5.8% (larger)
+    258 (best r)  0.61x (much slower)  +0.4% (still larger)
+
+Canterbury (smaller, cache-resident, not the target) is slightly kinder — cap 0
+ties speed, cap 258 reaches −1.6% ratio — but on Silesia the bucket cannot reach
+ratio *parity* at any speed cost: maxed-out insertion is still +0.4% larger than
+the chain while 39% slower. No config beats the chain on either axis. Interior
+insertion buys ratio by spending work; the fastest point is already slower AND
+larger. **L1 is emit-bound** (confirms #2726): the token walk + BitWriter
+dominate, so matcher microcost is diluted, and any ratio loss is paid back as
+extra emit work. #2738's "chain machinery ~47% of cycles → easy win" premise
+does not translate. Codex, consulted independently, agreed.
+
+So `lzMatch`/`lzMatchP` keep the chain at L1; the matcher stays as a verified
+reference with the frontier recorded in the `htMatch` docstring.
+
+## Process notes / lessons
+
+- Speed measurements on the shared box (`chungus`) were worthless under load
+  (load hit 60; the same change read as 0.7x–1.1x). Only a **same-core
+  back-to-back A/B** gave a trustworthy verdict, and the final Silesia sweep was
+  taken at load ~1.5 for good measure (master drift 1.005x confirmed it clean).
+  Kim asked to enforce single-core pinning; that is already handled by open PR
+  #2747 (`bench/pin_core.sh` picks the idlest core and routes `bench/run.sh` +
+  the perf-pr-graphs skill through it), so I did not duplicate it.
+- **Always benchmark on Silesia, not just Canterbury.** Canterbury (small,
+  cache-resident text) was misleadingly kind here — it showed cap 0 tying speed
+  and cap 258 winning ratio, which looked borderline-salvageable; Silesia (the
+  representative corpus) showed the bucket losing on *both* axes at every cap.
+  A Canterbury-only read would have overstated the case for the matcher.
+- The "table is a pure heuristic" property is powerful: it let interior
+  insertion be added/tuned with no proof churn at all.
+
+## Disposition
+
+PR #2748 keeps the matcher unwired as verified infra + documented finding.
+Asked Kim (no response in the session window) whether to keep-as-infra or close
+and ship nothing; defaulted to the PR so the work + finding are recorded. The
+path to the fast-L1 corner is the emit half (#2734), not the matcher half.
+
+## Quality metrics
+
+- sorry count in `Zip/`: 0 (unchanged).
+- Full `lake build` + `lake exe test` green.


### PR DESCRIPTION
This PR adds `htMatch`/`htMatchIter`/`htMatchIterP`, a formally-verified chainless 2-way-bucket match finder (libdeflate `ht_matchfinder` style: two positions per bucket, minimum match 4, `niceLen` 32 early-out, interior insertion via `htInsert`), together with its correctness (`ValidDecomp` → `resolves`, `encodable`, `empty` in `Zip/Spec/HtMatchCorrect.lean`, plus the packed-twin equivalence), and records that it does not beat the tuned depth-4 hash chain at level 1, so `lzMatch`/`lzMatchP` keep the chain and the new matcher stays as a verified reference (sorry-free).

Issue #2738's premise was that the chain machinery being ~47% of L1 cycles made a cheaper matcher an easy speed win. A direct A/B (both binaries `taskset`-pinned to one core, back-to-back so contention is common-mode, native compress) refutes that. On **Silesia** (12 files, the representative corpus; `dickens` is #2738's own profiling target; master drift 1.005x) no `htInsertCap` beats the chain on either axis:

| `htInsertCap` | L1 speed vs chain | L1 ratio vs chain |
|---|---|---|
| 0 (fastest) | 0.96x (slower) | +5.8% (larger) |
| 258 (best ratio) | 0.61x (−39%) | +0.4% (still larger) |

The bucket cannot even reach ratio *parity* on Silesia at any speed cost — maxed-out insertion is still +0.4% larger than the chain while 39% slower, and the fastest config is already slower and larger. (Canterbury, small cache-resident text, is slightly kinder — cap 0 ties speed, cap 258 reaches −1.6% ratio — but it is not the target.)

Root cause: L1 is emit-bound (confirms #2726). Halving the probe count (cap 0 vs the chain's depth 4) buys no throughput because the token walk + `BitWriter`, not the match search, are the wall; any ratio loss is repaid as extra emit work. There is no runtime perf change here (the matcher is unwired), so no before/after graphs apply — the frontier above is the evidence, recorded in the `htMatch` docstring so #2738 is not re-attempted blind. OpenAI Codex, consulted independently, reached the same conclusion.

The verified matcher is kept because its `htBest_spec`/`htProbe_spec` "probe returns a `countMatch`-verified in-window match" pattern is reusable and the table-is-a-pure-heuristic structure let `htInsert` be added with zero proof churn. If you would rather ship nothing, close this and the finding lives in the #2738 thread.

🤖 Prepared with Claude Code
