### PR TITLE
perf: attribute the RC/allocator tax; ctor-reuse the BitWriter (+9.9% L1, +3.8% L8)

### DIFF
--- a/Zip/Native/BitWriter.lean
+++ b/Zip/Native/BitWriter.lean
@@ -30,7 +30,15 @@ def bitLength (bw : BitWriter) : Nat := bw.data.size * 8 + bw.bitCount.toNat
 
 /-- Flush whole bytes out of a wide accumulator `acc` holding `total` valid
     low bits, LSB-first. Pushes `total / 8` bytes to `data`; the remaining
-    `total % 8` bits become the new partial byte. -/
+    `total % 8` bits become the new partial byte.
+
+    Reference form only: the production writers use the split
+    `flushBytes`/`dropBytes` loops (equal by `flushAcc_eq`, which the
+    `writeBits_def`/`writeHuffCode_def` equations build on) so the `BitWriter`
+    cell is constructed in the caller, where the ctor-reuse optimization can
+    recycle the input writer instead of allocating a fresh cell per field
+    (measured at ~59%/~19% of `mi_malloc_small` calls on L1/L8 compress,
+    #2739). -/
 def flushAcc (data : ByteArray) (acc : UInt64) : Nat → BitWriter
   | total =>
     if total ≥ 8 then
@@ -39,16 +47,64 @@ def flushAcc (data : ByteArray) (acc : UInt64) : Nat → BitWriter
       ⟨data, acc.toUInt8, total.toUInt8⟩
   termination_by total => total
 
+/-- The byte-pushing half of `flushAcc`: push the low `k` whole bytes of
+    `acc`, LSB-first. Returns only the grown `ByteArray` — the leftover
+    partial-byte state is pure arithmetic (`dropBytes`), so the caller can
+    build the result `BitWriter` itself and have ctor reuse recycle its
+    input cell. -/
+def flushBytes (data : ByteArray) (acc : UInt64) : Nat → ByteArray
+  | 0 => data
+  | k + 1 => flushBytes (data.push acc.toUInt8) (acc >>> 8) k
+
+/-- The accumulator half of `flushAcc`: `acc` after `k` byte-sized right
+    shifts (the value whose low bits become the new partial byte). Iterated
+    `>>> 8` rather than `>>> (8*k)` so it agrees with `flushAcc` for *every*
+    `k`, not just `8*k < 64`. -/
+def dropBytes (acc : UInt64) : Nat → UInt64
+  | 0 => acc
+  | k + 1 => dropBytes (acc >>> 8) k
+
+/-- `flushAcc` is the split pair `flushBytes`/`dropBytes`: the byte pushes
+    and the leftover accumulator commute past each other. -/
+theorem flushAcc_eq (data : ByteArray) (acc : UInt64) (total : Nat) :
+    flushAcc data acc total =
+      ⟨flushBytes data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
+        (total % 8).toUInt8⟩ := by
+  induction total using Nat.strongRecOn generalizing data acc with
+  | _ total ih =>
+    rw [flushAcc]
+    by_cases hge : total ≥ 8
+    · rw [if_pos hge, ih (total - 8) (by omega)]
+      have hdiv : total / 8 = (total - 8) / 8 + 1 := by omega
+      have hmod : (total - 8) % 8 = total % 8 := by omega
+      rw [hdiv, hmod, flushBytes, dropBytes]
+    · rw [if_neg hge]
+      have h8 : total / 8 = 0 := by omega
+      have hm : total % 8 = total := by omega
+      rw [h8, hm, flushBytes, dropBytes]
+
 /-- Write `n` bits (n ≤ 25) from `val`, LSB first.
     Fixed-width fields in DEFLATE are packed LSB-first.
 
     The low `n` bits of `val` are masked, shifted above the `bitCount`
     bits already in `bitBuf`, OR-ed into a 64-bit accumulator, then whole
-    bytes are flushed. -/
+    bytes are flushed. The result cell is constructed here (not in the
+    flush loop) so ctor reuse updates `bw` in place — see `flushAcc`. -/
 def writeBits (bw : BitWriter) (n : Nat) (val : UInt32) : BitWriter :=
   let masked : UInt64 := val.toUInt64 % (1 <<< n.toUInt64)
   let acc : UInt64 := bw.bitBuf.toUInt64 ||| (masked <<< bw.bitCount.toUInt64)
-  flushAcc bw.data acc (bw.bitCount.toNat + n)
+  let total := bw.bitCount.toNat + n
+  ⟨flushBytes bw.data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
+    (total % 8).toUInt8⟩
+
+/-- `writeBits` is `flushAcc` of the merged accumulator — the pre-#2739
+    defining equation, for the spec proofs. -/
+theorem writeBits_def (bw : BitWriter) (n : Nat) (val : UInt32) :
+    bw.writeBits n val =
+      flushAcc bw.data
+        (bw.bitBuf.toUInt64 ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64))
+        (bw.bitCount.toNat + n) :=
+  (flushAcc_eq ..).symm
 
 /-- Reverse all 16 bits of `x` (`bit i ↦ bit (15-i)`) with a branchless
     swap network — no per-bit loop. -/
@@ -69,7 +125,19 @@ def reverse16 (x : UInt16) : UInt16 :=
 def writeHuffCode (bw : BitWriter) (code : UInt16) (len : UInt8) : BitWriter :=
   let rev : UInt64 := (reverse16 code).toUInt64 >>> (16 - len.toUInt64)
   let acc : UInt64 := bw.bitBuf.toUInt64 ||| (rev <<< bw.bitCount.toUInt64)
-  flushAcc bw.data acc (bw.bitCount.toNat + len.toNat)
+  let total := bw.bitCount.toNat + len.toNat
+  ⟨flushBytes bw.data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
+    (total % 8).toUInt8⟩
+
+/-- `writeHuffCode` is `flushAcc` of the merged accumulator — the pre-#2739
+    defining equation, for the spec proofs. -/
+theorem writeHuffCode_def (bw : BitWriter) (code : UInt16) (len : UInt8) :
+    bw.writeHuffCode code len =
+      flushAcc bw.data
+        (bw.bitBuf.toUInt64 |||
+          (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)) <<< bw.bitCount.toUInt64))
+        (bw.bitCount.toNat + len.toNat) :=
+  (flushAcc_eq ..).symm
 
 /-- Flush any partial byte (pad with zeros). Returns the final ByteArray. -/
 def flush (bw : BitWriter) : ByteArray :=

--- a/Zip/Spec/BitWriterCorrect.lean
+++ b/Zip/Spec/BitWriterCorrect.lean
@@ -242,7 +242,7 @@ private theorem writeBits_spec (bw : BitWriter) (n : Nat) (val : UInt32)
   obtain ⟨hb, hw⟩ := flushAcc_spec bw.data _ (bw.bitCount.toNat + n) haccbound
   refine ⟨?_, ?_⟩
   · -- toBits
-    simp only [writeBits]
+    rw [writeBits_def]
     rw [hb, hacc_nat]
     simp only [toBits, List.append_assoc]
     congr 1
@@ -261,7 +261,7 @@ private theorem writeBits_spec (bw : BitWriter) (n : Nat) (val : UInt32)
       rw [Nat.add_comm i bw.bitCount.toNat,
         testBit_or_shiftLeft_above _ _ _ _ hbuf, Nat.testBit_mod_two_pow]
       simp only [hi, decide_true, Bool.true_and]
-  · simp only [writeBits]; exact hw
+  · rw [writeBits_def]; exact hw
 
 theorem writeBits_toBits (bw : BitWriter) (n : Nat) (val : UInt32)
     (hwf : bw.wf) (hn : n ≤ 25) :
@@ -356,7 +356,7 @@ private theorem writeHuffCode_spec (bw : BitWriter) (code : UInt16) (len : UInt8
     exact or_shiftLeft_lt bw.bitBuf.toNat _ bw.bitCount.toNat len.toNat hbuf hrev_lt
   obtain ⟨hb, hw⟩ := flushAcc_spec bw.data _ (bw.bitCount.toNat + len.toNat) haccbound
   refine ⟨?_, ?_⟩
-  · simp only [writeHuffCode]
+  · rw [writeHuffCode_def]
     rw [hb, hacc_nat]
     simp only [toBits, List.append_assoc]
     congr 1
@@ -375,7 +375,7 @@ private theorem writeHuffCode_spec (bw : BitWriter) (code : UInt16) (len : UInt8
       simp only [List.mem_range] at hi
       rw [Nat.add_comm i bw.bitCount.toNat, testBit_or_shiftLeft_above _ _ _ _ hbuf,
         hrev_bit i hi]
-  · simp only [writeHuffCode]; exact hw
+  · rw [writeHuffCode_def]; exact hw
 
 theorem writeHuffCode_toBits (bw : BitWriter) (code : UInt16) (len : UInt8)
     (hwf : bw.wf) (hlen : len.toNat ≤ 15) :

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pcd9cfc8edd)">
+   <g clip-path="url(#p72b3fc89f5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3Yz4pkZx3H4aruniEMzaBCYhxERFA37rPwGtzkQrwC7yJXIAiu3IagS3degv8IQsZg2hnTdGYqPdV1sss+8Hn5meJ5ruB7OMVbn/PuT5//ftvx7XK4m16wzuF2esES25v76QnL7J++Mz1hjUdvTS9Y5+JiesEabw7TC9bZn+c7214+n56wzHm+MQCAQQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACB29fHuZnrDEm9Oh+kJy/zgOz+ZnrDM9fbu9IQl9l+8mJ6wzJ9f/3V6whI/fPzO9IRljqf76QlL3D2c77l/fzpOT1jivac/mp6wjBssAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO1vv/zDNj1ihdfHu+kJy7x9ejI9YZ3j/fSCNe5uphes8/2fTS9Y4m57NT1hmXM9H9/erqcnLPN892J6whLPbv43PWEZN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQu7p+eTO9YYnrq8fTE9Y5fDq9YJnt7vPpCWucTtMLltk/+c/0hCXO+Qy5vno6PWGNx29NL1jm2ev76QlLbK/+PT1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxq+3m0+kNfFOn0/QC+Nr2yT+nJ6xx4fvzW8fZyP8RJwgAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDErn792b+mNyzx8vAwPWGZvzy/nZ6wzIfv/3J6whLvPvnx9IRlfvHb301PWOJXP/3e9IRl/vHyMD2Bb+ijP/59esISrz74zfSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx/PP1pmx6xwsPpOD1hmYv9+Xbx5eHV9IQ1Lq+mF6zzxYvpBUucvvtsesIy23aanrDE5RnfGbzZzvM/7dHxPJ9rt3ODBQCQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALGrizNtrG1/ns+12+12l599PD1hme32v9MT1jgepxcsc/r5e9MTlthPD1joYTvP3+Plw/SCdR4dbqcnLLF98rfpCcucb4UAAAwRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsa8AXvCNA0YY2CoAAAAASUVORK5CYII=" id="image86b5a4b89a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YTYpc1x2H4f6SEKIRccCKLIwxgXjkacgga8gkC8kKsousIBDIKFMT4qFnXoI/gglYMXZHskWr1emurptZ5oL38LeL51nBr7jFue89x/sf/rod8dNyfTm9YJ3rl9MLlthub6YnLHP86PH0hDXuPZhesM7JyfSCNW6vpxesc3yYz2x78Wx6wjKH+cQAAAYJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2NlXRxfTG5a43V9PT1jmnZ/9cnrCMufbk+kJSxy/ej49YZlPXn82PWGJd+8/np6wzG5/Mz1hicu7wz33b/a76QlL/ObRe9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHjl//92zY9YoXXu8vpCcu8vX84PWGd3c30gjUuL6YXrPOLD6YXLHG5XU1PWOZQz8e3t/PpCcs8O3o+PWGJpxffT09Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxM7OX1xMb1ji/Oz+9IR1rr+ZXrDMdvnD9IQ19vvpBcscP/x2esISh3yGnJ89mp6wxv0H0wuWefr6ZnrCEtvVv6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdrZdfDO9gTe1308vgP/bvv7n9IQ1Tnx//uQ4G/kRcYIAAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7OwP3/1resMSL67vpics8+mzl9MTlvno97+dnrDEk4fvT09Y5sM//2V6whK/+9XPpycs8+WL6+kJvKG//+OL6QlLXP3pj9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj3f7jbXrECnf73fSEZU6OD7eLT6+vpiescXo2vWCdV8+nFyyxf+vp9IRltm0/PWGJ0wO+M7jdDvOddm93mL/r6MgNFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTOpgfw5k6/+2p6wjLby/9MT1hjt5tesMzug19PT1jiZNtPT1jmbjvM/+PpdrivtHtX309PWGL7+vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/wD9DY34hJ0bGAAAAABJRU5ErkJggg==" id="image26d75d35bb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4d397662a8" d="M 0 0 
+       <path id="m705889b539" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4d397662a8" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4d397662a8" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4d397662a8" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4d397662a8" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4d397662a8" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4d397662a8" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4d397662a8" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4d397662a8" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4d397662a8" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4d397662a8" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4d397662a8" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705889b539" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="me7b39fc715" d="M 0 0 
+       <path id="mdd4ee07ef5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me7b39fc715" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +1 -->
+    <!-- +4 -->
     <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1321,21 +1321,61 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +9 -->
-    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+    <!-- +12 -->
+    <g transform="translate(147.693424 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -58 -->
+    <!-- -57 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -86 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1376,16 +1416,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -86 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1425,49 +1455,43 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +5 -->
+    <!-- +9 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +13 -->
+    <!-- +15 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -8 -->
+    <g transform="translate(426.067685 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -34 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1502,33 +1526,17 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -14 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -34 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -94 -->
+    <!-- -93 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1564,18 +1572,6 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2181,18 +2177,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagede1c50d781" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image90bff458bb" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m06363219d0" d="M 0 0 
+       <path id="md41e12b8ea" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2215,7 +2211,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2229,7 +2225,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2243,7 +2239,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,7 +2252,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2269,7 +2265,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2282,7 +2278,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m06363219d0" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md41e12b8ea" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2943,8 +2939,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.844609 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(20.059766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3011,16 +3007,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3055,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pcd9cfc8edd">
+  <clipPath id="p72b3fc89f5">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc2c20ed4c7)">
+   <g clip-path="url(#pa376e051fa)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3YQYrkZx2H8eqemiEMzaBCYhxEREjcuM/CM7jJQTyBt8gJBMGV2xCSpTuPkGgIQiYhtjOm6cxUemrqn132geflZ4rP5wTfouBXT70Xp6//uu34cTncTi9Y53AzvWCJ7eXd9IRlLh69MT1hjfuvTS9Y5/JyesEaLw/TC9a5OM/vbHv2ZHrCMuf5jQEADBJYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/We76+kNS7w8HaYnLPOLn/xmesIyV9ub0xOWuPjm6fSEZf7+4uPpCUv88sEb0xOWOZ7upicscfvqfO/+3ek4PWGJdx79anrCMl6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIHZx8+3ftukRK7w43k5PWOb108PpCesc76YXrHF7Pb1gnZ+/Pb1gidvt+fSEZc71Pr6+XU1PWObJ7un0hCUeX/9vesIyXrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr96dj29YYmr/YPpCescvpxesMx2+/X0hDVOp+kFy1w8/Gp6whLnfEOu9o+mJ6zx4LXpBcs8fnE3PWGJ7fkX0xOW8YIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbb9dfTm/ghzqdphfA97bPP52esMal/58/Om4j/0dcEACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjt//iff09vWOLZ4dX0hGX+8eRmesIy77/7++kJS7z58NfTE5b53Z//Mj1hiT+89bPpCcv869lhegI/0Acf/nN6whLP3/vT9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7OJ4+mibHrHCq9NxesIylxfn28X3Ds+nJ6xxbz+9YJ1vnk4vWOL008fTE5bZttP0hCXunfGbwcvtPH/T7h/P83Ptdl6wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/PNfGutxPL1jm8qtPpycss938d3rCGsfj9IJlTr99Z3rCEvfO9TbudrtXu9P0hDWOd9MLlrl/uJmesMT2+SfTE5Y53wsCADBEYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxL4DcT2MACaywPEAAAAASUVORK5CYII=" id="image254380e673" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3Yz4pkZx3H4aruniEMzaBCYhxERDArdy5ceA1uciFegXeRKxAEV25FdOnOS/AfQcgYTDtjms5Mpbu6jjv3gc/LzxTPcwXfwyne+px3f/r819uOr5fD3fSCdQ630wuW2B7upycss3/+3vSENZ68M71gnYuL6QVrPBymF6yzP893tr1+OT1hmfN8YwAAgwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDs6uPdzfSGJR5Oh+kJy3znGz+YnrDM9fb+9IQl9l+8mp6wzB/f/nl6whLfffre9IRljqf76QlL3D2e77l/fzpOT1jiJ8+/Nz1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENvffvmbbXrECm+Pd9MTlnn39Gx6wjrH++kFa9zdTC9Y59sfTC9Y4m57Mz1hmXM9H9/drqcnLPNy92p6whIvbv4zPWEZN1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQu7p+fTO9YYnrq6fTE9Y5fDq9YJnt7vPpCWucTtMLltk/+9f0hCXO+Qy5vno+PWGNp+9ML1jmxdv76QlLbG/+OT1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxq+3m0+kNfFWn0/QC+J/tk79PT1jjwvfn146zkf8jThAAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIXf38s39Mb1ji9eFxesIyf3p5Oz1hmd9++NPpCUu8/+z70xOW+dEvfzU9YYmf/fBb0xOW+dvrw/QEvqLf/f6v0xOWePPRL6YnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL74+kP2/SIFR5Px+kJy1zsz7eLLw9vpiescXk1vWCdL15NL1ji9M0X0xOW2bbT9IQlLs/4zuBhO8//tCfH83yu3c4NFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMSuLs60sbb9eT7XbrfbXX728fSEZbbbf09PWON4nF6wzMMHP56esMTV9ICFHrfz/D1ePk4vWOfJ4XZ6whLbJ3+ZnrDM+VYIAMAQgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEPsvd26M/tEWJp8AAAAASUVORK5CYII=" id="imagea496098569" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mbccef82159" d="M 0 0 
+       <path id="m9db07bcd3d" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbccef82159" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mbccef82159" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mbccef82159" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mbccef82159" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mbccef82159" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mbccef82159" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mbccef82159" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mbccef82159" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mbccef82159" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mbccef82159" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mbccef82159" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9db07bcd3d" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m228a284003" d="M 0 0 
+       <path id="m6c2aa5826b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m228a284003" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c2aa5826b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,15 +1303,8 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -2 -->
-    <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- +6 -->
-    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+    <!-- +2 -->
+    <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1328,6 +1321,22 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- +9 -->
+    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -56 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1359,28 +1368,9 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -57 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1462,37 +1452,31 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +9 -->
-    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+    <!-- +14 -->
+    <g transform="translate(304.696618 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +2 -->
+    <!-- +6 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +9 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+    <!-- +12 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -15 -->
+    <!-- -13 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -35 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1528,16 +1512,24 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -34 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -94 -->
+    <!-- -93 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1573,6 +1565,18 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2178,18 +2182,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagee97a8611c2" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image92e518c973" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mf51938092f" d="M 0 0 
+       <path id="m2ad4af4a01" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2216,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2230,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2244,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2257,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2270,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2283,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf51938092f" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ad4af4a01" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2944,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.775937 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3010,14 +3014,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc2c20ed4c7">
+  <clipPath id="pa376e051fa">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb0f61e527c" d="M 0 0 
+       <path id="m3c7f01c44b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb0f61e527c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb0f61e527c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb0f61e527c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb0f61e527c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb0f61e527c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb0f61e527c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb0f61e527c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3c7f01c44b" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc8638383b3" d="M 0 0 
+       <path id="m666f521d96" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc8638383b3" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m666f521d96" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc8638383b3" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m666f521d96" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc8638383b3" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m666f521d96" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="me8a2098b9a" d="M 0 0 
+       <path id="mbf5922e189" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#me8a2098b9a" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbf5922e189" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 167.766377) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 165.254203) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.414427) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 313.500074) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mb3823c5b33" d="M -2.5 2.5 
+     <path id="m968caa4214" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#mb3823c5b33" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3823c5b33" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m968caa4214" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m968caa4214" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m687185df19" d="M 0 -2.5 
+     <path id="m89d7d82d68" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#m687185df19" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m687185df19" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m89d7d82d68" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m89d7d82d68" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m8e2d76f097" d="M -0 3.535534 
+     <path id="m30967b80a9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#m8e2d76f097" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8e2d76f097" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m30967b80a9" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m30967b80a9" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="meb1d93cea0" d="M -0 2.5 
+     <path id="m4032d69e6f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#meb1d93cea0" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m4032d69e6f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m46b048311d" d="M -0.833333 2.5 
+     <path id="mb85b068f18" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#m46b048311d" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m46b048311d" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#mb85b068f18" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb85b068f18" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m6275ada190" d="M -1.25 2.5 
+     <path id="mf2b72a28e2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#m6275ada190" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6275ada190" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#mf2b72a28e2" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2b72a28e2" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="ma3c5c7e7cd" d="M 0 -2.5 
+     <path id="m6c534cbad0" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#ma3c5c7e7cd" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma3c5c7e7cd" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6c534cbad0" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mee93c94abc" d="M 0 -2.5 
+     <path id="m48de64e3ef" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#mee93c94abc" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee93c94abc" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m48de64e3ef" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m48de64e3ef" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="me0fe4fef36" d="M 0 3.5 
+      <path id="m6354c62893" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#me0fe4fef36" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6354c62893" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mb3823c5b33" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m968caa4214" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m687185df19" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m89d7d82d68" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m8e2d76f097" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m30967b80a9" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#meb1d93cea0" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4032d69e6f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m46b048311d" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb85b068f18" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m6275ada190" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf2b72a28e2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#ma3c5c7e7cd" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m6c534cbad0" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mee93c94abc" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m48de64e3ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p5bbd16b32b)">
-     <use xlink:href="#me0fe4fef36" x="289.669676" y="172.766377" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="214.084819" y="182.443154" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="206.266533" y="184.7724" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="187.75787" y="190.930643" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="186.58897" y="191.943866" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="184.505355" y="194.558953" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="164.72409" y="205.93449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="150.950891" y="251.117449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="118.987151" y="288.949057" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me0fe4fef36" x="98.348822" y="318.414427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p1bc8dd2d0a)">
+     <use xlink:href="#m6354c62893" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="189.634638" y="189.604975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="188.534126" y="190.642027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="185.32129" y="193.451183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="165.179564" y="205.631101" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="150.950891" y="250.636885" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="118.987151" y="289.09912" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6354c62893" x="98.348822" y="318.500074" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 172.766377 
-L 288.094992 172.98951 
-L 286.520307 173.211596 
-L 284.945623 173.432647 
-L 283.370938 173.652671 
-L 281.796253 173.871678 
-L 280.221569 174.089678 
-L 278.646884 174.30668 
-L 277.0722 174.522692 
-L 275.497515 174.737725 
-L 273.922831 174.951786 
-L 272.348146 175.164884 
-L 270.773462 175.377028 
-L 269.198777 175.588227 
-L 267.624093 175.798489 
-L 266.049408 176.007822 
-L 264.474724 176.216235 
-L 262.900039 176.423735 
-L 261.325355 176.63033 
-L 259.75067 176.836028 
-L 258.175986 177.040838 
-L 256.601301 177.244766 
-L 255.026616 177.44782 
-L 253.451932 177.650008 
-L 251.877247 177.851337 
-L 250.302563 178.051814 
-L 248.727878 178.251447 
-L 247.153194 178.450242 
-L 245.578509 178.648207 
-L 244.003825 178.845348 
-L 242.42914 179.041673 
-L 240.854456 179.237187 
-L 239.279771 179.431899 
-L 237.705087 179.625813 
-L 236.130402 179.818937 
-L 234.555718 180.011278 
-L 232.981033 180.20284 
-L 231.406349 180.393632 
-L 229.831664 180.583658 
-L 228.25698 180.772926 
-L 226.682295 180.961441 
-L 225.10761 181.149208 
-L 223.532926 181.336235 
-L 221.958241 181.522526 
-L 220.383557 181.708088 
-L 218.808872 181.892926 
-L 217.234188 182.077046 
-L 215.659503 182.260454 
-L 214.084819 182.443154 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 170.254203 
+L 288.298379 170.452222 
+L 286.927082 170.649418 
+L 285.555784 170.845796 
+L 284.184487 171.041364 
+L 282.81319 171.236128 
+L 281.441892 171.430094 
+L 280.070595 171.623271 
+L 278.699298 171.815662 
+L 277.328 172.007276 
+L 275.956703 172.198119 
+L 274.585406 172.388195 
+L 273.214109 172.577513 
+L 271.842811 172.766077 
+L 270.471514 172.953894 
+L 269.100217 173.140969 
+L 267.728919 173.327309 
+L 266.357622 173.512919 
+L 264.986325 173.697805 
+L 263.615028 173.881972 
+L 262.24373 174.065426 
+L 260.872433 174.248173 
+L 259.501136 174.430218 
+L 258.129838 174.611566 
+L 256.758541 174.792223 
+L 255.387244 174.972193 
+L 254.015947 175.151483 
+L 252.644649 175.330097 
+L 251.273352 175.50804 
+L 249.902055 175.685318 
+L 248.530757 175.861935 
+L 247.15946 176.037896 
+L 245.788163 176.213206 
+L 244.416866 176.38787 
+L 243.045568 176.561893 
+L 241.674271 176.735279 
+L 240.302974 176.908033 
+L 238.931676 177.080159 
+L 237.560379 177.251663 
+L 236.189082 177.422548 
+L 234.817784 177.592819 
+L 233.446487 177.76248 
+L 232.07519 177.931536 
+L 230.703893 178.099991 
+L 229.332595 178.26785 
+L 227.961298 178.435116 
+L 226.590001 178.601793 
+L 225.218703 178.767887 
+L 223.847406 178.9334 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 214.084819 182.443154 
-L 213.921938 182.492866 
-L 213.759057 182.542526 
-L 213.596176 182.592135 
-L 213.433295 182.641691 
-L 213.270414 182.691195 
-L 213.107533 182.740648 
-L 212.944652 182.790049 
-L 212.781771 182.839399 
-L 212.61889 182.888698 
-L 212.456009 182.937945 
-L 212.293128 182.987141 
-L 212.130247 183.036286 
-L 211.967366 183.085381 
-L 211.804485 183.134424 
-L 211.641604 183.183417 
-L 211.478723 183.232359 
-L 211.315843 183.28125 
-L 211.152962 183.330092 
-L 210.990081 183.378883 
-L 210.8272 183.427623 
-L 210.664319 183.476314 
-L 210.501438 183.524955 
-L 210.338557 183.573545 
-L 210.175676 183.622087 
-L 210.012795 183.670578 
-L 209.849914 183.71902 
-L 209.687033 183.767412 
-L 209.524152 183.815755 
-L 209.361271 183.864049 
-L 209.19839 183.912293 
-L 209.035509 183.960489 
-L 208.872628 184.008635 
-L 208.709747 184.056733 
-L 208.546866 184.104782 
-L 208.383985 184.152782 
-L 208.221104 184.200734 
-L 208.058223 184.248637 
-L 207.895342 184.296492 
-L 207.732462 184.344298 
-L 207.569581 184.392056 
-L 207.4067 184.439767 
-L 207.243819 184.487429 
-L 207.080938 184.535043 
-L 206.918057 184.58261 
-L 206.755176 184.630129 
-L 206.592295 184.6776 
-L 206.429414 184.725024 
-L 206.266533 184.7724 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 178.9334 
+L 223.605065 179.00911 
+L 223.362724 179.084698 
+L 223.120384 179.160166 
+L 222.878043 179.235514 
+L 222.635702 179.310742 
+L 222.393361 179.385852 
+L 222.15102 179.460842 
+L 221.908679 179.535714 
+L 221.666339 179.610468 
+L 221.423998 179.685104 
+L 221.181657 179.759622 
+L 220.939316 179.834024 
+L 220.696975 179.908309 
+L 220.454635 179.982478 
+L 220.212294 180.056531 
+L 219.969953 180.130468 
+L 219.727612 180.20429 
+L 219.485271 180.277997 
+L 219.24293 180.35159 
+L 219.00059 180.425069 
+L 218.758249 180.498434 
+L 218.515908 180.571686 
+L 218.273567 180.644824 
+L 218.031226 180.71785 
+L 217.788885 180.790763 
+L 217.546545 180.863565 
+L 217.304204 180.936255 
+L 217.061863 181.008833 
+L 216.819522 181.081301 
+L 216.577181 181.153657 
+L 216.33484 181.225904 
+L 216.0925 181.29804 
+L 215.850159 181.370067 
+L 215.607818 181.441985 
+L 215.365477 181.513793 
+L 215.123136 181.585493 
+L 214.880795 181.657085 
+L 214.638455 181.728569 
+L 214.396114 181.799945 
+L 214.153773 181.871213 
+L 213.911432 181.942375 
+L 213.669091 182.01343 
+L 213.42675 182.084378 
+L 213.18441 182.155221 
+L 212.942069 182.225958 
+L 212.699728 182.296589 
+L 212.457387 182.367115 
+L 212.215046 182.437536 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 206.266533 184.7724 
-L 205.880936 184.909209 
-L 205.495339 185.045623 
-L 205.109742 185.181646 
-L 204.724144 185.31728 
-L 204.338547 185.452526 
-L 203.95295 185.587388 
-L 203.567353 185.721867 
-L 203.181756 185.855966 
-L 202.796159 185.989686 
-L 202.410562 186.123029 
-L 202.024964 186.255999 
-L 201.639367 186.388597 
-L 201.25377 186.520824 
-L 200.868173 186.652684 
-L 200.482576 186.784178 
-L 200.096979 186.915308 
-L 199.711382 187.046076 
-L 199.325784 187.176484 
-L 198.940187 187.306534 
-L 198.55459 187.436229 
-L 198.168993 187.565569 
-L 197.783396 187.694557 
-L 197.397799 187.823196 
-L 197.012202 187.951486 
-L 196.626605 188.079429 
-L 196.241007 188.207028 
-L 195.85541 188.334285 
-L 195.469813 188.4612 
-L 195.084216 188.587777 
-L 194.698619 188.714017 
-L 194.313022 188.839921 
-L 193.927425 188.965491 
-L 193.541827 189.09073 
-L 193.15623 189.215638 
-L 192.770633 189.340218 
-L 192.385036 189.464472 
-L 191.999439 189.5884 
-L 191.613842 189.712006 
-L 191.228245 189.835289 
-L 190.842647 189.958253 
-L 190.45705 190.080899 
-L 190.071453 190.203228 
-L 189.685856 190.325242 
-L 189.300259 190.446942 
-L 188.914662 190.568331 
-L 188.529065 190.68941 
-L 188.143468 190.81018 
-L 187.75787 190.930643 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 182.437536 
+L 211.744621 182.598468 
+L 211.274196 182.758855 
+L 210.803771 182.918702 
+L 210.333346 183.07801 
+L 209.86292 183.236785 
+L 209.392495 183.39503 
+L 208.92207 183.552749 
+L 208.451645 183.709944 
+L 207.98122 183.866619 
+L 207.510795 184.022778 
+L 207.040369 184.178424 
+L 206.569944 184.333561 
+L 206.099519 184.488191 
+L 205.629094 184.642318 
+L 205.158669 184.795946 
+L 204.688244 184.949077 
+L 204.217818 185.101716 
+L 203.747393 185.253864 
+L 203.276968 185.405525 
+L 202.806543 185.556702 
+L 202.336118 185.707399 
+L 201.865693 185.857617 
+L 201.395268 186.007362 
+L 200.924842 186.156634 
+L 200.454417 186.305438 
+L 199.983992 186.453776 
+L 199.513567 186.601651 
+L 199.043142 186.749066 
+L 198.572717 186.896024 
+L 198.102291 187.042528 
+L 197.631866 187.18858 
+L 197.161441 187.334183 
+L 196.691016 187.47934 
+L 196.220591 187.624054 
+L 195.750166 187.768328 
+L 195.27974 187.912163 
+L 194.809315 188.055564 
+L 194.33889 188.198532 
+L 193.868465 188.341069 
+L 193.39804 188.483179 
+L 192.927615 188.624865 
+L 192.457189 188.766128 
+L 191.986764 188.906971 
+L 191.516339 189.047397 
+L 191.045914 189.187408 
+L 190.575489 189.327006 
+L 190.105064 189.466195 
+L 189.634638 189.604975 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 187.75787 190.930643 
-L 187.733518 190.951975 
-L 187.709166 190.973296 
-L 187.684814 190.994608 
-L 187.660462 191.015911 
-L 187.63611 191.037204 
-L 187.611758 191.058487 
-L 187.587406 191.079761 
-L 187.563054 191.101025 
-L 187.538702 191.12228 
-L 187.514349 191.143525 
-L 187.489997 191.164761 
-L 187.465645 191.185987 
-L 187.441293 191.207204 
-L 187.416941 191.228411 
-L 187.392589 191.249609 
-L 187.368237 191.270797 
-L 187.343885 191.291976 
-L 187.319533 191.313145 
-L 187.295181 191.334305 
-L 187.270829 191.355455 
-L 187.246476 191.376596 
-L 187.222124 191.397728 
-L 187.197772 191.41885 
-L 187.17342 191.439962 
-L 187.149068 191.461066 
-L 187.124716 191.48216 
-L 187.100364 191.503244 
-L 187.076012 191.524319 
-L 187.05166 191.545385 
-L 187.027308 191.566441 
-L 187.002956 191.587489 
-L 186.978603 191.608526 
-L 186.954251 191.629555 
-L 186.929899 191.650574 
-L 186.905547 191.671583 
-L 186.881195 191.692584 
-L 186.856843 191.713575 
-L 186.832491 191.734557 
-L 186.808139 191.755529 
-L 186.783787 191.776493 
-L 186.759435 191.797447 
-L 186.735083 191.818391 
-L 186.71073 191.839327 
-L 186.686378 191.860253 
-L 186.662026 191.88117 
-L 186.637674 191.902078 
-L 186.613322 191.922976 
-L 186.58897 191.943866 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 189.634638 189.604975 
+L 189.611711 189.626814 
+L 189.588784 189.648642 
+L 189.565856 189.67046 
+L 189.542929 189.692268 
+L 189.520002 189.714067 
+L 189.497074 189.735855 
+L 189.474147 189.757633 
+L 189.45122 189.779401 
+L 189.428292 189.801159 
+L 189.405365 189.822907 
+L 189.382438 189.844645 
+L 189.35951 189.866374 
+L 189.336583 189.888092 
+L 189.313656 189.9098 
+L 189.290728 189.931498 
+L 189.267801 189.953187 
+L 189.244874 189.974865 
+L 189.221946 189.996534 
+L 189.199019 190.018193 
+L 189.176092 190.039841 
+L 189.153164 190.06148 
+L 189.130237 190.083109 
+L 189.10731 190.104729 
+L 189.084382 190.126338 
+L 189.061455 190.147937 
+L 189.038528 190.169527 
+L 189.0156 190.191107 
+L 188.992673 190.212677 
+L 188.969746 190.234237 
+L 188.946818 190.255787 
+L 188.923891 190.277328 
+L 188.900964 190.298859 
+L 188.878036 190.32038 
+L 188.855109 190.341891 
+L 188.832182 190.363392 
+L 188.809254 190.384884 
+L 188.786327 190.406366 
+L 188.7634 190.427838 
+L 188.740472 190.449301 
+L 188.717545 190.470753 
+L 188.694618 190.492196 
+L 188.67169 190.51363 
+L 188.648763 190.535054 
+L 188.625836 190.556468 
+L 188.602908 190.577872 
+L 188.579981 190.599267 
+L 188.557054 190.620652 
+L 188.534126 190.642027 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 186.58897 191.943866 
-L 186.545561 191.999845 
-L 186.502153 192.055758 
-L 186.458744 192.111605 
-L 186.415335 192.167387 
-L 186.371927 192.223103 
-L 186.328518 192.278753 
-L 186.285109 192.334338 
-L 186.241701 192.389858 
-L 186.198292 192.445314 
-L 186.154883 192.500704 
-L 186.111475 192.556029 
-L 186.068066 192.611291 
-L 186.024658 192.666487 
-L 185.981249 192.72162 
-L 185.93784 192.776688 
-L 185.894432 192.831693 
-L 185.851023 192.886634 
-L 185.807614 192.941511 
-L 185.764206 192.996325 
-L 185.720797 193.051075 
-L 185.677388 193.105762 
-L 185.63398 193.160386 
-L 185.590571 193.214947 
-L 185.547162 193.269446 
-L 185.503754 193.323882 
-L 185.460345 193.378255 
-L 185.416936 193.432566 
-L 185.373528 193.486815 
-L 185.330119 193.541002 
-L 185.28671 193.595127 
-L 185.243302 193.649191 
-L 185.199893 193.703192 
-L 185.156484 193.757132 
-L 185.113076 193.811011 
-L 185.069667 193.864829 
-L 185.026258 193.918586 
-L 184.98285 193.972281 
-L 184.939441 194.025916 
-L 184.896033 194.079491 
-L 184.852624 194.133004 
-L 184.809215 194.186458 
-L 184.765807 194.239851 
-L 184.722398 194.293184 
-L 184.678989 194.346457 
-L 184.635581 194.399671 
-L 184.592172 194.452824 
-L 184.548763 194.505919 
-L 184.505355 194.558953 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 188.534126 190.642027 
+L 188.467192 190.702282 
+L 188.400258 190.762461 
+L 188.333324 190.822563 
+L 188.26639 190.882589 
+L 188.199456 190.94254 
+L 188.132522 191.002414 
+L 188.065588 191.062213 
+L 187.998654 191.121937 
+L 187.931719 191.181585 
+L 187.864785 191.241159 
+L 187.797851 191.300657 
+L 187.730917 191.360081 
+L 187.663983 191.419431 
+L 187.597049 191.478706 
+L 187.530115 191.537908 
+L 187.463181 191.597035 
+L 187.396247 191.656089 
+L 187.329313 191.715069 
+L 187.262379 191.773976 
+L 187.195444 191.83281 
+L 187.12851 191.891571 
+L 187.061576 191.950259 
+L 186.994642 192.008874 
+L 186.927708 192.067418 
+L 186.860774 192.125888 
+L 186.79384 192.184287 
+L 186.726906 192.242614 
+L 186.659972 192.300869 
+L 186.593038 192.359053 
+L 186.526104 192.417166 
+L 186.459169 192.475207 
+L 186.392235 192.533177 
+L 186.325301 192.591076 
+L 186.258367 192.648905 
+L 186.191433 192.706663 
+L 186.124499 192.764351 
+L 186.057565 192.821969 
+L 185.990631 192.879517 
+L 185.923697 192.936995 
+L 185.856763 192.994403 
+L 185.789829 193.051742 
+L 185.722895 193.109012 
+L 185.65596 193.166212 
+L 185.589026 193.223344 
+L 185.522092 193.280406 
+L 185.455158 193.3374 
+L 185.388224 193.394326 
+L 185.32129 193.451183 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 184.505355 194.558953 
-L 184.093245 194.826053 
-L 183.681135 195.091656 
-L 183.269026 195.355779 
-L 182.856916 195.618438 
-L 182.444806 195.879649 
-L 182.032697 196.139427 
-L 181.620587 196.39779 
-L 181.208477 196.654752 
-L 180.796368 196.910328 
-L 180.384258 197.164533 
-L 179.972148 197.417381 
-L 179.560039 197.668888 
-L 179.147929 197.919067 
-L 178.735819 198.167932 
-L 178.323709 198.415496 
-L 177.9116 198.661775 
-L 177.49949 198.90678 
-L 177.08738 199.150525 
-L 176.675271 199.393022 
-L 176.263161 199.634285 
-L 175.851051 199.874326 
-L 175.438942 200.113157 
-L 175.026832 200.35079 
-L 174.614722 200.587238 
-L 174.202613 200.822512 
-L 173.790503 201.056624 
-L 173.378393 201.289584 
-L 172.966284 201.521405 
-L 172.554174 201.752098 
-L 172.142064 201.981673 
-L 171.729955 202.210141 
-L 171.317845 202.437513 
-L 170.905735 202.663799 
-L 170.493626 202.88901 
-L 170.081516 203.113155 
-L 169.669406 203.336246 
-L 169.257297 203.558291 
-L 168.845187 203.7793 
-L 168.433077 203.999284 
-L 168.020968 204.218251 
-L 167.608858 204.436211 
-L 167.196748 204.653173 
-L 166.784639 204.869146 
-L 166.372529 205.084139 
-L 165.960419 205.298162 
-L 165.54831 205.511222 
-L 165.1362 205.723329 
-L 164.72409 205.93449 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 185.32129 193.451183 
+L 184.901671 193.739644 
+L 184.482051 194.02636 
+L 184.062432 194.311351 
+L 183.642813 194.594639 
+L 183.223194 194.876243 
+L 182.803574 195.156183 
+L 182.383955 195.43448 
+L 181.964336 195.711152 
+L 181.544716 195.986218 
+L 181.125097 196.259696 
+L 180.705478 196.531606 
+L 180.285858 196.801964 
+L 179.866239 197.070788 
+L 179.44662 197.338096 
+L 179.027001 197.603905 
+L 178.607381 197.868231 
+L 178.187762 198.131091 
+L 177.768143 198.3925 
+L 177.348523 198.652476 
+L 176.928904 198.911033 
+L 176.509285 199.168188 
+L 176.089666 199.423954 
+L 175.670046 199.678347 
+L 175.250427 199.931382 
+L 174.830808 200.183073 
+L 174.411188 200.433434 
+L 173.991569 200.68248 
+L 173.57195 200.930223 
+L 173.15233 201.176678 
+L 172.732711 201.421858 
+L 172.313092 201.665776 
+L 171.893473 201.908445 
+L 171.473853 202.149878 
+L 171.054234 202.390087 
+L 170.634615 202.629084 
+L 170.214995 202.866882 
+L 169.795376 203.103493 
+L 169.375757 203.338928 
+L 168.956138 203.5732 
+L 168.536518 203.806318 
+L 168.116899 204.038296 
+L 167.69728 204.269144 
+L 167.27766 204.498872 
+L 166.858041 204.727493 
+L 166.438422 204.955015 
+L 166.018802 205.181451 
+L 165.599183 205.406809 
+L 165.179564 205.631101 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 164.72409 205.93449 
-L 164.437149 207.48325 
-L 164.150207 208.982992 
-L 163.863265 210.436723 
-L 163.576324 211.847182 
-L 163.289382 213.216872 
-L 163.00244 214.548082 
-L 162.715499 215.842917 
-L 162.428557 217.103311 
-L 162.141615 218.33105 
-L 161.854674 219.527781 
-L 161.567732 220.695035 
-L 161.28079 221.834226 
-L 160.993849 222.946675 
-L 160.706907 224.033606 
-L 160.419966 225.096165 
-L 160.133024 226.13542 
-L 159.846082 227.152373 
-L 159.559141 228.14796 
-L 159.272199 229.12306 
-L 158.985257 230.0785 
-L 158.698316 231.015056 
-L 158.411374 231.933462 
-L 158.124432 232.834406 
-L 157.837491 233.718541 
-L 157.550549 234.586482 
-L 157.263608 235.438812 
-L 156.976666 236.276082 
-L 156.689724 237.098816 
-L 156.402783 237.90751 
-L 156.115841 238.702635 
-L 155.828899 239.484638 
-L 155.541958 240.253945 
-L 155.255016 241.010964 
-L 154.968074 241.756079 
-L 154.681133 242.489659 
-L 154.394191 243.212056 
-L 154.10725 243.923607 
-L 153.820308 244.624631 
-L 153.533366 245.315435 
-L 153.246425 245.996315 
-L 152.959483 246.667549 
-L 152.672541 247.329409 
-L 152.3856 247.982152 
-L 152.098658 248.626026 
-L 151.811716 249.261269 
-L 151.524775 249.888109 
-L 151.237833 250.506765 
-L 150.950891 251.117449 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.179564 205.631101 
+L 164.883133 207.170609 
+L 164.586703 208.661672 
+L 164.290272 210.107248 
+L 163.993841 211.510029 
+L 163.697411 212.872477 
+L 163.40098 214.196846 
+L 163.104549 215.485207 
+L 162.808118 216.739467 
+L 162.511688 217.961383 
+L 162.215257 219.152583 
+L 161.918826 220.314573 
+L 161.622396 221.448751 
+L 161.325965 222.556417 
+L 161.029534 223.638784 
+L 160.733104 224.696979 
+L 160.436673 225.732061 
+L 160.140242 226.745016 
+L 159.843812 227.736771 
+L 159.547381 228.708195 
+L 159.25095 229.660106 
+L 158.95452 230.593271 
+L 158.658089 231.508415 
+L 158.361658 232.40622 
+L 158.065228 233.287332 
+L 157.768797 234.15236 
+L 157.472366 235.00188 
+L 157.175936 235.836439 
+L 156.879505 236.656555 
+L 156.583074 237.462719 
+L 156.286644 238.255397 
+L 155.990213 239.035035 
+L 155.693782 239.802053 
+L 155.397352 240.556854 
+L 155.100921 241.29982 
+L 154.80449 242.031318 
+L 154.50806 242.751696 
+L 154.211629 243.461287 
+L 153.915198 244.16041 
+L 153.618768 244.849368 
+L 153.322337 245.528452 
+L 153.025906 246.197943 
+L 152.729476 246.858108 
+L 152.433045 247.509201 
+L 152.136614 248.151471 
+L 151.840183 248.785151 
+L 151.543753 249.41047 
+L 151.247322 250.027645 
+L 150.950891 250.636885 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 251.117449 
-L 150.28498 252.308608 
-L 149.619069 253.47056 
-L 148.953158 254.604701 
-L 148.287246 255.712332 
-L 147.621335 256.794665 
-L 146.955424 257.852829 
-L 146.289513 258.887879 
-L 145.623601 259.900805 
-L 144.95769 260.892532 
-L 144.291779 261.86393 
-L 143.625868 262.815814 
-L 142.959956 263.748955 
-L 142.294045 264.664075 
-L 141.628134 265.561857 
-L 140.962223 266.442947 
-L 140.296311 267.307953 
-L 139.6304 268.157453 
-L 138.964489 268.991992 
-L 138.298578 269.812089 
-L 137.632666 270.618234 
-L 136.966755 271.410895 
-L 136.300844 272.190514 
-L 135.634933 272.957516 
-L 134.969021 273.7123 
-L 134.30311 274.455251 
-L 133.637199 275.186734 
-L 132.971288 275.907097 
-L 132.305376 276.616674 
-L 131.639465 277.315782 
-L 130.973554 278.004727 
-L 130.307643 278.683798 
-L 129.641731 279.353276 
-L 128.97582 280.013428 
-L 128.309909 280.66451 
-L 127.643998 281.306767 
-L 126.978086 281.940437 
-L 126.312175 282.565744 
-L 125.646264 283.182908 
-L 124.980353 283.792138 
-L 124.314441 284.393635 
-L 123.64853 284.987592 
-L 122.982619 285.574197 
-L 122.316708 286.15363 
-L 121.650796 286.726063 
-L 120.984885 287.291664 
-L 120.318974 287.850594 
-L 119.653063 288.403008 
-L 118.987151 288.949057 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 250.636885 
+L 150.28498 251.856692 
+L 149.619069 253.045887 
+L 148.953158 254.205968 
+L 148.287246 255.338329 
+L 147.621335 256.444261 
+L 146.955424 257.524971 
+L 146.289513 258.581584 
+L 145.623601 259.615151 
+L 144.95769 260.626656 
+L 144.291779 261.617021 
+L 143.625868 262.587111 
+L 142.959956 263.537741 
+L 142.294045 264.469675 
+L 141.628134 265.383635 
+L 140.962223 266.280301 
+L 140.296311 267.160315 
+L 139.6304 268.024285 
+L 138.964489 268.872785 
+L 138.298578 269.706359 
+L 137.632666 270.525524 
+L 136.966755 271.330769 
+L 136.300844 272.122559 
+L 135.634933 272.901337 
+L 134.969021 273.667523 
+L 134.30311 274.421519 
+L 133.637199 275.163705 
+L 132.971288 275.894446 
+L 132.305376 276.614091 
+L 131.639465 277.32297 
+L 130.973554 278.021401 
+L 130.307643 278.709687 
+L 129.641731 279.38812 
+L 128.97582 280.056977 
+L 128.309909 280.716525 
+L 127.643998 281.367019 
+L 126.978086 282.008705 
+L 126.312175 282.641818 
+L 125.646264 283.266584 
+L 124.980353 283.88322 
+L 124.314441 284.491935 
+L 123.64853 285.092931 
+L 122.982619 285.686399 
+L 122.316708 286.272528 
+L 121.650796 286.851495 
+L 120.984885 287.423474 
+L 120.318974 287.988632 
+L 119.653063 288.547128 
+L 118.987151 289.09912 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 118.987151 288.949057 
-L 118.557186 289.792761 
-L 118.127221 290.621706 
-L 117.697256 291.4364 
-L 117.267291 292.237324 
-L 116.837325 293.024936 
-L 116.40736 293.799672 
-L 115.977395 294.561946 
-L 115.54743 295.312151 
-L 115.117465 296.050665 
-L 114.687499 296.777847 
-L 114.257534 297.494038 
-L 113.827569 298.199567 
-L 113.397604 298.894745 
-L 112.967639 299.579872 
-L 112.537673 300.255236 
-L 112.107708 300.921109 
-L 111.677743 301.577756 
-L 111.247778 302.225427 
-L 110.817813 302.864367 
-L 110.387847 303.494805 
-L 109.957882 304.116967 
-L 109.527917 304.731067 
-L 109.097952 305.33731 
-L 108.667987 305.935895 
-L 108.238021 306.527013 
-L 107.808056 307.110849 
-L 107.378091 307.687579 
-L 106.948126 308.257375 
-L 106.518161 308.820401 
-L 106.088195 309.376816 
-L 105.65823 309.926773 
-L 105.228265 310.470422 
-L 104.7983 311.007904 
-L 104.368335 311.539359 
-L 103.938369 312.064919 
-L 103.508404 312.584714 
-L 103.078439 313.09887 
-L 102.648474 313.607508 
-L 102.218509 314.110743 
-L 101.788543 314.608691 
-L 101.358578 315.101461 
-L 100.928613 315.58916 
-L 100.498648 316.07189 
-L 100.068683 316.549753 
-L 99.638717 317.022845 
-L 99.208752 317.491261 
-L 98.778787 317.955092 
-L 98.348822 318.414427 
-" clip-path="url(#p5bbd16b32b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 118.987151 289.09912 
+L 118.557186 289.94037 
+L 118.127221 290.766947 
+L 117.697256 291.579353 
+L 117.267291 292.378066 
+L 116.837325 293.16354 
+L 116.40736 293.936206 
+L 115.977395 294.696477 
+L 115.54743 295.444742 
+L 115.117465 296.181376 
+L 114.687499 296.906734 
+L 114.257534 297.621157 
+L 113.827569 298.324969 
+L 113.397604 299.018481 
+L 112.967639 299.701989 
+L 112.537673 300.37578 
+L 112.107708 301.040124 
+L 111.677743 301.695283 
+L 111.247778 302.341508 
+L 110.817813 302.97904 
+L 110.387847 303.608108 
+L 109.957882 304.228934 
+L 109.527917 304.841733 
+L 109.097952 305.446708 
+L 108.667987 306.044057 
+L 108.238021 306.63397 
+L 107.808056 307.21663 
+L 107.378091 307.792213 
+L 106.948126 308.360889 
+L 106.518161 308.922821 
+L 106.088195 309.478168 
+L 105.65823 310.027082 
+L 105.228265 310.569711 
+L 104.7983 311.106196 
+L 104.368335 311.636676 
+L 103.938369 312.161284 
+L 103.508404 312.680147 
+L 103.078439 313.193391 
+L 102.648474 313.701135 
+L 102.218509 314.203497 
+L 101.788543 314.700589 
+L 101.358578 315.192521 
+L 100.928613 315.679399 
+L 100.498648 316.161326 
+L 100.068683 316.6384 
+L 99.638717 317.11072 
+L 99.208752 317.578379 
+L 98.778787 318.041467 
+L 98.348822 318.500074 
+" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.844609 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.059766 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,6 +6276,19 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
@@ -6301,19 +6314,6 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6411,16 +6411,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6459,109 +6459,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5bbd16b32b">
+  <clipPath id="p1bc8dd2d0a">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m7780de3bce" d="M 0 0 
+       <path id="m751ba18116" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7780de3bce" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7780de3bce" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7780de3bce" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7780de3bce" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7780de3bce" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7780de3bce" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7780de3bce" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m751ba18116" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m8ad4076651" d="M 0 0 
+       <path id="me79fe9bd45" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8ad4076651" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me79fe9bd45" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8ad4076651" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me79fe9bd45" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8ad4076651" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me79fe9bd45" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m77f5b5e32e" d="M 0 0 
+       <path id="m2712d0e0cc" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m77f5b5e32e" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2712d0e0cc" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 167.848132) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 166.210642) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.954264) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 313.895449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m4fcd2ef7e3" d="M -2.5 2.5 
+     <path id="m8248797231" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m4fcd2ef7e3" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fcd2ef7e3" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m8248797231" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8248797231" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mce8897395c" d="M 0 -2.5 
+     <path id="m0aa2e42289" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#mce8897395c" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce8897395c" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m0aa2e42289" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0aa2e42289" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m0580dc963e" d="M -0 3.535534 
+     <path id="maa7c5be4a6" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m0580dc963e" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0580dc963e" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#maa7c5be4a6" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa7c5be4a6" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m261fc7a5d8" d="M -0 2.5 
+     <path id="m4f8d9f4214" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m261fc7a5d8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m4f8d9f4214" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m77769d5b4d" d="M -0.833333 2.5 
+     <path id="m5e15292337" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m77769d5b4d" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m77769d5b4d" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m5e15292337" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5e15292337" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mafc31e1f46" d="M -1.25 2.5 
+     <path id="me837150432" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#mafc31e1f46" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafc31e1f46" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#me837150432" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me837150432" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m3120d4c380" d="M 0 -2.5 
+     <path id="m33da524915" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m3120d4c380" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3120d4c380" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m33da524915" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m33da524915" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m841d576127" d="M 0 -2.5 
+     <path id="m62941d48c0" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m841d576127" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m841d576127" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m62941d48c0" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m62941d48c0" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m8901decd07" d="M 0 3.5 
+      <path id="m6c2a93bf4c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8901decd07" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6c2a93bf4c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m4fcd2ef7e3" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8248797231" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mce8897395c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0aa2e42289" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m0580dc963e" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maa7c5be4a6" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m261fc7a5d8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4f8d9f4214" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m77769d5b4d" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5e15292337" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mafc31e1f46" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me837150432" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m3120d4c380" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m33da524915" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m841d576127" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m62941d48c0" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p3b7b607bad)">
-     <use xlink:href="#m8901decd07" x="289.669676" y="172.848132" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="214.084819" y="182.450275" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="206.266533" y="184.920059" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="187.75787" y="191.660998" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="186.58897" y="192.681555" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="184.505355" y="195.094623" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="164.72409" y="206.647831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="150.950891" y="251.835626" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="118.987151" y="290.412797" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8901decd07" x="98.348822" y="318.954264" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pbd2445a49c)">
+     <use xlink:href="#m6c2a93bf4c" x="289.669676" y="171.210642" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="214.084819" y="180.736541" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="206.266533" y="183.356427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="187.75787" y="190.442845" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="186.58897" y="191.46395" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="184.505355" y="193.942692" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="164.72409" y="205.767024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="150.950891" y="251.670942" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="118.987151" y="290.062143" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6c2a93bf4c" x="98.348822" y="318.895449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 172.848132 
-L 288.094992 173.069368 
-L 286.520307 173.289575 
-L 284.945623 173.508764 
-L 283.370938 173.726944 
-L 281.796253 173.944124 
-L 280.221569 174.160313 
-L 278.646884 174.37552 
-L 277.0722 174.589755 
-L 275.497515 174.803025 
-L 273.922831 175.01534 
-L 272.348146 175.226707 
-L 270.773462 175.437137 
-L 269.198777 175.646636 
-L 267.624093 175.855212 
-L 266.049408 176.062875 
-L 264.474724 176.269632 
-L 262.900039 176.475491 
-L 261.325355 176.680459 
-L 259.75067 176.884544 
-L 258.175986 177.087755 
-L 256.601301 177.290097 
-L 255.026616 177.49158 
-L 253.451932 177.692209 
-L 251.877247 177.891993 
-L 250.302563 178.090937 
-L 248.727878 178.28905 
-L 247.153194 178.486339 
-L 245.578509 178.682809 
-L 244.003825 178.878468 
-L 242.42914 179.073323 
-L 240.854456 179.26738 
-L 239.279771 179.460645 
-L 237.705087 179.653125 
-L 236.130402 179.844827 
-L 234.555718 180.035756 
-L 232.981033 180.22592 
-L 231.406349 180.415323 
-L 229.831664 180.603972 
-L 228.25698 180.791873 
-L 226.682295 180.979032 
-L 225.10761 181.165455 
-L 223.532926 181.351147 
-L 221.958241 181.536114 
-L 220.383557 181.720363 
-L 218.808872 181.903897 
-L 217.234188 182.086724 
-L 215.659503 182.268848 
-L 214.084819 182.450275 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 171.210642 
+L 288.094992 171.429943 
+L 286.520307 171.648234 
+L 284.945623 171.865524 
+L 283.370938 172.081822 
+L 281.796253 172.297137 
+L 280.221569 172.511478 
+L 278.646884 172.724855 
+L 277.0722 172.937274 
+L 275.497515 173.148746 
+L 273.922831 173.359279 
+L 272.348146 173.56888 
+L 270.773462 173.777558 
+L 269.198777 173.985321 
+L 267.624093 174.192178 
+L 266.049408 174.398135 
+L 264.474724 174.603201 
+L 262.900039 174.807384 
+L 261.325355 175.010691 
+L 259.75067 175.213129 
+L 258.175986 175.414706 
+L 256.601301 175.615429 
+L 255.026616 175.815305 
+L 253.451932 176.014342 
+L 251.877247 176.212547 
+L 250.302563 176.409926 
+L 248.727878 176.606486 
+L 247.153194 176.802235 
+L 245.578509 176.997178 
+L 244.003825 177.191322 
+L 242.42914 177.384675 
+L 240.854456 177.577241 
+L 239.279771 177.769029 
+L 237.705087 177.960043 
+L 236.130402 178.15029 
+L 234.555718 178.339777 
+L 232.981033 178.528509 
+L 231.406349 178.716493 
+L 229.831664 178.903733 
+L 228.25698 179.090237 
+L 226.682295 179.27601 
+L 225.10761 179.461057 
+L 223.532926 179.645384 
+L 221.958241 179.828997 
+L 220.383557 180.011902 
+L 218.808872 180.194103 
+L 217.234188 180.375607 
+L 215.659503 180.556418 
+L 214.084819 180.736541 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 214.084819 182.450275 
-L 213.921938 182.503063 
-L 213.759057 182.555794 
-L 213.596176 182.608465 
-L 213.433295 182.661078 
-L 213.270414 182.713633 
-L 213.107533 182.766129 
-L 212.944652 182.818568 
-L 212.781771 182.870948 
-L 212.61889 182.92327 
-L 212.456009 182.975535 
-L 212.293128 183.027743 
-L 212.130247 183.079892 
-L 211.967366 183.131985 
-L 211.804485 183.18402 
-L 211.641604 183.235998 
-L 211.478723 183.28792 
-L 211.315843 183.339784 
-L 211.152962 183.391592 
-L 210.990081 183.443343 
-L 210.8272 183.495038 
-L 210.664319 183.546676 
-L 210.501438 183.598258 
-L 210.338557 183.649785 
-L 210.175676 183.701255 
-L 210.012795 183.752669 
-L 209.849914 183.804028 
-L 209.687033 183.85533 
-L 209.524152 183.906578 
-L 209.361271 183.95777 
-L 209.19839 184.008907 
-L 209.035509 184.059989 
-L 208.872628 184.111015 
-L 208.709747 184.161987 
-L 208.546866 184.212904 
-L 208.383985 184.263767 
-L 208.221104 184.314575 
-L 208.058223 184.365328 
-L 207.895342 184.416028 
-L 207.732462 184.466673 
-L 207.569581 184.517264 
-L 207.4067 184.567801 
-L 207.243819 184.618284 
-L 207.080938 184.668713 
-L 206.918057 184.719089 
-L 206.755176 184.769411 
-L 206.592295 184.81968 
-L 206.429414 184.869896 
-L 206.266533 184.920059 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 214.084819 180.736541 
+L 213.921938 180.792626 
+L 213.759057 180.848644 
+L 213.596176 180.904597 
+L 213.433295 180.960483 
+L 213.270414 181.016303 
+L 213.107533 181.072058 
+L 212.944652 181.127747 
+L 212.781771 181.183371 
+L 212.61889 181.23893 
+L 212.456009 181.294423 
+L 212.293128 181.349852 
+L 212.130247 181.405216 
+L 211.967366 181.460515 
+L 211.804485 181.51575 
+L 211.641604 181.570921 
+L 211.478723 181.626027 
+L 211.315843 181.68107 
+L 211.152962 181.736048 
+L 210.990081 181.790963 
+L 210.8272 181.845814 
+L 210.664319 181.900602 
+L 210.501438 181.955327 
+L 210.338557 182.009988 
+L 210.175676 182.064587 
+L 210.012795 182.119123 
+L 209.849914 182.173596 
+L 209.687033 182.228006 
+L 209.524152 182.282354 
+L 209.361271 182.33664 
+L 209.19839 182.390863 
+L 209.035509 182.445025 
+L 208.872628 182.499125 
+L 208.709747 182.553163 
+L 208.546866 182.60714 
+L 208.383985 182.661055 
+L 208.221104 182.714909 
+L 208.058223 182.768702 
+L 207.895342 182.822434 
+L 207.732462 182.876105 
+L 207.569581 182.929715 
+L 207.4067 182.983264 
+L 207.243819 183.036754 
+L 207.080938 183.090183 
+L 206.918057 183.143551 
+L 206.755176 183.19686 
+L 206.592295 183.250109 
+L 206.429414 183.303298 
+L 206.266533 183.356427 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 206.266533 184.920059 
-L 205.880936 185.070734 
-L 205.495339 185.220933 
-L 205.109742 185.370656 
-L 204.724144 185.519908 
-L 204.338547 185.668692 
-L 203.95295 185.817009 
-L 203.567353 185.964865 
-L 203.181756 186.11226 
-L 202.796159 186.259198 
-L 202.410562 186.405682 
-L 202.024964 186.551714 
-L 201.639367 186.697298 
-L 201.25377 186.842436 
-L 200.868173 186.987131 
-L 200.482576 187.131386 
-L 200.096979 187.275202 
-L 199.711382 187.418584 
-L 199.325784 187.561533 
-L 198.940187 187.704052 
-L 198.55459 187.846143 
-L 198.168993 187.98781 
-L 197.783396 188.129055 
-L 197.397799 188.26988 
-L 197.012202 188.410288 
-L 196.626605 188.550281 
-L 196.241007 188.689861 
-L 195.85541 188.829032 
-L 195.469813 188.967795 
-L 195.084216 189.106153 
-L 194.698619 189.244108 
-L 194.313022 189.381663 
-L 193.927425 189.51882 
-L 193.541827 189.655581 
-L 193.15623 189.791948 
-L 192.770633 189.927924 
-L 192.385036 190.063511 
-L 191.999439 190.198711 
-L 191.613842 190.333526 
-L 191.228245 190.46796 
-L 190.842647 190.602012 
-L 190.45705 190.735687 
-L 190.071453 190.868986 
-L 189.685856 191.00191 
-L 189.300259 191.134463 
-L 188.914662 191.266646 
-L 188.529065 191.398462 
-L 188.143468 191.529912 
-L 187.75787 191.660998 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 206.266533 183.356427 
+L 205.880936 183.515404 
+L 205.495339 183.673849 
+L 205.109742 183.831766 
+L 204.724144 183.989158 
+L 204.338547 184.14603 
+L 203.95295 184.302384 
+L 203.567353 184.458224 
+L 203.181756 184.613553 
+L 202.796159 184.768374 
+L 202.410562 184.922692 
+L 202.024964 185.076508 
+L 201.639367 185.229827 
+L 201.25377 185.382651 
+L 200.868173 185.534984 
+L 200.482576 185.686829 
+L 200.096979 185.838189 
+L 199.711382 185.989067 
+L 199.325784 186.139467 
+L 198.940187 186.28939 
+L 198.55459 186.438841 
+L 198.168993 186.587821 
+L 197.783396 186.736335 
+L 197.397799 186.884385 
+L 197.012202 187.031974 
+L 196.626605 187.179105 
+L 196.241007 187.32578 
+L 195.85541 187.472002 
+L 195.469813 187.617775 
+L 195.084216 187.763101 
+L 194.698619 187.907982 
+L 194.313022 188.052422 
+L 193.927425 188.196423 
+L 193.541827 188.339988 
+L 193.15623 188.483119 
+L 192.770633 188.625819 
+L 192.385036 188.768091 
+L 191.999439 188.909937 
+L 191.613842 189.051359 
+L 191.228245 189.192361 
+L 190.842647 189.332944 
+L 190.45705 189.473112 
+L 190.071453 189.612866 
+L 189.685856 189.752209 
+L 189.300259 189.891144 
+L 188.914662 190.029673 
+L 188.529065 190.167797 
+L 188.143468 190.305521 
+L 187.75787 190.442845 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 187.75787 191.660998 
-L 187.733518 191.682485 
-L 187.709166 191.703963 
-L 187.684814 191.725431 
-L 187.660462 191.746889 
-L 187.63611 191.768337 
-L 187.611758 191.789776 
-L 187.587406 191.811205 
-L 187.563054 191.832624 
-L 187.538702 191.854034 
-L 187.514349 191.875434 
-L 187.489997 191.896824 
-L 187.465645 191.918205 
-L 187.441293 191.939576 
-L 187.416941 191.960938 
-L 187.392589 191.982289 
-L 187.368237 192.003632 
-L 187.343885 192.024964 
-L 187.319533 192.046287 
-L 187.295181 192.067601 
-L 187.270829 192.088904 
-L 187.246476 192.110199 
-L 187.222124 192.131483 
-L 187.197772 192.152758 
-L 187.17342 192.174024 
-L 187.149068 192.19528 
-L 187.124716 192.216526 
-L 187.100364 192.237763 
-L 187.076012 192.258991 
-L 187.05166 192.280209 
-L 187.027308 192.301417 
-L 187.002956 192.322616 
-L 186.978603 192.343806 
-L 186.954251 192.364986 
-L 186.929899 192.386156 
-L 186.905547 192.407317 
-L 186.881195 192.428469 
-L 186.856843 192.449611 
-L 186.832491 192.470744 
-L 186.808139 192.491867 
-L 186.783787 192.512981 
-L 186.759435 192.534086 
-L 186.735083 192.555181 
-L 186.71073 192.576267 
-L 186.686378 192.597343 
-L 186.662026 192.61841 
-L 186.637674 192.639468 
-L 186.613322 192.660516 
-L 186.58897 192.681555 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 187.75787 190.442845 
+L 187.733518 190.464344 
+L 187.709166 190.485833 
+L 187.684814 190.507313 
+L 187.660462 190.528783 
+L 187.63611 190.550243 
+L 187.611758 190.571693 
+L 187.587406 190.593134 
+L 187.563054 190.614565 
+L 187.538702 190.635986 
+L 187.514349 190.657397 
+L 187.489997 190.678799 
+L 187.465645 190.700191 
+L 187.441293 190.721574 
+L 187.416941 190.742947 
+L 187.392589 190.76431 
+L 187.368237 190.785664 
+L 187.343885 190.807008 
+L 187.319533 190.828342 
+L 187.295181 190.849667 
+L 187.270829 190.870982 
+L 187.246476 190.892288 
+L 187.222124 190.913584 
+L 187.197772 190.934871 
+L 187.17342 190.956148 
+L 187.149068 190.977415 
+L 187.124716 190.998673 
+L 187.100364 191.019921 
+L 187.076012 191.04116 
+L 187.05166 191.062389 
+L 187.027308 191.083609 
+L 187.002956 191.104819 
+L 186.978603 191.12602 
+L 186.954251 191.147212 
+L 186.929899 191.168393 
+L 186.905547 191.189566 
+L 186.881195 191.210729 
+L 186.856843 191.231882 
+L 186.832491 191.253026 
+L 186.808139 191.274161 
+L 186.783787 191.295286 
+L 186.759435 191.316402 
+L 186.735083 191.337508 
+L 186.71073 191.358605 
+L 186.686378 191.379693 
+L 186.662026 191.400771 
+L 186.637674 191.42184 
+L 186.613322 191.4429 
+L 186.58897 191.46395 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 186.58897 192.681555 
-L 186.545561 192.733101 
-L 186.502153 192.784591 
-L 186.458744 192.836026 
-L 186.415335 192.887404 
-L 186.371927 192.938727 
-L 186.328518 192.989994 
-L 186.285109 193.041206 
-L 186.241701 193.092363 
-L 186.198292 193.143465 
-L 186.154883 193.194511 
-L 186.111475 193.245502 
-L 186.068066 193.296439 
-L 186.024658 193.347321 
-L 185.981249 193.398149 
-L 185.93784 193.448922 
-L 185.894432 193.49964 
-L 185.851023 193.550305 
-L 185.807614 193.600915 
-L 185.764206 193.651471 
-L 185.720797 193.701974 
-L 185.677388 193.752422 
-L 185.63398 193.802817 
-L 185.590571 193.853159 
-L 185.547162 193.903447 
-L 185.503754 193.953682 
-L 185.460345 194.003863 
-L 185.416936 194.053992 
-L 185.373528 194.104067 
-L 185.330119 194.15409 
-L 185.28671 194.20406 
-L 185.243302 194.253977 
-L 185.199893 194.303842 
-L 185.156484 194.353654 
-L 185.113076 194.403414 
-L 185.069667 194.453122 
-L 185.026258 194.502778 
-L 184.98285 194.552382 
-L 184.939441 194.601933 
-L 184.896033 194.651434 
-L 184.852624 194.700882 
-L 184.809215 194.750279 
-L 184.765807 194.799625 
-L 184.722398 194.848919 
-L 184.678989 194.898162 
-L 184.635581 194.947354 
-L 184.592172 194.996494 
-L 184.548763 195.045584 
-L 184.505355 195.094623 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 191.46395 
+L 186.545561 191.516935 
+L 186.502153 191.569861 
+L 186.458744 191.622728 
+L 186.415335 191.675536 
+L 186.371927 191.728286 
+L 186.328518 191.780976 
+L 186.285109 191.833608 
+L 186.241701 191.886182 
+L 186.198292 191.938698 
+L 186.154883 191.991155 
+L 186.111475 192.043554 
+L 186.068066 192.095896 
+L 186.024658 192.14818 
+L 185.981249 192.200406 
+L 185.93784 192.252574 
+L 185.894432 192.304686 
+L 185.851023 192.35674 
+L 185.807614 192.408737 
+L 185.764206 192.460677 
+L 185.720797 192.51256 
+L 185.677388 192.564386 
+L 185.63398 192.616156 
+L 185.590571 192.667869 
+L 185.547162 192.719526 
+L 185.503754 192.771126 
+L 185.460345 192.822671 
+L 185.416936 192.874159 
+L 185.373528 192.925592 
+L 185.330119 192.976969 
+L 185.28671 193.02829 
+L 185.243302 193.079555 
+L 185.199893 193.130766 
+L 185.156484 193.181921 
+L 185.113076 193.233021 
+L 185.069667 193.284065 
+L 185.026258 193.335055 
+L 184.98285 193.38599 
+L 184.939441 193.436871 
+L 184.896033 193.487696 
+L 184.852624 193.538468 
+L 184.809215 193.589185 
+L 184.765807 193.639847 
+L 184.722398 193.690456 
+L 184.678989 193.741011 
+L 184.635581 193.791512 
+L 184.592172 193.841959 
+L 184.548763 193.892352 
+L 184.505355 193.942692 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 184.505355 195.094623 
-L 184.093245 195.366411 
-L 183.681135 195.636649 
-L 183.269026 195.905355 
-L 182.856916 196.172545 
-L 182.444806 196.438238 
-L 182.032697 196.702449 
-L 181.620587 196.965195 
-L 181.208477 197.226493 
-L 180.796368 197.486358 
-L 180.384258 197.744805 
-L 179.972148 198.00185 
-L 179.560039 198.257509 
-L 179.147929 198.511796 
-L 178.735819 198.764726 
-L 178.323709 199.016313 
-L 177.9116 199.266571 
-L 177.49949 199.515515 
-L 177.08738 199.763157 
-L 176.675271 200.009513 
-L 176.263161 200.254594 
-L 175.851051 200.498414 
-L 175.438942 200.740986 
-L 175.026832 200.982323 
-L 174.614722 201.222437 
-L 174.202613 201.46134 
-L 173.790503 201.699046 
-L 173.378393 201.935564 
-L 172.966284 202.170908 
-L 172.554174 202.40509 
-L 172.142064 202.638119 
-L 171.729955 202.870008 
-L 171.317845 203.100769 
-L 170.905735 203.33041 
-L 170.493626 203.558945 
-L 170.081516 203.786382 
-L 169.669406 204.012733 
-L 169.257297 204.238009 
-L 168.845187 204.462218 
-L 168.433077 204.685371 
-L 168.020968 204.907479 
-L 167.608858 205.128551 
-L 167.196748 205.348595 
-L 166.784639 205.567623 
-L 166.372529 205.785644 
-L 165.960419 206.002665 
-L 165.54831 206.218698 
-L 165.1362 206.43375 
-L 164.72409 206.647831 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 184.505355 193.942692 
+L 184.093245 194.221666 
+L 183.681135 194.499008 
+L 183.269026 194.774736 
+L 182.856916 195.048869 
+L 182.444806 195.321426 
+L 182.032697 195.592423 
+L 181.620587 195.86188 
+L 181.208477 196.129814 
+L 180.796368 196.396241 
+L 180.384258 196.661178 
+L 179.972148 196.924643 
+L 179.560039 197.18665 
+L 179.147929 197.447217 
+L 178.735819 197.70636 
+L 178.323709 197.964093 
+L 177.9116 198.220431 
+L 177.49949 198.475391 
+L 177.08738 198.728986 
+L 176.675271 198.981231 
+L 176.263161 199.232141 
+L 175.851051 199.481729 
+L 175.438942 199.73001 
+L 175.026832 199.976996 
+L 174.614722 200.222702 
+L 174.202613 200.467141 
+L 173.790503 200.710325 
+L 173.378393 200.952268 
+L 172.966284 201.192981 
+L 172.554174 201.432479 
+L 172.142064 201.670771 
+L 171.729955 201.907872 
+L 171.317845 202.143792 
+L 170.905735 202.378544 
+L 170.493626 202.612138 
+L 170.081516 202.844586 
+L 169.669406 203.0759 
+L 169.257297 203.30609 
+L 168.845187 203.535168 
+L 168.433077 203.763143 
+L 168.020968 203.990027 
+L 167.608858 204.21583 
+L 167.196748 204.440562 
+L 166.784639 204.664234 
+L 166.372529 204.886854 
+L 165.960419 205.108434 
+L 165.54831 205.328983 
+L 165.1362 205.548509 
+L 164.72409 205.767024 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 164.72409 206.647831 
-L 164.437149 208.196844 
-L 164.150207 209.696823 
-L 163.863265 211.150777 
-L 163.576324 212.561446 
-L 163.289382 213.931333 
-L 163.00244 215.262731 
-L 162.715499 216.557742 
-L 162.428557 217.818304 
-L 162.141615 219.046201 
-L 161.854674 220.243084 
-L 161.567732 221.410481 
-L 161.28079 222.54981 
-L 160.993849 223.662388 
-L 160.706907 224.749444 
-L 160.419966 225.812122 
-L 160.133024 226.851492 
-L 159.846082 227.868554 
-L 159.559141 228.864245 
-L 159.272199 229.839445 
-L 158.985257 230.794982 
-L 158.698316 231.731631 
-L 158.411374 232.650125 
-L 158.124432 233.551155 
-L 157.837491 234.435372 
-L 157.550549 235.303393 
-L 157.263608 236.155799 
-L 156.976666 236.993144 
-L 156.689724 237.815949 
-L 156.402783 238.624712 
-L 156.115841 239.419903 
-L 155.828899 240.201971 
-L 155.541958 240.971341 
-L 155.255016 241.728419 
-L 154.968074 242.473593 
-L 154.681133 243.20723 
-L 154.394191 243.929682 
-L 154.10725 244.641286 
-L 153.820308 245.342362 
-L 153.533366 246.033217 
-L 153.246425 246.714145 
-L 152.959483 247.385427 
-L 152.672541 248.047333 
-L 152.3856 248.700121 
-L 152.098658 249.344039 
-L 151.811716 249.979324 
-L 151.524775 250.606206 
-L 151.237833 251.224902 
-L 150.950891 251.835626 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 164.72409 205.767024 
+L 164.437149 207.353776 
+L 164.150207 208.889115 
+L 163.863265 210.376267 
+L 163.576324 211.818167 
+L 163.289382 213.217486 
+L 163.00244 214.576668 
+L 162.715499 215.89795 
+L 162.428557 217.183391 
+L 162.141615 218.434882 
+L 161.854674 219.654171 
+L 161.567732 220.842873 
+L 161.28079 222.002486 
+L 160.993849 223.1344 
+L 160.706907 224.239907 
+L 160.419966 225.320211 
+L 160.133024 226.376435 
+L 159.846082 227.409631 
+L 159.559141 228.420779 
+L 159.272199 229.410803 
+L 158.985257 230.380566 
+L 158.698316 231.330881 
+L 158.411374 232.262513 
+L 158.124432 233.176182 
+L 157.837491 234.072568 
+L 157.550549 234.952313 
+L 157.263608 235.816023 
+L 156.976666 236.664272 
+L 156.689724 237.497605 
+L 156.402783 238.316536 
+L 156.115841 239.121555 
+L 155.828899 239.913127 
+L 155.541958 240.691694 
+L 155.255016 241.457676 
+L 154.968074 242.211473 
+L 154.681133 242.953468 
+L 154.394191 243.684023 
+L 154.10725 244.403487 
+L 153.820308 245.112191 
+L 153.533366 245.810453 
+L 153.246425 246.498575 
+L 152.959483 247.176847 
+L 152.672541 247.845549 
+L 152.3856 248.504945 
+L 152.098658 249.155292 
+L 151.811716 249.796835 
+L 151.524775 250.429808 
+L 151.237833 251.054438 
+L 150.950891 251.670942 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 251.835626 
-L 150.28498 253.060693 
-L 149.619069 254.254887 
-L 148.953158 255.419725 
-L 148.287246 256.556617 
-L 147.621335 257.666872 
-L 146.955424 258.75171 
-L 146.289513 259.812267 
-L 145.623601 260.849609 
-L 144.95769 261.864728 
-L 144.291779 262.858558 
-L 143.625868 263.831972 
-L 142.959956 264.785794 
-L 142.294045 265.720795 
-L 141.628134 266.637705 
-L 140.962223 267.537211 
-L 140.296311 268.419959 
-L 139.6304 269.286565 
-L 138.964489 270.137607 
-L 138.298578 270.973634 
-L 137.632666 271.795168 
-L 136.966755 272.602702 
-L 136.300844 273.396705 
-L 135.634933 274.177624 
-L 134.969021 274.945882 
-L 134.30311 275.701884 
-L 133.637199 276.446015 
-L 132.971288 277.178641 
-L 132.305376 277.900112 
-L 131.639465 278.610765 
-L 130.973554 279.310917 
-L 130.307643 280.000876 
-L 129.641731 280.680933 
-L 128.97582 281.351368 
-L 128.309909 282.012451 
-L 127.643998 282.664438 
-L 126.978086 283.307577 
-L 126.312175 283.942104 
-L 125.646264 284.568247 
-L 124.980353 285.186224 
-L 124.314441 285.796247 
-L 123.64853 286.398516 
-L 122.982619 286.993227 
-L 122.316708 287.580567 
-L 121.650796 288.160717 
-L 120.984885 288.73385 
-L 120.318974 289.300134 
-L 119.653063 289.859731 
-L 118.987151 290.412797 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 251.670942 
+L 150.28498 252.887504 
+L 149.619069 254.073614 
+L 148.953158 255.23076 
+L 148.287246 256.360323 
+L 147.621335 257.463588 
+L 146.955424 258.54175 
+L 146.289513 259.595927 
+L 145.623601 260.627164 
+L 144.95769 261.636436 
+L 144.291779 262.624661 
+L 143.625868 263.592698 
+L 142.959956 264.541356 
+L 142.294045 265.471395 
+L 141.628134 266.383532 
+L 140.962223 267.278443 
+L 140.296311 268.156767 
+L 139.6304 269.019108 
+L 138.964489 269.866036 
+L 138.298578 270.698094 
+L 137.632666 271.515794 
+L 136.966755 272.319624 
+L 136.300844 273.110045 
+L 135.634933 273.887499 
+L 134.969021 274.652404 
+L 134.30311 275.405158 
+L 133.637199 276.146142 
+L 132.971288 276.875717 
+L 132.305376 277.594231 
+L 131.639465 278.302013 
+L 130.973554 278.999379 
+L 130.307643 279.686631 
+L 129.641731 280.364059 
+L 128.97582 281.031939 
+L 128.309909 281.690538 
+L 127.643998 282.340108 
+L 126.978086 282.980895 
+L 126.312175 283.613132 
+L 125.646264 284.237046 
+L 124.980353 284.852852 
+L 124.314441 285.460758 
+L 123.64853 286.060964 
+L 122.982619 286.653664 
+L 122.316708 287.239042 
+L 121.650796 287.817277 
+L 120.984885 288.388542 
+L 120.318974 288.953002 
+L 119.653063 289.510817 
+L 118.987151 290.062143 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 118.987151 290.412797 
-L 118.557186 291.221617 
-L 118.127221 292.016864 
-L 117.697256 292.798986 
-L 117.267291 293.568408 
-L 116.837325 294.325538 
-L 116.40736 295.07076 
-L 115.977395 295.804445 
-L 115.54743 296.526943 
-L 115.117465 297.238591 
-L 114.687499 297.939711 
-L 114.257534 298.630608 
-L 113.827569 299.311577 
-L 113.397604 299.982899 
-L 112.967639 300.644843 
-L 112.537673 301.297669 
-L 112.107708 301.941623 
-L 111.677743 302.576944 
-L 111.247778 303.20386 
-L 110.817813 303.822591 
-L 110.387847 304.433347 
-L 109.957882 305.036331 
-L 109.527917 305.63174 
-L 109.097952 306.21976 
-L 108.667987 306.800573 
-L 108.238021 307.374354 
-L 107.808056 307.94127 
-L 107.378091 308.501485 
-L 106.948126 309.055154 
-L 106.518161 309.602429 
-L 106.088195 310.143455 
-L 105.65823 310.678375 
-L 105.228265 311.207324 
-L 104.7983 311.730433 
-L 104.368335 312.247832 
-L 103.938369 312.759642 
-L 103.508404 313.265984 
-L 103.078439 313.766972 
-L 102.648474 314.26272 
-L 102.218509 314.753335 
-L 101.788543 315.238923 
-L 101.358578 315.719585 
-L 100.928613 316.195421 
-L 100.498648 316.666527 
-L 100.068683 317.132995 
-L 99.638717 317.594916 
-L 99.208752 318.052378 
-L 98.778787 318.505466 
-L 98.348822 318.954264 
-" clip-path="url(#p3b7b607bad)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 118.987151 290.062143 
+L 118.557186 290.881912 
+L 118.127221 291.68774 
+L 117.697256 292.480095 
+L 117.267291 293.259418 
+L 116.837325 294.026133 
+L 116.40736 294.780639 
+L 115.977395 295.523321 
+L 115.54743 296.254543 
+L 115.117465 296.974653 
+L 114.687499 297.683984 
+L 114.257534 298.382854 
+L 113.827569 299.071567 
+L 113.397604 299.750414 
+L 112.967639 300.419674 
+L 112.537673 301.079613 
+L 112.107708 301.730488 
+L 111.677743 302.372545 
+L 111.247778 303.006018 
+L 110.817813 303.631135 
+L 110.387847 304.248113 
+L 109.957882 304.857162 
+L 109.527917 305.458482 
+L 109.097952 306.052268 
+L 108.667987 306.638705 
+L 108.238021 307.217974 
+L 107.808056 307.790247 
+L 107.378091 308.355692 
+L 106.948126 308.91447 
+L 106.518161 309.466735 
+L 106.088195 310.012639 
+L 105.65823 310.552325 
+L 105.228265 311.085934 
+L 104.7983 311.613602 
+L 104.368335 312.135459 
+L 103.938369 312.651631 
+L 103.508404 313.162242 
+L 103.078439 313.667409 
+L 102.648474 314.167248 
+L 102.218509 314.66187 
+L 101.788543 315.151383 
+L 101.358578 315.635891 
+L 100.928613 316.115495 
+L 100.498648 316.590294 
+L 100.068683 317.060383 
+L 99.638717 317.525854 
+L 99.208752 317.986798 
+L 98.778787 318.443302 
+L 98.348822 318.895449 
+" clip-path="url(#pbd2445a49c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.775937 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6291,34 +6291,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6378,31 +6373,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6443,14 +6413,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6489,109 +6459,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3b7b607bad">
+  <clipPath id="pbd2445a49c">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pcf9178e861)">
+   <g clip-path="url(#p8ace74368b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image5803a62010" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image6209b0b35a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md729ad210e" d="M 0 0 
+       <path id="mc5f534246c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md729ad210e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md729ad210e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md729ad210e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md729ad210e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md729ad210e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md729ad210e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md729ad210e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md729ad210e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md729ad210e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md729ad210e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md729ad210e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc5f534246c" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mda94dd544c" d="M 0 0 
+       <path id="m2ea6e44432" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mda94dd544c" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ea6e44432" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8093874de4" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec426961807" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m673b099688" d="M 0 0 
+       <path id="m880ec00649" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m673b099688" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m880ec00649" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.775937 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,14 +2953,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pcf9178e861">
+  <clipPath id="p8ace74368b">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb9b265a204)">
+   <g clip-path="url(#p7af755313f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image833819d187" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+0lEQVR4nO3YsaplZx2H4b1nzjmcSXBAmcSQUmIhSLBI4zSpcyfp7CwlfUqvIfEGAkFCbESx0UIsBLUTCUMyiZOZcM6Zfdb2Ekbhk3/Y7/NcwW/BWt96+fbblx8cd6fm6efTC5Y6fnFaz7Pb7Xb//PlH0xOW+sefn01PWO7tD9+ZnrDc/idvTU9Ya39nesF6Tz6bXrDe5f3pBUv96vvvT09Y7gS/JACA/54YAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI218fPj5Oj1jtuNumJyy1P8FmPb9zMT1hqZvtanrCcud/+cP0hOUOP344PWGpw3YzPWG5Z4cn0xOWe3Bix8Pz+w+mJyx3en9ZAID/gRgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7O3/21fSG9a6/mV6w1nGbXrDevfvTC5a6mB7wf3B88mx6wnLnXz+enrDU+XaYnrDcvVM8766eTi9Y6vzs9E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud37nYnrCUrfHw/SE5e4+fTw9Yb3vvDq9YKnn2830hOW+uPrX9ITlXrs+m56w1Pbd16cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO/vjo99Nb1juzm4/PWGpV156MD1hudvtMD1hqYu7l9MTlnv3N7+dnrDcez/94fSEpQ7HbXrCcr/4/d+mJyz38PWXpycs9e6bD6cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn757e/Pk6PWO3m9mp6wlL39pfTE3iBm/1hesJy/77+fHrCct+7fG16wlLbcZuesNxX14+mJyz3+Pqz6QlL/eD+m9MTlnMzBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLT9tn16nB4BfAsdbqYXrHd2Mb2AF7i6/WZ6wnKXd1+ansALuBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tnuuE1vWG+v8b71DjfTC5bazs6mJyz3px/9bHrCcm/99ZfTE9a6e3rv3e3xMD1hvUd/n16w1qtvTC9YTjUAAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7T9w24kn6oVK9AAAAABJRU5ErkJggg==" id="imageedeff1431a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m49c6fcdf4a" d="M 0 0 
+       <path id="m9dd5d6d7d6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m49c6fcdf4a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9dd5d6d7d6" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m6906ffe2ca" d="M 0 0 
+       <path id="md4e4fd9c2e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m6906ffe2ca" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1389,10 +1389,10 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -2 -->
+    <!-- -1 -->
     <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image3851066319" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image9bc6f4c546" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mb52d7aa687" d="M 0 0 
+       <path id="m5c4ea6dab1" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb52d7aa687" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.844609 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(20.059766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2951,16 +2951,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb9b265a204">
+  <clipPath id="p7af755313f">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.848125pt" height="386.202469pt" viewBox="0 0 568.848125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.848125 386.202469 
-L 568.848125 0 
+L 568.591094 386.202469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.549062 104.1264 
-L 291.174062 104.1264 
-L 291.174062 74.7432 
-L 186.549062 74.7432 
+    <path d="M 186.420547 104.1264 
+L 291.045547 104.1264 
+L 291.045547 74.7432 
+L 186.420547 74.7432 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.174062 104.1264 
-L 395.799062 104.1264 
-L 395.799062 74.7432 
-L 291.174062 74.7432 
+    <path d="M 291.045547 104.1264 
+L 395.670547 104.1264 
+L 395.670547 74.7432 
+L 291.045547 74.7432 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.799062 104.1264 
-L 500.424062 104.1264 
-L 500.424062 74.7432 
-L 395.799062 74.7432 
+    <path d="M 395.670547 104.1264 
+L 500.295547 104.1264 
+L 500.295547 74.7432 
+L 395.670547 74.7432 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.549062 133.5096 
-L 291.174062 133.5096 
-L 291.174062 104.1264 
-L 186.549062 104.1264 
+    <path d="M 186.420547 133.5096 
+L 291.045547 133.5096 
+L 291.045547 104.1264 
+L 186.420547 104.1264 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.174062 133.5096 
-L 395.799062 133.5096 
-L 395.799062 104.1264 
-L 291.174062 104.1264 
+    <path d="M 291.045547 133.5096 
+L 395.670547 133.5096 
+L 395.670547 104.1264 
+L 291.045547 104.1264 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.799062 133.5096 
-L 500.424062 133.5096 
-L 500.424062 104.1264 
-L 395.799062 104.1264 
+    <path d="M 395.670547 133.5096 
+L 500.295547 133.5096 
+L 500.295547 104.1264 
+L 395.670547 104.1264 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.549062 162.8928 
-L 291.174062 162.8928 
-L 291.174062 133.5096 
-L 186.549062 133.5096 
+    <path d="M 186.420547 162.8928 
+L 291.045547 162.8928 
+L 291.045547 133.5096 
+L 186.420547 133.5096 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.174062 162.8928 
-L 395.799062 162.8928 
-L 395.799062 133.5096 
-L 291.174062 133.5096 
+    <path d="M 291.045547 162.8928 
+L 395.670547 162.8928 
+L 395.670547 133.5096 
+L 291.045547 133.5096 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.799062 162.8928 
-L 500.424062 162.8928 
-L 500.424062 133.5096 
-L 395.799062 133.5096 
+    <path d="M 395.670547 162.8928 
+L 500.295547 162.8928 
+L 500.295547 133.5096 
+L 395.670547 133.5096 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.549062 192.276 
-L 291.174062 192.276 
-L 291.174062 162.8928 
-L 186.549062 162.8928 
+    <path d="M 186.420547 192.276 
+L 291.045547 192.276 
+L 291.045547 162.8928 
+L 186.420547 162.8928 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.174062 192.276 
-L 395.799062 192.276 
-L 395.799062 162.8928 
-L 291.174062 162.8928 
+    <path d="M 291.045547 192.276 
+L 395.670547 192.276 
+L 395.670547 162.8928 
+L 291.045547 162.8928 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.799062 192.276 
-L 500.424062 192.276 
-L 500.424062 162.8928 
-L 395.799062 162.8928 
+    <path d="M 395.670547 192.276 
+L 500.295547 192.276 
+L 500.295547 162.8928 
+L 395.670547 162.8928 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.549062 221.6592 
-L 291.174062 221.6592 
-L 291.174062 192.276 
-L 186.549062 192.276 
+    <path d="M 186.420547 221.6592 
+L 291.045547 221.6592 
+L 291.045547 192.276 
+L 186.420547 192.276 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.174062 221.6592 
-L 395.799062 221.6592 
-L 395.799062 192.276 
-L 291.174062 192.276 
+    <path d="M 291.045547 221.6592 
+L 395.670547 221.6592 
+L 395.670547 192.276 
+L 291.045547 192.276 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.799062 221.6592 
-L 500.424062 221.6592 
-L 500.424062 192.276 
-L 395.799062 192.276 
+    <path d="M 395.670547 221.6592 
+L 500.295547 221.6592 
+L 500.295547 192.276 
+L 395.670547 192.276 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.549062 251.0424 
-L 291.174062 251.0424 
-L 291.174062 221.6592 
-L 186.549062 221.6592 
+    <path d="M 186.420547 251.0424 
+L 291.045547 251.0424 
+L 291.045547 221.6592 
+L 186.420547 221.6592 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.174062 251.0424 
-L 395.799062 251.0424 
-L 395.799062 221.6592 
-L 291.174062 221.6592 
+    <path d="M 291.045547 251.0424 
+L 395.670547 251.0424 
+L 395.670547 221.6592 
+L 291.045547 221.6592 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.799062 251.0424 
-L 500.424062 251.0424 
-L 500.424062 221.6592 
-L 395.799062 221.6592 
+    <path d="M 395.670547 251.0424 
+L 500.295547 251.0424 
+L 500.295547 221.6592 
+L 395.670547 221.6592 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.549062 280.4256 
-L 291.174062 280.4256 
-L 291.174062 251.0424 
-L 186.549062 251.0424 
+    <path d="M 186.420547 280.4256 
+L 291.045547 280.4256 
+L 291.045547 251.0424 
+L 186.420547 251.0424 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.174062 280.4256 
-L 395.799062 280.4256 
-L 395.799062 251.0424 
-L 291.174062 251.0424 
+    <path d="M 291.045547 280.4256 
+L 395.670547 280.4256 
+L 395.670547 251.0424 
+L 291.045547 251.0424 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.799062 280.4256 
-L 500.424062 280.4256 
-L 500.424062 251.0424 
-L 395.799062 251.0424 
+    <path d="M 395.670547 280.4256 
+L 500.295547 280.4256 
+L 500.295547 251.0424 
+L 395.670547 251.0424 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.549062 309.8088 
-L 291.174062 309.8088 
-L 291.174062 280.4256 
-L 186.549062 280.4256 
+    <path d="M 186.420547 309.8088 
+L 291.045547 309.8088 
+L 291.045547 280.4256 
+L 186.420547 280.4256 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.174062 309.8088 
-L 395.799062 309.8088 
-L 395.799062 280.4256 
-L 291.174062 280.4256 
+    <path d="M 291.045547 309.8088 
+L 395.670547 309.8088 
+L 395.670547 280.4256 
+L 291.045547 280.4256 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.799062 309.8088 
-L 500.424062 309.8088 
-L 500.424062 280.4256 
-L 395.799062 280.4256 
+    <path d="M 395.670547 309.8088 
+L 500.295547 309.8088 
+L 500.295547 280.4256 
+L 395.670547 280.4256 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.549062 339.192 
-L 291.174062 339.192 
-L 291.174062 309.8088 
-L 186.549062 309.8088 
+    <path d="M 186.420547 339.192 
+L 291.045547 339.192 
+L 291.045547 309.8088 
+L 186.420547 309.8088 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.174062 339.192 
-L 395.799062 339.192 
-L 395.799062 309.8088 
-L 291.174062 309.8088 
+    <path d="M 291.045547 339.192 
+L 395.670547 339.192 
+L 395.670547 309.8088 
+L 291.045547 309.8088 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.799062 339.192 
-L 500.424062 339.192 
-L 500.424062 309.8088 
-L 395.799062 309.8088 
+    <path d="M 395.670547 339.192 
+L 500.295547 339.192 
+L 500.295547 309.8088 
+L 395.670547 309.8088 
 z
-" clip-path="url(#p90644f9fd0)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pcbdff3ccff)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.536328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.820547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.392656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.744375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.474062 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.410313 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.851562 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.476562 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.112187 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.410313 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.396563 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.476562 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.375312 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.410313 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.396563 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.476562 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.681562 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.553047 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.410313 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.396563 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.476562 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.837812 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.410313 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.396563 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.476562 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.183437 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.209688 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.081172 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 25 -->
-    <g transform="translate(337.920312 238.5583) scale(0.08 -0.08)">
+    <!-- 26 -->
+    <g transform="translate(337.791797 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,59 +1724,84 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 207 -->
-    <g transform="translate(439.762187 238.5583) scale(0.08 -0.08)">
+    <!-- 209 -->
+    <g transform="translate(439.633672 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.298437 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1905,7 +1930,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.410313 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1915,14 +1940,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.396563 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.476562 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1930,7 +1955,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.805312 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1986,7 +2011,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.410313 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1996,21 +2021,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.396563 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.021563 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.893047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.519687 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2021,7 +2046,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.410313 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2031,13 +2056,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.941562 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.111562 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2053,7 +2078,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.932812 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.804297 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2192,36 +2217,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2266,7 +2261,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2407,14 +2402,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2453,110 +2448,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p90644f9fd0">
-   <rect x="81.924063" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pcbdff3ccff">
+   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.710781pt" height="386.202469pt" viewBox="0 0 570.710781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.280469pt" height="386.202469pt" viewBox="0 0 568.280469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.710781 386.202469 
-L 570.710781 0 
+L 568.280469 386.202469 
+L 568.280469 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.480391 104.1264 
-L 292.105391 104.1264 
-L 292.105391 74.7432 
-L 187.480391 74.7432 
+    <path d="M 186.265234 104.1264 
+L 290.890234 104.1264 
+L 290.890234 74.7432 
+L 186.265234 74.7432 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.105391 104.1264 
-L 396.730391 104.1264 
-L 396.730391 74.7432 
-L 292.105391 74.7432 
+    <path d="M 290.890234 104.1264 
+L 395.515234 104.1264 
+L 395.515234 74.7432 
+L 290.890234 74.7432 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.730391 104.1264 
-L 501.355391 104.1264 
-L 501.355391 74.7432 
-L 396.730391 74.7432 
+    <path d="M 395.515234 104.1264 
+L 500.140234 104.1264 
+L 500.140234 74.7432 
+L 395.515234 74.7432 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.480391 133.5096 
-L 292.105391 133.5096 
-L 292.105391 104.1264 
-L 187.480391 104.1264 
+    <path d="M 186.265234 133.5096 
+L 290.890234 133.5096 
+L 290.890234 104.1264 
+L 186.265234 104.1264 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.105391 133.5096 
-L 396.730391 133.5096 
-L 396.730391 104.1264 
-L 292.105391 104.1264 
+    <path d="M 290.890234 133.5096 
+L 395.515234 133.5096 
+L 395.515234 104.1264 
+L 290.890234 104.1264 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.730391 133.5096 
-L 501.355391 133.5096 
-L 501.355391 104.1264 
-L 396.730391 104.1264 
+    <path d="M 395.515234 133.5096 
+L 500.140234 133.5096 
+L 500.140234 104.1264 
+L 395.515234 104.1264 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.480391 162.8928 
-L 292.105391 162.8928 
-L 292.105391 133.5096 
-L 187.480391 133.5096 
+    <path d="M 186.265234 162.8928 
+L 290.890234 162.8928 
+L 290.890234 133.5096 
+L 186.265234 133.5096 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.105391 162.8928 
-L 396.730391 162.8928 
-L 396.730391 133.5096 
-L 292.105391 133.5096 
+    <path d="M 290.890234 162.8928 
+L 395.515234 162.8928 
+L 395.515234 133.5096 
+L 290.890234 133.5096 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.730391 162.8928 
-L 501.355391 162.8928 
-L 501.355391 133.5096 
-L 396.730391 133.5096 
+    <path d="M 395.515234 162.8928 
+L 500.140234 162.8928 
+L 500.140234 133.5096 
+L 395.515234 133.5096 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.480391 192.276 
-L 292.105391 192.276 
-L 292.105391 162.8928 
-L 187.480391 162.8928 
+    <path d="M 186.265234 192.276 
+L 290.890234 192.276 
+L 290.890234 162.8928 
+L 186.265234 162.8928 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.105391 192.276 
-L 396.730391 192.276 
-L 396.730391 162.8928 
-L 292.105391 162.8928 
+    <path d="M 290.890234 192.276 
+L 395.515234 192.276 
+L 395.515234 162.8928 
+L 290.890234 162.8928 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.730391 192.276 
-L 501.355391 192.276 
-L 501.355391 162.8928 
-L 396.730391 162.8928 
+    <path d="M 395.515234 192.276 
+L 500.140234 192.276 
+L 500.140234 162.8928 
+L 395.515234 162.8928 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.480391 221.6592 
-L 292.105391 221.6592 
-L 292.105391 192.276 
-L 187.480391 192.276 
+    <path d="M 186.265234 221.6592 
+L 290.890234 221.6592 
+L 290.890234 192.276 
+L 186.265234 192.276 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.105391 221.6592 
-L 396.730391 221.6592 
-L 396.730391 192.276 
-L 292.105391 192.276 
+    <path d="M 290.890234 221.6592 
+L 395.515234 221.6592 
+L 395.515234 192.276 
+L 290.890234 192.276 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.730391 221.6592 
-L 501.355391 221.6592 
-L 501.355391 192.276 
-L 396.730391 192.276 
+    <path d="M 395.515234 221.6592 
+L 500.140234 221.6592 
+L 500.140234 192.276 
+L 395.515234 192.276 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.480391 251.0424 
-L 292.105391 251.0424 
-L 292.105391 221.6592 
-L 187.480391 221.6592 
+    <path d="M 186.265234 251.0424 
+L 290.890234 251.0424 
+L 290.890234 221.6592 
+L 186.265234 221.6592 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.105391 251.0424 
-L 396.730391 251.0424 
-L 396.730391 221.6592 
-L 292.105391 221.6592 
+    <path d="M 290.890234 251.0424 
+L 395.515234 251.0424 
+L 395.515234 221.6592 
+L 290.890234 221.6592 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.730391 251.0424 
-L 501.355391 251.0424 
-L 501.355391 221.6592 
-L 396.730391 221.6592 
+    <path d="M 395.515234 251.0424 
+L 500.140234 251.0424 
+L 500.140234 221.6592 
+L 395.515234 221.6592 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.480391 280.4256 
-L 292.105391 280.4256 
-L 292.105391 251.0424 
-L 187.480391 251.0424 
+    <path d="M 186.265234 280.4256 
+L 290.890234 280.4256 
+L 290.890234 251.0424 
+L 186.265234 251.0424 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.105391 280.4256 
-L 396.730391 280.4256 
-L 396.730391 251.0424 
-L 292.105391 251.0424 
+    <path d="M 290.890234 280.4256 
+L 395.515234 280.4256 
+L 395.515234 251.0424 
+L 290.890234 251.0424 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.730391 280.4256 
-L 501.355391 280.4256 
-L 501.355391 251.0424 
-L 396.730391 251.0424 
+    <path d="M 395.515234 280.4256 
+L 500.140234 280.4256 
+L 500.140234 251.0424 
+L 395.515234 251.0424 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.480391 309.8088 
-L 292.105391 309.8088 
-L 292.105391 280.4256 
-L 187.480391 280.4256 
+    <path d="M 186.265234 309.8088 
+L 290.890234 309.8088 
+L 290.890234 280.4256 
+L 186.265234 280.4256 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.105391 309.8088 
-L 396.730391 309.8088 
-L 396.730391 280.4256 
-L 292.105391 280.4256 
+    <path d="M 290.890234 309.8088 
+L 395.515234 309.8088 
+L 395.515234 280.4256 
+L 290.890234 280.4256 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.730391 309.8088 
-L 501.355391 309.8088 
-L 501.355391 280.4256 
-L 396.730391 280.4256 
+    <path d="M 395.515234 309.8088 
+L 500.140234 309.8088 
+L 500.140234 280.4256 
+L 395.515234 280.4256 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.480391 339.192 
-L 292.105391 339.192 
-L 292.105391 309.8088 
-L 187.480391 309.8088 
+    <path d="M 186.265234 339.192 
+L 290.890234 339.192 
+L 290.890234 309.8088 
+L 186.265234 309.8088 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.105391 339.192 
-L 396.730391 339.192 
-L 396.730391 309.8088 
-L 292.105391 309.8088 
+    <path d="M 290.890234 339.192 
+L 395.515234 339.192 
+L 395.515234 309.8088 
+L 290.890234 309.8088 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.730391 339.192 
-L 501.355391 339.192 
-L 501.355391 309.8088 
-L 396.730391 309.8088 
+    <path d="M 395.515234 339.192 
+L 500.140234 339.192 
+L 500.140234 309.8088 
+L 395.515234 309.8088 
 z
-" clip-path="url(#pf05d7a535d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9cd57fcbb3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.467656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.2525 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.751875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.536719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.323984 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.108828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.675703 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.460547 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.405391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.190234 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.341641 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.782891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.567734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.407891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.043516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.828359 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.341641 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.327891 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.407891 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.306641 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.091484 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.341641 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.327891 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.407891 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.612891 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.397734 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.341641 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.327891 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.407891 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.769141 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.553984 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.341641 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.327891 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.407891 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.114766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.899609 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(227.141016 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(225.925859 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 25 -->
-    <g transform="translate(338.851641 238.5583) scale(0.08 -0.08)">
+    <!-- 26 -->
+    <g transform="translate(337.636484 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,54 +1724,45 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 138 -->
-    <g transform="translate(440.693516 238.5583) scale(0.08 -0.08)">
+    <!-- 208 -->
+    <g transform="translate(439.478359 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1812,14 +1803,14 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.229766 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.014609 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1948,7 +1939,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.341641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1958,14 +1949,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.327891 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.407891 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1973,7 +1964,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.736641 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.521484 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2029,7 +2020,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.341641 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2039,21 +2030,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.327891 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.952891 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.737734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.451016 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.235859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2064,7 +2055,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.341641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2074,13 +2065,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.872891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.657734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.042891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.827734 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2096,7 +2087,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.864141 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.648984 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2235,36 +2226,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2309,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2448,16 +2409,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2496,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf05d7a535d">
-   <rect x="82.855391" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p9cd57fcbb3">
+   <rect x="81.640234" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p73048467a7)">
+   <g clip-path="url(#pf07b6e874b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6klEQVR4nO3YvY5VVQCG4TkzhwEHUBSEqAmxUStNiFY23oGFl2Fpa29pbWvvDVhprEyM0Q47CVooRCM/kmHOcMYrsCLrXcPO81zBN9ln7fXuWW3/+vJkZ8k2h7MX8DS2x7MXjLXanb1grOOj2QvGOrg0e8FYjx/OXjDW3v7sBTyNpf8+9w9mLxhq4bcfAACnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1/nFza/aGoda7e7MnDLU9OZk9YairF6/OnjDUrfu/zZ4w1sI/cd88d2n2hKE2Z/dnTxjqpzs3Z08Y6p0rb8yeMNTj/e3sCUOtVo9mTxhq4dcDAACnjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK2vX3x99oahLp29OnvCUHcPf589YahXHy37G+nC5bdnTxhqb7WePWGo7c529oShXt65MnvCUMdXjmZPGOrawfXZE4babJf9/M4fLfv9suzbHQCAU0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQWq9Wy27QB5u/Z08Y6rm9C7MnDPXk8kuzJwz1x72fZ08Y6uHR4ewJQ7374nuzJwx1tDd7wVj/bh7MnsBT+OfxndkTxjp7dfaCoZZdnwAAnDoCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1OrJd5+czB4x1HY7ewH8v13fgM8075dn29LP39J/n57fM23hTw8AgNNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFpf++GX2RuG2l0vu7Hv3Lw7e8JQX3x8Y/aEoT77/s/ZE4b64PoLsycM9dW3v86eMNSnH701e8JQn39ze/aEoT688crsCUPdvvd49oSh3n/t/OwJQy27zgAAOHUEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqtXny9cnsESPtHR/PnjDW7nr2grGOD2cvGGv/YPaCsVYL/8Y92c5eMNbG+XumPVn2/bdZLfv8nVl4vyz8dgAA4LQRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNbbk+3sDUPtnTk3e8JQ251lP7/dB/dnTxjq6Mx69oSh9lfLPn87x0ezF4y1OZy9YKj7q2X/fc/vHMyeMNSZ3WW/P5d+/vwHFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACD1H9lrfbegjrEtAAAAAElFTkSuQmCC" id="imagee847e27e8e" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7klEQVR4nO3Yv46cZx2GYc/OeA2bRBjHOAIkiwaoQIpCRcMZUHAYlLT0lNS09JwAFYgKCSHoQkcUUgRHRAkxxruzO8sRUFnv/Vt/uq4jeEbfn/f+Znf6169v723Z8eX0Al7F6Xp6wVq7s+kFa11fTS9Y6+Lh9IK1Lp9PL1hrfz69gFex9fvz/GJ6wVIbP/0AALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDn48fTG9Y6nC2n56w1On2dnrCUk/eejI9YakP/v2P6QlrbfwT9ztfejg9Yanjg/PpCUv95dn70xOW+v7jb09PWOry/DQ9Yand7sX0hKU2fjwAAHDXCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1OHpW9+a3rDUwwdPpics9cnLj6YnLPWNF9v+Rnrz7e9NT1hqvztMT1jqdO80PWGpr917PD1hqevHV9MTlnrn4un0hKWOp21fvzeutv1+2fbpDgDAnSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIHXa7bTfoF8dPpycs9eX9m9MTlrp5+9H0hKU+/vyv0xOWen71cnrCUu999QfTE5a62k8vWOs/xy+mJ/AKPrt8Nj1hrQdPphcste36BADgzhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdjd/+Nnt9IilTqfpBfD/nfkGfK15v7zetv78bf3+dP1eaxu/egAA3DUCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1OGdP/1tesNSZ4dtN/az9z+ZnrDUr3767vSEpX7xx39OT1jqR0+/Mj1hqd/8/u/TE5b6+U++Oz1hqV/+7sPpCUv9+N2vT09Y6sPPL6cnLPXDb74xPWGpbdcZAAB3jgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2ON7+9nR6x0v76enrCWmeH6QVrXb+cXrDW+cX0grV2G//GvT1NL1jr6Pl7rd1s+/w77rb9/N3feL9s/HQAAOCuEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQOx9PV9Ial9vcvpicstfXrd//l8+kJS/13P71grQeHbT9/ZzfX0xPW2vjv+/Ty4+kJSz3aP5qesNT9/fn0hLWuX0wvWMo/oAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/wHycn+vLuOlTwAAAABJRU5ErkJggg==" id="imagec82a54009a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0f861f2c05" d="M 0 0 
+       <path id="mf6afec97ac" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0f861f2c05" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0f861f2c05" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0f861f2c05" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0f861f2c05" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0f861f2c05" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0f861f2c05" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0f861f2c05" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0f861f2c05" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0f861f2c05" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0f861f2c05" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0f861f2c05" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0f861f2c05" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6afec97ac" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mb097deb774" d="M 0 0 
+       <path id="m102865455f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb097deb774" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m102865455f" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,8 +1138,8 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +9 -->
-    <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
+    <!-- +14 -->
+    <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1156,6 +1156,82 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- +2 -->
+    <g transform="translate(151.301137 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +9 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1191,72 +1267,8 @@ z
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -0 -->
-    <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +5 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
    <g id="text_24">
-    <!-- -32 -->
+    <!-- -30 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1291,102 +1303,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +11 -->
+    <!-- +16 -->
     <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -0 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -22 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +23 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -12 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -6 -->
-    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1419,16 +1365,61 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +3 -->
+    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -9 -->
+    <g transform="translate(354.238989 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -19 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +29 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -9 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- +2 -->
+    <g transform="translate(513.797724 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -22 -->
+    <!-- -20 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1456,6 +1447,33 @@ z
    <g id="text_36">
     <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -1811,27 +1829,6 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2192,18 +2189,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image6e782a4bf2" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image5f4742e7ef" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m740fdfa940" d="M 0 0 
+       <path id="m3662bd515e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2223,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2237,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2251,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2264,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2277,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2290,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m740fdfa940" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3662bd515e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2906,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.775937 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,14 +2998,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3047,109 +3044,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p73048467a7">
+  <clipPath id="pf07b6e874b">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pfc103d0df5)">
+   <g clip-path="url(#p40a50ea330)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9ElEQVR4nO3YsY5cZx2H4Z3d8Ro7DjGJcQRIFg1QgRRBlSZ3QMFlUNLSU1LT0nMDVCAqJISgCx1RQgGOQDhxnPXO7ixXQGV973999DxX8JPO+eZ7z+yO//71zcmWHS6mF/AqjlfTC9banU4vWOvqcnrBWvcfTi9Y6+Xz6QVrnZ1PL+BVbP39PL8/vWCpjd9+AADcNgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/s+Hj6Y3LLU/PZuesNTx5mZ6wlKP33w8PWGpjz77ZHrCWhv/xP3uVx5OT1jqcPd8esJSf3n64fSEpX7w6DvTE5Z6eX6cnrDUbvdiesJSG78eAAC4bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr/5M1vT29Y6uHdx9MTlvr04h/TE5b65ottfyM9eOf70xOWOtvtpycsdTw5Tk9Y6usnj6YnLHX16HJ6wlLv3n8yPWGpw3Hbz++Ny23/vmz7dgcA4NYRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPa73bYb9PPDf6YnLHXv7MH0hKWu33l7esJS/3z21+kJSz2/vJiesNQPv/aj6QlLXZ5NL1jri8Pn0xN4Bf99+XR6wlp3H08vWGrb9QkAwK0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2u//Czm+kRSx2P0wvg/zv1Dfha8/vyetv6+dv6++n5vdY2/vQAALhtBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9u3/62/SGpU73227spx9+Oj1hqV/99L3pCUv94o//mp6w1AdP3pqesNRvfv/36QlL/fwn35uesNQvf/fx9ISlfvzeN6YnLPXxs5fTE5Z6/1tvTE9Yatt1BgDArSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7w/Vvb6ZHrHR2dTU9Ya3T/fSCta4uphesdX5/esFau41/494cpxesdXD+XmvX277/Drttn787G++Xjd8OAADcNgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/vL6YnrDUvfuPJiesNT1zdX0hKXOvvxsesJSX55NL1jr3n7b5+/ketvn7+TqcnrBUs9OXkxPWOqt069OT1jqzul+esJah+fTC5byDygAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBA6n8u8368afVbQwAAAABJRU5ErkJggg==" id="imageda370cb140" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3Yv46cZx2GYc/OeI0dRzjEOAIkiwaoQIqgouEMKDgMSlp6Smpaek6ACkSFhBB0oSMKKcARf0Ica3dnd5YjoLLe+7f+dF1H8Iy+eee9v9md/vnL23tbdryYXsDrOF1PL1hrdza9YK3rq+kFaz16Mr1grcuX0wvW2p9PL+B1bP37ef5oesFSG7/9AAC4awQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpwx+PH05vWOpwtp+esNTp9nZ6wlLP3n42PWGpD//7t+kJa238FfebX3gyPWGp44Pz6QlL/enFB9MTlvrO029MT1jq8vw0PWGp3e7V9ISlNn49AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTh+dtfn96w1JMHz6YnLPXJxcfTE5b66qttvyM9fvfb0xOW2u8O0xOWOt07TU9Y6sv3nk5PWOr66dX0hKXee/R8esJSx9O2n99bV9v+fdn27Q4AwJ0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB12u2036GfHf01PWOrh/vH0hKVu3v3S9ISl/v7pn6cnLPXy6mJ6wlLffed70xOWutpPL1jr8+Nn0xN4Df+5fDE9Ya0Hz6YXLLXt+gQA4M4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHY3v/vJ7fSIpU6n6QXw/515B3yj+X15s239/G39++n5vdE2/vQAALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDe3/4y/SGpc4O227sFx98Mj1hqV/8+P3pCUv97Pf/mJ6w1A+ef3F6wlK/+u1fpycs9dMffWt6wlI//81H0xOW+uH7X5mesNRHn15OT1jq+197a3rCUtuuMwAA7hwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaHW9+fTs9YqX99fX0hLXODtML1rq+mF6w1vmj6QVr7Tb+jnt7ml6w1tH5e6PdbPv+O+62ff7ub7xfNn47AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh4ubV9Mblnp4//H0hKVuTtfTE5a6f/FyesJSn+9P0xOWenjY9vk7u9n2+bu38c/378sX0xOWemf/ZHrCUvf359MT1rq5mF6wlH9AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A7yZgLa2ceZGAAAAAElFTkSuQmCC" id="imaged698f36fd6" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc7e7ed113c" d="M 0 0 
+       <path id="m6e348fb301" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc7e7ed113c" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc7e7ed113c" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e348fb301" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mee0427f564" d="M 0 0 
+       <path id="m2a645aad02" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mee0427f564" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2a645aad02" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +15 -->
+    <!-- +17 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1170,54 +1170,25 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- +1 -->
+    <!-- +3 -->
     <g transform="translate(151.301137 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +5 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -32 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1251,98 +1222,14 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +14 -->
-    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -0 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -8 -->
-    <g transform="translate(354.238989 69.553235) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- +8 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1384,56 +1271,130 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -30 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +17 -->
+    <g transform="translate(270.06552 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +5 -->
+    <g transform="translate(312.410731 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -8 -->
+    <g transform="translate(354.238989 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -20 -->
+    <!-- -18 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- +26 -->
+    <!-- +28 -->
     <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1476,23 +1437,55 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -4 -->
-    <g transform="translate(515.348583 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    <!-- +1 -->
+    <g transform="translate(513.797724 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -22 -->
+    <!-- -18 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +6 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1689,18 +1682,6 @@ z
    <g id="text_57">
     <!-- -97 -->
     <g transform="translate(110.506785 180.060583) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -1829,6 +1810,27 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2189,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef72a2da63b" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2552ce6f69" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma29543604c" d="M 0 0 
+       <path id="ma13c141384" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2223,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2237,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2251,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2264,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2277,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2290,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma29543604c" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma13c141384" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2906,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.844609 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.059766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2996,16 +2998,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3044,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfc103d0df5">
+  <clipPath id="p40a50ea330">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6031139fd1" d="M 0 0 
+       <path id="m5b513b6efd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6031139fd1" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6031139fd1" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6031139fd1" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6031139fd1" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6031139fd1" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6031139fd1" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6031139fd1" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b513b6efd" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdb50f0ea4a" d="M 0 0 
+       <path id="mf1dd8325d7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb50f0ea4a" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1dd8325d7" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdb50f0ea4a" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1dd8325d7" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdb50f0ea4a" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1dd8325d7" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mfb6d3d25d7" d="M 0 0 
+       <path id="mbef475ce14" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mfb6d3d25d7" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbef475ce14" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 135.288663) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 130.866393) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(100.319203 333.267132) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 333.5714) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m0a43d18606" d="M -2.5 2.5 
+     <path id="mc31b32c70f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#m0a43d18606" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a43d18606" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#mc31b32c70f" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc31b32c70f" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m6a6b9bdf21" d="M 0 -2.5 
+     <path id="m20e5a3a884" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#m6a6b9bdf21" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a6b9bdf21" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m20e5a3a884" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20e5a3a884" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m80da4c7c29" d="M -0 3.535534 
+     <path id="mec66f40677" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#m80da4c7c29" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m80da4c7c29" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#mec66f40677" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec66f40677" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="md06b759e8f" d="M -0 2.5 
+     <path id="m0371099678" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#md06b759e8f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m0371099678" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mb144d42348" d="M -0.833333 2.5 
+     <path id="m1a1cb11bce" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#mb144d42348" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb144d42348" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m1a1cb11bce" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1a1cb11bce" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mc5cfb06a3d" d="M -1.25 2.5 
+     <path id="m2b8c5c5b26" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#mc5cfb06a3d" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc5cfb06a3d" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m2b8c5c5b26" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2b8c5c5b26" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m0534aab66b" d="M 0 -2.5 
+     <path id="mcda5a313e1" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#m0534aab66b" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0534aab66b" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mcda5a313e1" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m72de3b1393" d="M 0 -2.5 
+     <path id="m3b162cb89b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#m72de3b1393" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m72de3b1393" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m3b162cb89b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b162cb89b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="md15745ea6e" d="M 0 3.5 
+      <path id="m533d69b66c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md15745ea6e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m533d69b66c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m0a43d18606" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc31b32c70f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m6a6b9bdf21" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m20e5a3a884" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m80da4c7c29" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mec66f40677" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#md06b759e8f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0371099678" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mb144d42348" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1a1cb11bce" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mc5cfb06a3d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2b8c5c5b26" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m0534aab66b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mcda5a313e1" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m72de3b1393" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3b162cb89b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p4e5194c456)">
-     <use xlink:href="#md15745ea6e" x="319.643112" y="140.288663" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="236.23654" y="154.18065" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="222.073314" y="158.804995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="202.315941" y="168.676543" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="199.905291" y="170.550904" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="195.893147" y="174.506217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="187.210062" y="188.464675" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="157.246106" y="245.048178" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="123.427553" y="301.716006" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md15745ea6e" x="95.319203" y="338.267132" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pbbbb7115c6)">
+     <use xlink:href="#m533d69b66c" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="210.483065" y="166.559544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="208.196568" y="168.292731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="197.379782" y="173.102943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="187.620351" y="187.562061" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="157.246106" y="244.18749" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="123.427553" y="301.770983" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m533d69b66c" x="95.319203" y="338.5714" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 140.288663 
-L 317.905475 140.617617 
-L 316.167838 140.944584 
-L 314.430201 141.269586 
-L 312.692564 141.592649 
-L 310.954927 141.913795 
-L 309.21729 142.233046 
-L 307.479654 142.550425 
-L 305.742017 142.865953 
-L 304.00438 143.179653 
-L 302.266743 143.491544 
-L 300.529106 143.801649 
-L 298.791469 144.109987 
-L 297.053832 144.416577 
-L 295.316195 144.721441 
-L 293.578558 145.024597 
-L 291.840921 145.326064 
-L 290.103284 145.625861 
-L 288.365648 145.924007 
-L 286.628011 146.220519 
-L 284.890374 146.515415 
-L 283.152737 146.808714 
-L 281.4151 147.100431 
-L 279.677463 147.390584 
-L 277.939826 147.67919 
-L 276.202189 147.966264 
-L 274.464552 148.251824 
-L 272.726915 148.535886 
-L 270.989278 148.818464 
-L 269.251642 149.099574 
-L 267.514005 149.379231 
-L 265.776368 149.657451 
-L 264.038731 149.934248 
-L 262.301094 150.209636 
-L 260.563457 150.48363 
-L 258.82582 150.756244 
-L 257.088183 151.027492 
-L 255.350546 151.297386 
-L 253.612909 151.565942 
-L 251.875272 151.833171 
-L 250.137636 152.099087 
-L 248.399999 152.363703 
-L 246.662362 152.627032 
-L 244.924725 152.889085 
-L 243.187088 153.149876 
-L 241.449451 153.409416 
-L 239.711814 153.667717 
-L 237.974177 153.924791 
-L 236.23654 154.18065 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 135.866393 
+L 318.590755 136.201744 
+L 317.538397 136.53503 
+L 316.48604 136.866276 
+L 315.433682 137.195506 
+L 314.381325 137.522746 
+L 313.328968 137.848019 
+L 312.27661 138.171349 
+L 311.224253 138.492758 
+L 310.171896 138.81227 
+L 309.119538 139.129906 
+L 308.067181 139.445689 
+L 307.014823 139.759641 
+L 305.962466 140.071781 
+L 304.910109 140.382131 
+L 303.857751 140.690712 
+L 302.805394 140.997543 
+L 301.753037 141.302645 
+L 300.700679 141.606036 
+L 299.648322 141.907735 
+L 298.595965 142.207762 
+L 297.543607 142.506135 
+L 296.49125 142.802872 
+L 295.438892 143.097991 
+L 294.386535 143.391509 
+L 293.334178 143.683444 
+L 292.28182 143.973812 
+L 291.229463 144.262631 
+L 290.177106 144.549916 
+L 289.124748 144.835685 
+L 288.072391 145.119952 
+L 287.020033 145.402735 
+L 285.967676 145.684047 
+L 284.915319 145.963904 
+L 283.862961 146.242322 
+L 282.810604 146.519315 
+L 281.758247 146.794897 
+L 280.705889 147.069083 
+L 279.653532 147.341887 
+L 278.601175 147.613323 
+L 277.548817 147.883404 
+L 276.49646 148.152143 
+L 275.444102 148.419555 
+L 274.391745 148.685652 
+L 273.339388 148.950447 
+L 272.28703 149.213953 
+L 271.234673 149.476182 
+L 270.182316 149.737147 
+L 269.129958 149.996859 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 236.23654 154.18065 
-L 235.941473 154.281133 
-L 235.646406 154.38143 
-L 235.351339 154.481541 
-L 235.056271 154.581467 
-L 234.761204 154.68121 
-L 234.466137 154.780769 
-L 234.17107 154.880144 
-L 233.876003 154.979338 
-L 233.580935 155.078351 
-L 233.285868 155.177182 
-L 232.990801 155.275834 
-L 232.695734 155.374305 
-L 232.400667 155.472598 
-L 232.105599 155.570713 
-L 231.810532 155.66865 
-L 231.515465 155.766411 
-L 231.220398 155.863995 
-L 230.92533 155.961403 
-L 230.630263 156.058637 
-L 230.335196 156.155696 
-L 230.040129 156.252581 
-L 229.745062 156.349293 
-L 229.449994 156.445833 
-L 229.154927 156.5422 
-L 228.85986 156.638397 
-L 228.564793 156.734423 
-L 228.269726 156.830278 
-L 227.974658 156.925964 
-L 227.679591 157.021482 
-L 227.384524 157.116831 
-L 227.089457 157.212012 
-L 226.794389 157.307026 
-L 226.499322 157.401874 
-L 226.204255 157.496555 
-L 225.909188 157.591072 
-L 225.614121 157.685423 
-L 225.319053 157.779611 
-L 225.023986 157.873635 
-L 224.728919 157.967495 
-L 224.433852 158.061193 
-L 224.138785 158.15473 
-L 223.843717 158.248104 
-L 223.54865 158.341318 
-L 223.253583 158.434372 
-L 222.958516 158.527266 
-L 222.663449 158.620001 
-L 222.368381 158.712577 
-L 222.073314 158.804995 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 149.996859 
+L 268.678353 150.098063 
+L 268.226747 150.199078 
+L 267.775142 150.299905 
+L 267.323537 150.400545 
+L 266.871931 150.500998 
+L 266.420326 150.601265 
+L 265.96872 150.701346 
+L 265.517115 150.801242 
+L 265.065509 150.900955 
+L 264.613904 151.000484 
+L 264.162299 151.09983 
+L 263.710693 151.198995 
+L 263.259088 151.297978 
+L 262.807482 151.39678 
+L 262.355877 151.495402 
+L 261.904271 151.593845 
+L 261.452666 151.692109 
+L 261.001061 151.790195 
+L 260.549455 151.888104 
+L 260.09785 151.985835 
+L 259.646244 152.083391 
+L 259.194639 152.180771 
+L 258.743034 152.277976 
+L 258.291428 152.375007 
+L 257.839823 152.471864 
+L 257.388217 152.568548 
+L 256.936612 152.66506 
+L 256.485006 152.7614 
+L 256.033401 152.857568 
+L 255.581796 152.953566 
+L 255.13019 153.049395 
+L 254.678585 153.145053 
+L 254.226979 153.240543 
+L 253.775374 153.335865 
+L 253.323769 153.431019 
+L 252.872163 153.526006 
+L 252.420558 153.620827 
+L 251.968952 153.715482 
+L 251.517347 153.809971 
+L 251.065741 153.904296 
+L 250.614136 153.998457 
+L 250.162531 154.092454 
+L 249.710925 154.186289 
+L 249.25932 154.279961 
+L 248.807714 154.373471 
+L 248.356109 154.466819 
+L 247.904503 154.560007 
+L 247.452898 154.653035 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 222.073314 158.804995 
-L 221.661702 159.030134 
-L 221.25009 159.254341 
-L 220.838478 159.477623 
-L 220.426866 159.699987 
-L 220.015254 159.921441 
-L 219.603642 160.141992 
-L 219.19203 160.361649 
-L 218.780418 160.580417 
-L 218.368807 160.798305 
-L 217.957195 161.015319 
-L 217.545583 161.231466 
-L 217.133971 161.446754 
-L 216.722359 161.661188 
-L 216.310747 161.874776 
-L 215.899135 162.087525 
-L 215.487523 162.29944 
-L 215.075911 162.510529 
-L 214.664299 162.720798 
-L 214.252687 162.930252 
-L 213.841075 163.1389 
-L 213.429463 163.346746 
-L 213.017851 163.553796 
-L 212.606239 163.760058 
-L 212.194627 163.965537 
-L 211.783015 164.170238 
-L 211.371403 164.374168 
-L 210.959791 164.577332 
-L 210.54818 164.779737 
-L 210.136568 164.981387 
-L 209.724956 165.182289 
-L 209.313344 165.382448 
-L 208.901732 165.581869 
-L 208.49012 165.780558 
-L 208.078508 165.97852 
-L 207.666896 166.175761 
-L 207.255284 166.372285 
-L 206.843672 166.568099 
-L 206.43206 166.763206 
-L 206.020448 166.957613 
-L 205.608836 167.151323 
-L 205.197224 167.344343 
-L 204.785612 167.536677 
-L 204.374 167.72833 
-L 203.962388 167.919306 
-L 203.550776 168.109611 
-L 203.139164 168.299249 
-L 202.727553 168.488225 
-L 202.315941 168.676543 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 154.653035 
+L 246.682693 154.929781 
+L 245.912488 155.20512 
+L 245.142283 155.479065 
+L 244.372079 155.751629 
+L 243.601874 156.022829 
+L 242.831669 156.292675 
+L 242.061464 156.561183 
+L 241.291259 156.828366 
+L 240.521054 157.094235 
+L 239.750849 157.358805 
+L 238.980645 157.622088 
+L 238.21044 157.884096 
+L 237.440235 158.144842 
+L 236.67003 158.404338 
+L 235.899825 158.662595 
+L 235.12962 158.919626 
+L 234.359415 159.175441 
+L 233.589211 159.430053 
+L 232.819006 159.683473 
+L 232.048801 159.935712 
+L 231.278596 160.186781 
+L 230.508391 160.43669 
+L 229.738186 160.68545 
+L 228.967981 160.933072 
+L 228.197777 161.179567 
+L 227.427572 161.424943 
+L 226.657367 161.669212 
+L 225.887162 161.912384 
+L 225.116957 162.154468 
+L 224.346752 162.395474 
+L 223.576547 162.635411 
+L 222.806343 162.874289 
+L 222.036138 163.112117 
+L 221.265933 163.348905 
+L 220.495728 163.584662 
+L 219.725523 163.819395 
+L 218.955318 164.053115 
+L 218.185113 164.28583 
+L 217.414909 164.517549 
+L 216.644704 164.748279 
+L 215.874499 164.978031 
+L 215.104294 165.20681 
+L 214.334089 165.434627 
+L 213.563884 165.661489 
+L 212.793679 165.887404 
+L 212.023475 166.112379 
+L 211.25327 166.336424 
+L 210.483065 166.559544 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 202.315941 168.676543 
-L 202.265719 168.716262 
-L 202.215497 168.755951 
-L 202.165275 168.795612 
-L 202.115053 168.835243 
-L 202.064831 168.874846 
-L 202.014609 168.914419 
-L 201.964388 168.953964 
-L 201.914166 168.99348 
-L 201.863944 169.032966 
-L 201.813722 169.072424 
-L 201.7635 169.111854 
-L 201.713278 169.151254 
-L 201.663056 169.190626 
-L 201.612834 169.22997 
-L 201.562613 169.269284 
-L 201.512391 169.308571 
-L 201.462169 169.347828 
-L 201.411947 169.387058 
-L 201.361725 169.426258 
-L 201.311503 169.465431 
-L 201.261281 169.504575 
-L 201.21106 169.543691 
-L 201.160838 169.582778 
-L 201.110616 169.621838 
-L 201.060394 169.660869 
-L 201.010172 169.699872 
-L 200.95995 169.738847 
-L 200.909728 169.777794 
-L 200.859507 169.816713 
-L 200.809285 169.855604 
-L 200.759063 169.894467 
-L 200.708841 169.933302 
-L 200.658619 169.972109 
-L 200.608397 170.010889 
-L 200.558175 170.04964 
-L 200.507953 170.088364 
-L 200.457732 170.127061 
-L 200.40751 170.165729 
-L 200.357288 170.20437 
-L 200.307066 170.242984 
-L 200.256844 170.28157 
-L 200.206622 170.320128 
-L 200.1564 170.358659 
-L 200.106179 170.397163 
-L 200.055957 170.435639 
-L 200.005735 170.474088 
-L 199.955513 170.512509 
-L 199.905291 170.550904 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 210.483065 166.559544 
+L 210.43543 166.596224 
+L 210.387794 166.632879 
+L 210.340159 166.66951 
+L 210.292523 166.706115 
+L 210.244888 166.742696 
+L 210.197253 166.779252 
+L 210.149617 166.815784 
+L 210.101982 166.852291 
+L 210.054347 166.888773 
+L 210.006711 166.925231 
+L 209.959076 166.961664 
+L 209.911441 166.998072 
+L 209.863805 167.034456 
+L 209.81617 167.070816 
+L 209.768535 167.107151 
+L 209.720899 167.143462 
+L 209.673264 167.179749 
+L 209.625628 167.216011 
+L 209.577993 167.252249 
+L 209.530358 167.288463 
+L 209.482722 167.324652 
+L 209.435087 167.360817 
+L 209.387452 167.396959 
+L 209.339816 167.433076 
+L 209.292181 167.469169 
+L 209.244546 167.505237 
+L 209.19691 167.541282 
+L 209.149275 167.577303 
+L 209.10164 167.6133 
+L 209.054004 167.649273 
+L 209.006369 167.685222 
+L 208.958734 167.721147 
+L 208.911098 167.757049 
+L 208.863463 167.792926 
+L 208.815827 167.82878 
+L 208.768192 167.86461 
+L 208.720557 167.900417 
+L 208.672921 167.936199 
+L 208.625286 167.971958 
+L 208.577651 168.007694 
+L 208.530015 168.043406 
+L 208.48238 168.079094 
+L 208.434745 168.114759 
+L 208.387109 168.1504 
+L 208.339474 168.186018 
+L 208.291839 168.221612 
+L 208.244203 168.257183 
+L 208.196568 168.292731 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 199.905291 170.550904 
-L 199.821705 170.636325 
-L 199.738118 170.721611 
-L 199.654532 170.806763 
-L 199.570946 170.891781 
-L 199.487359 170.976666 
-L 199.403773 171.061418 
-L 199.320187 171.146038 
-L 199.2366 171.230525 
-L 199.153014 171.314881 
-L 199.069428 171.399105 
-L 198.985841 171.483199 
-L 198.902255 171.567162 
-L 198.818669 171.650995 
-L 198.735082 171.734698 
-L 198.651496 171.818272 
-L 198.56791 171.901717 
-L 198.484323 171.985034 
-L 198.400737 172.068223 
-L 198.317151 172.151284 
-L 198.233564 172.234218 
-L 198.149978 172.317024 
-L 198.066392 172.399705 
-L 197.982805 172.482259 
-L 197.899219 172.564687 
-L 197.815633 172.64699 
-L 197.732046 172.729169 
-L 197.64846 172.811222 
-L 197.564874 172.893151 
-L 197.481287 172.974957 
-L 197.397701 173.056639 
-L 197.314115 173.138198 
-L 197.230528 173.219634 
-L 197.146942 173.300948 
-L 197.063356 173.382139 
-L 196.979769 173.46321 
-L 196.896183 173.544159 
-L 196.812597 173.624987 
-L 196.72901 173.705694 
-L 196.645424 173.786281 
-L 196.561838 173.866749 
-L 196.478251 173.947097 
-L 196.394665 174.027326 
-L 196.311079 174.107436 
-L 196.227492 174.187428 
-L 196.143906 174.267301 
-L 196.06032 174.347057 
-L 195.976733 174.426696 
-L 195.893147 174.506217 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 208.196568 168.292731 
+L 207.971218 168.397431 
+L 207.745868 168.501929 
+L 207.520519 168.606225 
+L 207.295169 168.710321 
+L 207.069819 168.814217 
+L 206.84447 168.917914 
+L 206.61912 169.021412 
+L 206.39377 169.124713 
+L 206.168421 169.227817 
+L 205.943071 169.330726 
+L 205.717721 169.433438 
+L 205.492371 169.535957 
+L 205.267022 169.638281 
+L 205.041672 169.740412 
+L 204.816322 169.842351 
+L 204.590973 169.944099 
+L 204.365623 170.045655 
+L 204.140273 170.147021 
+L 203.914924 170.248198 
+L 203.689574 170.349185 
+L 203.464224 170.449985 
+L 203.238874 170.550597 
+L 203.013525 170.651023 
+L 202.788175 170.751263 
+L 202.562825 170.851317 
+L 202.337476 170.951187 
+L 202.112126 171.050872 
+L 201.886776 171.150375 
+L 201.661427 171.249695 
+L 201.436077 171.348832 
+L 201.210727 171.447789 
+L 200.985377 171.546565 
+L 200.760028 171.645161 
+L 200.534678 171.743578 
+L 200.309328 171.841816 
+L 200.083979 171.939876 
+L 199.858629 172.037758 
+L 199.633279 172.135464 
+L 199.40793 172.232994 
+L 199.18258 172.330349 
+L 198.95723 172.427528 
+L 198.73188 172.524534 
+L 198.506531 172.621366 
+L 198.281181 172.718025 
+L 198.055831 172.814511 
+L 197.830482 172.910826 
+L 197.605132 173.00697 
+L 197.379782 173.102943 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 195.893147 174.506217 
-L 195.712249 174.836951 
-L 195.531352 175.165677 
-L 195.350454 175.492417 
-L 195.169557 175.817197 
-L 194.988659 176.140039 
-L 194.807761 176.460967 
-L 194.626864 176.780003 
-L 194.445966 177.097169 
-L 194.265069 177.412487 
-L 194.084171 177.725978 
-L 193.903273 178.037664 
-L 193.722376 178.347566 
-L 193.541478 178.655702 
-L 193.360581 178.962094 
-L 193.179683 179.266762 
-L 192.998785 179.569724 
-L 192.817888 179.870999 
-L 192.63699 180.170606 
-L 192.456093 180.468564 
-L 192.275195 180.76489 
-L 192.094297 181.059603 
-L 191.9134 181.352719 
-L 191.732502 181.644256 
-L 191.551605 181.934231 
-L 191.370707 182.222661 
-L 191.189809 182.509562 
-L 191.008912 182.79495 
-L 190.828014 183.07884 
-L 190.647117 183.36125 
-L 190.466219 183.642193 
-L 190.285321 183.921685 
-L 190.104424 184.199741 
-L 189.923526 184.476376 
-L 189.742629 184.751604 
-L 189.561731 185.02544 
-L 189.380833 185.297896 
-L 189.199936 185.568988 
-L 189.019038 185.838729 
-L 188.838141 186.107132 
-L 188.657243 186.374211 
-L 188.476345 186.639977 
-L 188.295448 186.904446 
-L 188.11455 187.167627 
-L 187.933653 187.429536 
-L 187.752755 187.690183 
-L 187.571857 187.94958 
-L 187.39096 188.20774 
-L 187.210062 188.464675 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 197.379782 173.102943 
+L 197.176461 173.447155 
+L 196.973139 173.789192 
+L 196.769818 174.12908 
+L 196.566496 174.466847 
+L 196.363175 174.802519 
+L 196.159853 175.136122 
+L 195.956532 175.467681 
+L 195.75321 175.797221 
+L 195.549889 176.124766 
+L 195.346567 176.450341 
+L 195.143246 176.773969 
+L 194.939924 177.095674 
+L 194.736603 177.415477 
+L 194.533281 177.733401 
+L 194.32996 178.049469 
+L 194.126638 178.363702 
+L 193.923317 178.67612 
+L 193.719995 178.986745 
+L 193.516674 179.295598 
+L 193.313353 179.602698 
+L 193.110031 179.908065 
+L 192.90671 180.211719 
+L 192.703388 180.513678 
+L 192.500067 180.813962 
+L 192.296745 181.112589 
+L 192.093424 181.409577 
+L 191.890102 181.704945 
+L 191.686781 181.998709 
+L 191.483459 182.290887 
+L 191.280138 182.581496 
+L 191.076816 182.870553 
+L 190.873495 183.158074 
+L 190.670173 183.444076 
+L 190.466852 183.728574 
+L 190.26353 184.011584 
+L 190.060209 184.293122 
+L 189.856887 184.573203 
+L 189.653566 184.851842 
+L 189.450244 185.129054 
+L 189.246923 185.404853 
+L 189.043601 185.679254 
+L 188.84028 185.95227 
+L 188.636958 186.223916 
+L 188.433637 186.494205 
+L 188.230315 186.763151 
+L 188.026994 187.030767 
+L 187.823672 187.297066 
+L 187.620351 187.562061 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 187.210062 188.464675 
-L 186.585813 190.505826 
-L 185.961564 192.472782 
-L 185.337315 194.370748 
-L 184.713066 196.204401 
-L 184.088817 197.977956 
-L 183.464568 199.695229 
-L 182.840319 201.359681 
-L 182.21607 202.974466 
-L 181.591821 204.542462 
-L 180.967571 206.066304 
-L 180.343322 207.548411 
-L 179.719073 208.991007 
-L 179.094824 210.396147 
-L 178.470575 211.765724 
-L 177.846326 213.101495 
-L 177.222077 214.405089 
-L 176.597828 215.678019 
-L 175.973579 216.921696 
-L 175.34933 218.137432 
-L 174.725081 219.326457 
-L 174.100832 220.489919 
-L 173.476582 221.628894 
-L 172.852333 222.744391 
-L 172.228084 223.83736 
-L 171.603835 224.908691 
-L 170.979586 225.959224 
-L 170.355337 226.989753 
-L 169.731088 228.001025 
-L 169.106839 228.993746 
-L 168.48259 229.968585 
-L 167.858341 230.926174 
-L 167.234092 231.867113 
-L 166.609843 232.791972 
-L 165.985594 233.70129 
-L 165.361344 234.595582 
-L 164.737095 235.475336 
-L 164.112846 236.341018 
-L 163.488597 237.193069 
-L 162.864348 238.031913 
-L 162.240099 238.857954 
-L 161.61585 239.671575 
-L 160.991601 240.473145 
-L 160.367352 241.263016 
-L 159.743103 242.041524 
-L 159.118854 242.808992 
-L 158.494605 243.565728 
-L 157.870355 244.312029 
-L 157.246106 245.048178 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 187.620351 187.562061 
+L 186.987554 189.605606 
+L 186.354757 191.574785 
+L 185.721961 193.474821 
+L 185.089164 195.310405 
+L 184.456367 197.085768 
+L 183.82357 198.804734 
+L 183.190774 200.470778 
+L 182.557977 202.087061 
+L 181.92518 203.656469 
+L 181.292383 205.181644 
+L 180.659587 206.665013 
+L 180.02679 208.108805 
+L 179.393993 209.515078 
+L 178.761196 210.885732 
+L 178.1284 212.222528 
+L 177.495603 213.527098 
+L 176.862806 214.800959 
+L 176.230009 216.045523 
+L 175.597212 217.262109 
+L 174.964416 218.451946 
+L 174.331619 219.616185 
+L 173.698822 220.755905 
+L 173.066025 221.872117 
+L 172.433229 222.965771 
+L 171.800432 224.037761 
+L 171.167635 225.088928 
+L 170.534838 226.120067 
+L 169.902042 227.131926 
+L 169.269245 228.125213 
+L 168.636448 229.100597 
+L 168.003651 230.058712 
+L 167.370855 231.00016 
+L 166.738058 231.92551 
+L 166.105261 232.835303 
+L 165.472464 233.730055 
+L 164.839668 234.610253 
+L 164.206871 235.476364 
+L 163.574074 236.328833 
+L 162.941277 237.168081 
+L 162.30848 237.994513 
+L 161.675684 238.808514 
+L 161.042887 239.610453 
+L 160.41009 240.400682 
+L 159.777293 241.179539 
+L 159.144497 241.947345 
+L 158.5117 242.70441 
+L 157.878903 243.45103 
+L 157.246106 244.18749 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 245.048178 
-L 156.541553 247.094145 
-L 155.837 249.065573 
-L 155.132447 250.967703 
-L 154.427894 252.805242 
-L 153.72334 254.582433 
-L 153.018787 256.303113 
-L 152.314234 257.970767 
-L 151.609681 259.588565 
-L 150.905128 261.159401 
-L 150.200574 262.685925 
-L 149.496021 264.17057 
-L 148.791468 265.615571 
-L 148.086915 267.022991 
-L 147.382362 268.394735 
-L 146.677808 269.732567 
-L 145.973255 271.038123 
-L 145.268702 272.312925 
-L 144.564149 273.558388 
-L 143.859596 274.775831 
-L 143.155042 275.966489 
-L 142.450489 277.131514 
-L 141.745936 278.271987 
-L 141.041383 279.388921 
-L 140.33683 280.483269 
-L 139.632277 281.555925 
-L 138.927723 282.607733 
-L 138.22317 283.639488 
-L 137.518617 284.651941 
-L 136.814064 285.6458 
-L 136.109511 286.621735 
-L 135.404957 287.580383 
-L 134.700404 288.522344 
-L 133.995851 289.448191 
-L 133.291298 290.358464 
-L 132.586745 291.253679 
-L 131.882191 292.134327 
-L 131.177638 293.000873 
-L 130.473085 293.853762 
-L 129.768532 294.693419 
-L 129.063979 295.520247 
-L 128.359425 296.334632 
-L 127.654872 297.136944 
-L 126.950319 297.927535 
-L 126.245766 298.706743 
-L 125.541213 299.474891 
-L 124.836659 300.232288 
-L 124.132106 300.979231 
-L 123.427553 301.716006 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.246106 244.18749 
+L 156.541553 246.286216 
+L 155.837 248.306583 
+L 155.132447 250.254231 
+L 154.427894 252.134214 
+L 153.72334 253.951077 
+L 153.018787 255.70892 
+L 152.314234 257.411458 
+L 151.609681 259.062064 
+L 150.905128 260.663814 
+L 150.200574 262.219516 
+L 149.496021 263.731744 
+L 148.791468 265.202863 
+L 148.086915 266.635048 
+L 147.382362 268.030306 
+L 146.677808 269.390495 
+L 145.973255 270.717335 
+L 145.268702 272.01242 
+L 144.564149 273.277237 
+L 143.859596 274.513167 
+L 143.155042 275.7215 
+L 142.450489 276.903443 
+L 141.745936 278.060123 
+L 141.041383 279.192597 
+L 140.33683 280.301859 
+L 139.632277 281.38884 
+L 138.927723 282.454418 
+L 138.22317 283.499419 
+L 137.518617 284.524624 
+L 136.814064 285.530768 
+L 136.109511 286.518547 
+L 135.404957 287.48862 
+L 134.700404 288.44161 
+L 133.995851 289.378109 
+L 133.291298 290.298677 
+L 132.586745 291.203848 
+L 131.882191 292.094127 
+L 131.177638 292.969998 
+L 130.473085 293.831919 
+L 129.768532 294.680328 
+L 129.063979 295.515641 
+L 128.359425 296.338257 
+L 127.654872 297.148556 
+L 126.950319 297.946901 
+L 126.245766 298.73364 
+L 125.541213 299.509106 
+L 124.836659 300.273617 
+L 124.132106 301.027478 
+L 123.427553 301.770983 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 123.427553 301.716006 
-L 122.841962 302.793 
-L 122.256372 303.848978 
-L 121.670781 304.884746 
-L 121.08519 305.901062 
-L 120.4996 306.898644 
-L 119.914009 307.878169 
-L 119.328419 308.84028 
-L 118.742828 309.785585 
-L 118.157237 310.714661 
-L 117.571647 311.628056 
-L 116.986056 312.526291 
-L 116.400465 313.40986 
-L 115.814875 314.279235 
-L 115.229284 315.134864 
-L 114.643693 315.977177 
-L 114.058103 316.80658 
-L 113.472512 317.623463 
-L 112.886922 318.428199 
-L 112.301331 319.221144 
-L 111.71574 320.002638 
-L 111.13015 320.773008 
-L 110.544559 321.532565 
-L 109.958968 322.281609 
-L 109.373378 323.020428 
-L 108.787787 323.749295 
-L 108.202197 324.468477 
-L 107.616606 325.178227 
-L 107.031015 325.878788 
-L 106.445425 326.570397 
-L 105.859834 327.253279 
-L 105.274243 327.927651 
-L 104.688653 328.593723 
-L 104.103062 329.251697 
-L 103.517471 329.901768 
-L 102.931881 330.544122 
-L 102.34629 331.178941 
-L 101.7607 331.8064 
-L 101.175109 332.426668 
-L 100.589518 333.039907 
-L 100.003928 333.646275 
-L 99.418337 334.245924 
-L 98.832746 334.839001 
-L 98.247156 335.42565 
-L 97.661565 336.006007 
-L 97.075974 336.580206 
-L 96.490384 337.148378 
-L 95.904793 337.710646 
-L 95.319203 338.267132 
-" clip-path="url(#p4e5194c456)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 123.427553 301.770983 
+L 122.841962 302.858002 
+L 122.256372 303.923617 
+L 121.670781 304.968654 
+L 121.08519 305.993893 
+L 120.4996 307.00007 
+L 119.914009 307.987881 
+L 119.328419 308.957985 
+L 118.742828 309.911004 
+L 118.157237 310.847531 
+L 117.571647 311.768127 
+L 116.986056 312.673324 
+L 116.400465 313.56363 
+L 115.814875 314.439526 
+L 115.229284 315.301471 
+L 114.643693 316.149903 
+L 114.058103 316.985239 
+L 113.472512 317.807877 
+L 112.886922 318.618197 
+L 112.301331 319.416563 
+L 111.71574 320.203322 
+L 111.13015 320.978808 
+L 110.544559 321.743338 
+L 109.958968 322.497218 
+L 109.373378 323.24074 
+L 108.787787 323.974186 
+L 108.202197 324.697824 
+L 107.616606 325.411913 
+L 107.031015 326.116703 
+L 106.445425 326.812433 
+L 105.859834 327.499331 
+L 105.274243 328.17762 
+L 104.688653 328.847514 
+L 104.103062 329.509216 
+L 103.517471 330.162925 
+L 102.931881 330.808833 
+L 102.34629 331.447122 
+L 101.7607 332.07797 
+L 101.175109 332.70155 
+L 100.589518 333.318026 
+L 100.003928 333.927559 
+L 99.418337 334.530303 
+L 98.832746 335.126408 
+L 98.247156 335.716018 
+L 97.661565 336.299274 
+L 97.075974 336.876311 
+L 96.490384 337.44726 
+L 95.904793 338.012249 
+L 95.319203 338.5714 
+" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.844609 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.059766 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,6 +6188,19 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
@@ -6213,19 +6226,6 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6323,16 +6323,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6371,109 +6371,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4e5194c456">
+  <clipPath id="pbbbb7115c6">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mdefcd809b0" d="M 0 0 
+       <path id="m925d18834f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdefcd809b0" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdefcd809b0" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mdefcd809b0" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mdefcd809b0" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mdefcd809b0" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mdefcd809b0" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdefcd809b0" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m925d18834f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m743fa97187" d="M 0 0 
+       <path id="mdbeedc36f9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m743fa97187" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbeedc36f9" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m743fa97187" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbeedc36f9" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m743fa97187" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbeedc36f9" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mbe40020857" d="M 0 0 
+       <path id="mb23367bc59" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mbe40020857" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb23367bc59" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 136.020628) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 131.616323) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(100.319203 333.986682) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 333.941883) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="md959d810f4" d="M -2.5 2.5 
+     <path id="m7d756d4e9c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#md959d810f4" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md959d810f4" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m7d756d4e9c" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7d756d4e9c" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m38fd3422ce" d="M 0 -2.5 
+     <path id="mf26cfcc357" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m38fd3422ce" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38fd3422ce" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#mf26cfcc357" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf26cfcc357" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m4dfe50dee7" d="M -0 3.535534 
+     <path id="m53248addb2" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m4dfe50dee7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4dfe50dee7" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m53248addb2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m53248addb2" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m59e614aad6" d="M -0 2.5 
+     <path id="ma8d7df69bb" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m59e614aad6" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#ma8d7df69bb" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="maef0e71a16" d="M -0.833333 2.5 
+     <path id="m504de00973" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#maef0e71a16" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maef0e71a16" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m504de00973" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m504de00973" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m6b9f2bd1f9" d="M -1.25 2.5 
+     <path id="m4790e0aa82" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m6b9f2bd1f9" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6b9f2bd1f9" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m4790e0aa82" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4790e0aa82" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m5967f52dd5" d="M 0 -2.5 
+     <path id="m5c48b0f9e1" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m5967f52dd5" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5967f52dd5" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m5c48b0f9e1" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5c48b0f9e1" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m8f4e8a955b" d="M 0 -2.5 
+     <path id="mb0af94cf08" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m8f4e8a955b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8f4e8a955b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#mb0af94cf08" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0af94cf08" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m2a9fff6e5a" d="M 0 3.5 
+      <path id="m85630589b6" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m2a9fff6e5a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m85630589b6" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#md959d810f4" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7d756d4e9c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m38fd3422ce" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf26cfcc357" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m4dfe50dee7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m53248addb2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m59e614aad6" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8d7df69bb" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#maef0e71a16" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m504de00973" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m6b9f2bd1f9" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4790e0aa82" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m5967f52dd5" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m5c48b0f9e1" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m8f4e8a955b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb0af94cf08" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pa763b8a2fd)">
-     <use xlink:href="#m2a9fff6e5a" x="319.643112" y="141.020628" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="236.23654" y="153.837799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="222.073314" y="158.344596" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="202.315941" y="169.763614" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="199.905291" y="171.284162" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="195.893147" y="175.469859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="187.210062" y="189.359123" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="157.246106" y="246.53899" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="123.427553" y="303.111135" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2a9fff6e5a" x="95.319203" y="338.986682" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p2893819ee3)">
+     <use xlink:href="#m85630589b6" x="319.643112" y="136.616323" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="236.23654" y="150.904354" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="222.073314" y="155.778999" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="202.315941" y="167.365845" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="199.905291" y="169.142776" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="195.893147" y="173.441256" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="187.210062" y="187.761876" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="157.246106" y="244.300425" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="123.427553" y="302.502212" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m85630589b6" x="95.319203" y="338.941883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 141.020628 
-L 317.905475 141.321089 
-L 316.167838 141.61989 
-L 314.430201 141.917051 
-L 312.692564 142.212589 
-L 310.954927 142.506522 
-L 309.21729 142.798867 
-L 307.479654 143.089642 
-L 305.742017 143.378862 
-L 304.00438 143.666545 
-L 302.266743 143.952707 
-L 300.529106 144.237364 
-L 298.791469 144.520531 
-L 297.053832 144.802224 
-L 295.316195 145.082459 
-L 293.578558 145.36125 
-L 291.840921 145.638612 
-L 290.103284 145.91456 
-L 288.365648 146.189108 
-L 286.628011 146.46227 
-L 284.890374 146.73406 
-L 283.152737 147.004493 
-L 281.4151 147.27358 
-L 279.677463 147.541336 
-L 277.939826 147.807774 
-L 276.202189 148.072907 
-L 274.464552 148.336747 
-L 272.726915 148.599307 
-L 270.989278 148.8606 
-L 269.251642 149.120637 
-L 267.514005 149.37943 
-L 265.776368 149.636992 
-L 264.038731 149.893333 
-L 262.301094 150.148467 
-L 260.563457 150.402403 
-L 258.82582 150.655153 
-L 257.088183 150.906728 
-L 255.350546 151.157139 
-L 253.612909 151.406397 
-L 251.875272 151.654512 
-L 250.137636 151.901495 
-L 248.399999 152.147356 
-L 246.662362 152.392104 
-L 244.924725 152.635751 
-L 243.187088 152.878306 
-L 241.449451 153.119779 
-L 239.711814 153.360179 
-L 237.974177 153.599516 
-L 236.23654 153.837799 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 136.616323 
+L 317.905475 136.955916 
+L 316.167838 137.293391 
+L 314.430201 137.628774 
+L 312.692564 137.962092 
+L 310.954927 138.29337 
+L 309.21729 138.622632 
+L 307.479654 138.949903 
+L 305.742017 139.275206 
+L 304.00438 139.598566 
+L 302.266743 139.920006 
+L 300.529106 140.239547 
+L 298.791469 140.557213 
+L 297.053832 140.873025 
+L 295.316195 141.187005 
+L 293.578558 141.499173 
+L 291.840921 141.809552 
+L 290.103284 142.11816 
+L 288.365648 142.425018 
+L 286.628011 142.730147 
+L 284.890374 143.033565 
+L 283.152737 143.335291 
+L 281.4151 143.635344 
+L 279.677463 143.933743 
+L 277.939826 144.230505 
+L 276.202189 144.525649 
+L 274.464552 144.819192 
+L 272.726915 145.111152 
+L 270.989278 145.401544 
+L 269.251642 145.690387 
+L 267.514005 145.977697 
+L 265.776368 146.263489 
+L 264.038731 146.54778 
+L 262.301094 146.830586 
+L 260.563457 147.111921 
+L 258.82582 147.391801 
+L 257.088183 147.670241 
+L 255.350546 147.947256 
+L 253.612909 148.22286 
+L 251.875272 148.497068 
+L 250.137636 148.769894 
+L 248.399999 149.041351 
+L 246.662362 149.311453 
+L 244.924725 149.580214 
+L 243.187088 149.847646 
+L 241.449451 150.113764 
+L 239.711814 150.378579 
+L 237.974177 150.642105 
+L 236.23654 150.904354 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 236.23654 153.837799 
-L 235.941473 153.935622 
-L 235.646406 154.033269 
-L 235.351339 154.13074 
-L 235.056271 154.228036 
-L 234.761204 154.325157 
-L 234.466137 154.422104 
-L 234.17107 154.518878 
-L 233.876003 154.61548 
-L 233.580935 154.711909 
-L 233.285868 154.808166 
-L 232.990801 154.904253 
-L 232.695734 155.000169 
-L 232.400667 155.095916 
-L 232.105599 155.191493 
-L 231.810532 155.286902 
-L 231.515465 155.382143 
-L 231.220398 155.477217 
-L 230.92533 155.572124 
-L 230.630263 155.666865 
-L 230.335196 155.76144 
-L 230.040129 155.855851 
-L 229.745062 155.950097 
-L 229.449994 156.044179 
-L 229.154927 156.138098 
-L 228.85986 156.231854 
-L 228.564793 156.325448 
-L 228.269726 156.41888 
-L 227.974658 156.512152 
-L 227.679591 156.605263 
-L 227.384524 156.698214 
-L 227.089457 156.791005 
-L 226.794389 156.883638 
-L 226.499322 156.976112 
-L 226.204255 157.068429 
-L 225.909188 157.160589 
-L 225.614121 157.252592 
-L 225.319053 157.344438 
-L 225.023986 157.436129 
-L 224.728919 157.527666 
-L 224.433852 157.619047 
-L 224.138785 157.710274 
-L 223.843717 157.801348 
-L 223.54865 157.892269 
-L 223.253583 157.983038 
-L 222.958516 158.073654 
-L 222.663449 158.164119 
-L 222.368381 158.254433 
-L 222.073314 158.344596 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 236.23654 150.904354 
+L 235.941473 151.010519 
+L 235.646406 151.116477 
+L 235.351339 151.222227 
+L 235.056271 151.327771 
+L 234.761204 151.433109 
+L 234.466137 151.538243 
+L 234.17107 151.643173 
+L 233.876003 151.7479 
+L 233.580935 151.852425 
+L 233.285868 151.956748 
+L 232.990801 152.060871 
+L 232.695734 152.164793 
+L 232.400667 152.268517 
+L 232.105599 152.372041 
+L 231.810532 152.475369 
+L 231.515465 152.578499 
+L 231.220398 152.681433 
+L 230.92533 152.784172 
+L 230.630263 152.886716 
+L 230.335196 152.989067 
+L 230.040129 153.091224 
+L 229.745062 153.193188 
+L 229.449994 153.294961 
+L 229.154927 153.396543 
+L 228.85986 153.497934 
+L 228.564793 153.599136 
+L 228.269726 153.700149 
+L 227.974658 153.800974 
+L 227.679591 153.901611 
+L 227.384524 154.002062 
+L 227.089457 154.102326 
+L 226.794389 154.202405 
+L 226.499322 154.302299 
+L 226.204255 154.402009 
+L 225.909188 154.501536 
+L 225.614121 154.60088 
+L 225.319053 154.700042 
+L 225.023986 154.799023 
+L 224.728919 154.897823 
+L 224.433852 154.996443 
+L 224.138785 155.094884 
+L 223.843717 155.193145 
+L 223.54865 155.291229 
+L 223.253583 155.389136 
+L 222.958516 155.486865 
+L 222.663449 155.584418 
+L 222.368381 155.681796 
+L 222.073314 155.778999 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 222.073314 158.344596 
-L 221.661702 158.608807 
-L 221.25009 158.871734 
-L 220.838478 159.13339 
-L 220.426866 159.393787 
-L 220.015254 159.652937 
-L 219.603642 159.910852 
-L 219.19203 160.167543 
-L 218.780418 160.423023 
-L 218.368807 160.677302 
-L 217.957195 160.930393 
-L 217.545583 161.182305 
-L 217.133971 161.43305 
-L 216.722359 161.682638 
-L 216.310747 161.931081 
-L 215.899135 162.178389 
-L 215.487523 162.424571 
-L 215.075911 162.669639 
-L 214.664299 162.913602 
-L 214.252687 163.15647 
-L 213.841075 163.398253 
-L 213.429463 163.63896 
-L 213.017851 163.878602 
-L 212.606239 164.117187 
-L 212.194627 164.354725 
-L 211.783015 164.591225 
-L 211.371403 164.826696 
-L 210.959791 165.061147 
-L 210.54818 165.294587 
-L 210.136568 165.527024 
-L 209.724956 165.758466 
-L 209.313344 165.988924 
-L 208.901732 166.218404 
-L 208.49012 166.446915 
-L 208.078508 166.674465 
-L 207.666896 166.901063 
-L 207.255284 167.126716 
-L 206.843672 167.351432 
-L 206.43206 167.575218 
-L 206.020448 167.798083 
-L 205.608836 168.020034 
-L 205.197224 168.241078 
-L 204.785612 168.461224 
-L 204.374 168.680477 
-L 203.962388 168.898846 
-L 203.550776 169.116337 
-L 203.139164 169.332957 
-L 202.727553 169.548714 
-L 202.315941 169.763614 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 222.073314 155.778999 
+L 221.661702 156.047513 
+L 221.25009 156.314701 
+L 220.838478 156.580577 
+L 220.426866 156.845153 
+L 220.015254 157.108441 
+L 219.603642 157.370455 
+L 219.19203 157.631207 
+L 218.780418 157.890708 
+L 218.368807 158.14897 
+L 217.957195 158.406007 
+L 217.545583 158.661828 
+L 217.133971 158.916445 
+L 216.722359 159.16987 
+L 216.310747 159.422114 
+L 215.899135 159.673188 
+L 215.487523 159.923102 
+L 215.075911 160.171868 
+L 214.664299 160.419495 
+L 214.252687 160.665995 
+L 213.841075 160.911376 
+L 213.429463 161.15565 
+L 213.017851 161.398827 
+L 212.606239 161.640916 
+L 212.194627 161.881926 
+L 211.783015 162.121868 
+L 211.371403 162.360751 
+L 210.959791 162.598584 
+L 210.54818 162.835377 
+L 210.136568 163.071137 
+L 209.724956 163.305876 
+L 209.313344 163.5396 
+L 208.901732 163.77232 
+L 208.49012 164.004043 
+L 208.078508 164.234778 
+L 207.666896 164.464533 
+L 207.255284 164.693317 
+L 206.843672 164.921139 
+L 206.43206 165.148005 
+L 206.020448 165.373924 
+L 205.608836 165.598903 
+L 205.197224 165.822952 
+L 204.785612 166.046076 
+L 204.374 166.268285 
+L 203.962388 166.489585 
+L 203.550776 166.709983 
+L 203.139164 166.929488 
+L 202.727553 167.148106 
+L 202.315941 167.365845 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 202.315941 169.763614 
-L 202.265719 169.795732 
-L 202.215497 169.827831 
-L 202.165275 169.859911 
-L 202.115053 169.891971 
-L 202.064831 169.924013 
-L 202.014609 169.956036 
-L 201.964388 169.988039 
-L 201.914166 170.020024 
-L 201.863944 170.05199 
-L 201.813722 170.083937 
-L 201.7635 170.115866 
-L 201.713278 170.147775 
-L 201.663056 170.179666 
-L 201.612834 170.211538 
-L 201.562613 170.243391 
-L 201.512391 170.275225 
-L 201.462169 170.307041 
-L 201.411947 170.338838 
-L 201.361725 170.370616 
-L 201.311503 170.402376 
-L 201.261281 170.434117 
-L 201.21106 170.465839 
-L 201.160838 170.497543 
-L 201.110616 170.529228 
-L 201.060394 170.560895 
-L 201.010172 170.592543 
-L 200.95995 170.624173 
-L 200.909728 170.655784 
-L 200.859507 170.687377 
-L 200.809285 170.718951 
-L 200.759063 170.750507 
-L 200.708841 170.782045 
-L 200.658619 170.813564 
-L 200.608397 170.845065 
-L 200.558175 170.876547 
-L 200.507953 170.908012 
-L 200.457732 170.939457 
-L 200.40751 170.970885 
-L 200.357288 171.002295 
-L 200.307066 171.033686 
-L 200.256844 171.065059 
-L 200.206622 171.096414 
-L 200.1564 171.12775 
-L 200.106179 171.159069 
-L 200.055957 171.190369 
-L 200.005735 171.221652 
-L 199.955513 171.252916 
-L 199.905291 171.284162 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 202.315941 167.365845 
+L 202.265719 167.403465 
+L 202.215497 167.44106 
+L 202.165275 167.478629 
+L 202.115053 167.516171 
+L 202.064831 167.553687 
+L 202.014609 167.591178 
+L 201.964388 167.628643 
+L 201.914166 167.666081 
+L 201.863944 167.703494 
+L 201.813722 167.740881 
+L 201.7635 167.778242 
+L 201.713278 167.815577 
+L 201.663056 167.852887 
+L 201.612834 167.890171 
+L 201.562613 167.927429 
+L 201.512391 167.964661 
+L 201.462169 168.001868 
+L 201.411947 168.03905 
+L 201.361725 168.076205 
+L 201.311503 168.113336 
+L 201.261281 168.150441 
+L 201.21106 168.18752 
+L 201.160838 168.224574 
+L 201.110616 168.261603 
+L 201.060394 168.298607 
+L 201.010172 168.335585 
+L 200.95995 168.372538 
+L 200.909728 168.409465 
+L 200.859507 168.446368 
+L 200.809285 168.483245 
+L 200.759063 168.520097 
+L 200.708841 168.556925 
+L 200.658619 168.593727 
+L 200.608397 168.630504 
+L 200.558175 168.667256 
+L 200.507953 168.703983 
+L 200.457732 168.740685 
+L 200.40751 168.777363 
+L 200.357288 168.814015 
+L 200.307066 168.850643 
+L 200.256844 168.887246 
+L 200.206622 168.923824 
+L 200.1564 168.960378 
+L 200.106179 168.996907 
+L 200.055957 169.033411 
+L 200.005735 169.069891 
+L 199.955513 169.106346 
+L 199.905291 169.142776 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 199.905291 171.284162 
-L 199.821705 171.374749 
-L 199.738118 171.465185 
-L 199.654532 171.55547 
-L 199.570946 171.645604 
-L 199.487359 171.735589 
-L 199.403773 171.825424 
-L 199.320187 171.91511 
-L 199.2366 172.004648 
-L 199.153014 172.094038 
-L 199.069428 172.183281 
-L 198.985841 172.272376 
-L 198.902255 172.361326 
-L 198.818669 172.450129 
-L 198.735082 172.538787 
-L 198.651496 172.6273 
-L 198.56791 172.715668 
-L 198.484323 172.803892 
-L 198.400737 172.891973 
-L 198.317151 172.97991 
-L 198.233564 173.067705 
-L 198.149978 173.155358 
-L 198.066392 173.242869 
-L 197.982805 173.330238 
-L 197.899219 173.417467 
-L 197.815633 173.504556 
-L 197.732046 173.591504 
-L 197.64846 173.678313 
-L 197.564874 173.764983 
-L 197.481287 173.851515 
-L 197.397701 173.937908 
-L 197.314115 174.024164 
-L 197.230528 174.110282 
-L 197.146942 174.196264 
-L 197.063356 174.282109 
-L 196.979769 174.367818 
-L 196.896183 174.453392 
-L 196.812597 174.53883 
-L 196.72901 174.624134 
-L 196.645424 174.709304 
-L 196.561838 174.79434 
-L 196.478251 174.879242 
-L 196.394665 174.964012 
-L 196.311079 175.048649 
-L 196.227492 175.133153 
-L 196.143906 175.217526 
-L 196.06032 175.301768 
-L 195.976733 175.385879 
-L 195.893147 175.469859 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 169.142776 
+L 199.821705 169.2359 
+L 199.738118 169.328864 
+L 199.654532 169.421669 
+L 199.570946 169.514315 
+L 199.487359 169.606802 
+L 199.403773 169.699132 
+L 199.320187 169.791304 
+L 199.2366 169.883319 
+L 199.153014 169.975179 
+L 199.069428 170.066883 
+L 198.985841 170.158431 
+L 198.902255 170.249825 
+L 198.818669 170.341065 
+L 198.735082 170.432152 
+L 198.651496 170.523085 
+L 198.56791 170.613866 
+L 198.484323 170.704495 
+L 198.400737 170.794972 
+L 198.317151 170.885298 
+L 198.233564 170.975474 
+L 198.149978 171.0655 
+L 198.066392 171.155376 
+L 197.982805 171.245103 
+L 197.899219 171.334682 
+L 197.815633 171.424112 
+L 197.732046 171.513396 
+L 197.64846 171.602532 
+L 197.564874 171.691521 
+L 197.481287 171.780365 
+L 197.397701 171.869062 
+L 197.314115 171.957615 
+L 197.230528 172.046023 
+L 197.146942 172.134287 
+L 197.063356 172.222407 
+L 196.979769 172.310384 
+L 196.896183 172.398218 
+L 196.812597 172.48591 
+L 196.72901 172.57346 
+L 196.645424 172.660868 
+L 196.561838 172.748136 
+L 196.478251 172.835263 
+L 196.394665 172.92225 
+L 196.311079 173.009097 
+L 196.227492 173.095805 
+L 196.143906 173.182375 
+L 196.06032 173.268806 
+L 195.976733 173.3551 
+L 195.893147 173.441256 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 195.893147 175.469859 
-L 195.712249 175.79874 
-L 195.531352 176.125634 
-L 195.350454 176.450566 
-L 195.169557 176.773558 
-L 194.988659 177.094635 
-L 194.807761 177.413817 
-L 194.626864 177.731128 
-L 194.445966 178.04659 
-L 194.265069 178.360223 
-L 194.084171 178.672049 
-L 193.903273 178.982089 
-L 193.722376 179.290362 
-L 193.541478 179.59689 
-L 193.360581 179.901691 
-L 193.179683 180.204785 
-L 192.998785 180.506191 
-L 192.817888 180.805928 
-L 192.63699 181.104013 
-L 192.456093 181.400466 
-L 192.275195 181.695304 
-L 192.094297 181.988544 
-L 191.9134 182.280204 
-L 191.732502 182.5703 
-L 191.551605 182.85885 
-L 191.370707 183.145869 
-L 191.189809 183.431374 
-L 191.008912 183.715381 
-L 190.828014 183.997905 
-L 190.647117 184.278962 
-L 190.466219 184.558567 
-L 190.285321 184.836735 
-L 190.104424 185.11348 
-L 189.923526 185.388817 
-L 189.742629 185.662761 
-L 189.561731 185.935325 
-L 189.380833 186.206523 
-L 189.199936 186.476368 
-L 189.019038 186.744875 
-L 188.838141 187.012056 
-L 188.657243 187.277925 
-L 188.476345 187.542494 
-L 188.295448 187.805776 
-L 188.11455 188.067783 
-L 187.933653 188.328528 
-L 187.752755 188.588022 
-L 187.571857 188.846278 
-L 187.39096 189.103308 
-L 187.210062 189.359123 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 195.893147 173.441256 
+L 195.712249 173.781727 
+L 195.531352 174.12007 
+L 195.350454 174.456311 
+L 195.169557 174.790475 
+L 194.988659 175.122589 
+L 194.807761 175.452677 
+L 194.626864 175.780764 
+L 194.445966 176.106874 
+L 194.265069 176.431031 
+L 194.084171 176.753257 
+L 193.903273 177.073577 
+L 193.722376 177.392011 
+L 193.541478 177.708583 
+L 193.360581 178.023314 
+L 193.179683 178.336225 
+L 192.998785 178.647337 
+L 192.817888 178.956671 
+L 192.63699 179.264247 
+L 192.456093 179.570085 
+L 192.275195 179.874204 
+L 192.094297 180.176624 
+L 191.9134 180.477363 
+L 191.732502 180.77644 
+L 191.551605 181.073873 
+L 191.370707 181.36968 
+L 191.189809 181.66388 
+L 191.008912 181.956489 
+L 190.828014 182.247524 
+L 190.647117 182.537002 
+L 190.466219 182.824941 
+L 190.285321 183.111355 
+L 190.104424 183.396262 
+L 189.923526 183.679676 
+L 189.742629 183.961614 
+L 189.561731 184.242091 
+L 189.380833 184.521122 
+L 189.199936 184.798722 
+L 189.019038 185.074904 
+L 188.838141 185.349685 
+L 188.657243 185.623077 
+L 188.476345 185.895095 
+L 188.295448 186.165753 
+L 188.11455 186.435064 
+L 187.933653 186.703042 
+L 187.752755 186.969699 
+L 187.571857 187.235048 
+L 187.39096 187.499103 
+L 187.210062 187.761876 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 187.210062 189.359123 
-L 186.585813 191.434489 
-L 185.961564 193.433199 
-L 185.337315 195.360714 
-L 184.713066 197.221931 
-L 184.088817 199.021262 
-L 183.464568 200.762688 
-L 182.840319 202.449821 
-L 182.21607 204.085945 
-L 181.591821 205.674052 
-L 180.967571 207.216883 
-L 180.343322 208.716946 
-L 179.719073 210.176549 
-L 179.094824 211.597818 
-L 178.470575 212.982714 
-L 177.846326 214.333053 
-L 177.222077 215.650518 
-L 176.597828 216.936671 
-L 175.973579 218.192966 
-L 175.34933 219.420758 
-L 174.725081 220.621312 
-L 174.100832 221.795811 
-L 173.476582 222.94536 
-L 172.852333 224.070998 
-L 172.228084 225.1737 
-L 171.603835 226.254382 
-L 170.979586 227.313905 
-L 170.355337 228.353083 
-L 169.731088 229.372682 
-L 169.106839 230.373427 
-L 168.48259 231.356001 
-L 167.858341 232.321054 
-L 167.234092 233.269198 
-L 166.609843 234.201017 
-L 165.985594 235.117063 
-L 165.361344 236.017861 
-L 164.737095 236.903911 
-L 164.112846 237.775687 
-L 163.488597 238.633643 
-L 162.864348 239.478209 
-L 162.240099 240.309797 
-L 161.61585 241.1288 
-L 160.991601 241.935593 
-L 160.367352 242.730535 
-L 159.743103 243.513969 
-L 159.118854 244.286223 
-L 158.494605 245.047613 
-L 157.870355 245.798439 
-L 157.246106 246.53899 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 187.210062 187.761876 
+L 186.585813 189.800462 
+L 185.961564 191.765036 
+L 185.337315 193.660785 
+L 184.713066 195.492367 
+L 184.088817 197.263986 
+L 183.464568 198.979443 
+L 182.840319 200.64219 
+L 182.21607 202.255369 
+L 181.591821 203.821851 
+L 180.967571 205.344263 
+L 180.343322 206.825017 
+L 179.719073 208.266332 
+L 179.094824 209.670256 
+L 178.470575 211.038678 
+L 177.846326 212.37335 
+L 177.222077 213.675898 
+L 176.597828 214.94783 
+L 175.973579 216.190554 
+L 175.34933 217.40538 
+L 174.725081 218.593535 
+L 174.100832 219.756163 
+L 173.476582 220.894339 
+L 172.852333 222.00907 
+L 172.228084 223.101302 
+L 171.603835 224.171926 
+L 170.979586 225.22178 
+L 170.355337 226.251655 
+L 169.731088 227.262297 
+L 169.106839 228.254411 
+L 168.48259 229.228664 
+L 167.858341 230.185688 
+L 167.234092 231.126082 
+L 166.609843 232.050414 
+L 165.985594 232.959223 
+L 165.361344 233.853023 
+L 164.737095 234.7323 
+L 164.112846 235.59752 
+L 163.488597 236.449124 
+L 162.864348 237.287535 
+L 162.240099 238.113155 
+L 161.61585 238.926368 
+L 160.991601 239.727543 
+L 160.367352 240.517029 
+L 159.743103 241.295164 
+L 159.118854 242.062269 
+L 158.494605 242.818653 
+L 157.870355 243.56461 
+L 157.246106 244.300425 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 246.53899 
-L 156.541553 248.579493 
-L 155.837 250.545847 
-L 155.132447 252.443253 
-L 154.427894 254.276383 
-L 153.72334 256.049449 
-L 153.018787 257.766262 
-L 152.314234 259.430284 
-L 151.609681 261.044663 
-L 150.905128 262.612276 
-L 150.200574 264.135757 
-L 149.496021 265.617522 
-L 148.791468 267.059795 
-L 148.086915 268.464627 
-L 147.382362 269.833912 
-L 146.677808 271.169406 
-L 145.973255 272.472735 
-L 145.268702 273.745413 
-L 144.564149 274.988849 
-L 143.859596 276.204356 
-L 143.155042 277.393161 
-L 142.450489 278.556412 
-L 141.745936 279.695185 
-L 141.041383 280.810489 
-L 140.33683 281.903271 
-L 139.632277 282.974423 
-L 138.927723 284.024786 
-L 138.22317 285.055149 
-L 137.518617 286.066262 
-L 136.814064 287.058829 
-L 136.109511 288.03352 
-L 135.404957 288.990966 
-L 134.700404 289.931768 
-L 133.995851 290.856494 
-L 133.291298 291.765684 
-L 132.586745 292.659851 
-L 131.882191 293.539485 
-L 131.177638 294.405049 
-L 130.473085 295.256988 
-L 129.768532 296.095723 
-L 129.063979 296.921657 
-L 128.359425 297.735175 
-L 127.654872 298.536645 
-L 126.950319 299.326419 
-L 126.245766 300.104833 
-L 125.541213 300.872209 
-L 124.836659 301.628856 
-L 124.132106 302.37507 
-L 123.427553 303.111135 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.246106 244.300425 
+L 156.541553 246.435255 
+L 155.837 248.489058 
+L 155.132447 250.46776 
+L 154.427894 252.376661 
+L 153.72334 254.220517 
+L 153.018787 256.003617 
+L 152.314234 257.729836 
+L 151.609681 259.402691 
+L 150.905128 261.025384 
+L 150.200574 262.600835 
+L 149.496021 264.131717 
+L 148.791468 265.620482 
+L 148.086915 267.069387 
+L 147.382362 268.48051 
+L 146.677808 269.855772 
+L 145.973255 271.196949 
+L 145.268702 272.505692 
+L 144.564149 273.783531 
+L 143.859596 275.031893 
+L 143.155042 276.252106 
+L 142.450489 277.445413 
+L 141.745936 278.612974 
+L 141.041383 279.755878 
+L 140.33683 280.875143 
+L 139.632277 281.971728 
+L 138.927723 283.046534 
+L 138.22317 284.100409 
+L 137.518617 285.134153 
+L 136.814064 286.14852 
+L 136.109511 287.144224 
+L 135.404957 288.121939 
+L 134.700404 289.082303 
+L 133.995851 290.025922 
+L 133.291298 290.953369 
+L 132.586745 291.86519 
+L 131.882191 292.761902 
+L 131.177638 293.643998 
+L 130.473085 294.511946 
+L 129.768532 295.366194 
+L 129.063979 296.207167 
+L 128.359425 297.035272 
+L 127.654872 297.850896 
+L 126.950319 298.65441 
+L 126.245766 299.446168 
+L 125.541213 300.226509 
+L 124.836659 300.995759 
+L 124.132106 301.754227 
+L 123.427553 302.502212 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 123.427553 303.111135 
-L 122.841962 304.161182 
-L 122.256372 305.191242 
-L 121.670781 306.202063 
-L 121.08519 307.194349 
-L 120.4996 308.168768 
-L 119.914009 309.125953 
-L 119.328419 310.066501 
-L 118.742828 310.990983 
-L 118.157237 311.899936 
-L 117.571647 312.793876 
-L 116.986056 313.673288 
-L 116.400465 314.538639 
-L 115.814875 315.39037 
-L 115.229284 316.228903 
-L 114.643693 317.054643 
-L 114.058103 317.867972 
-L 113.472512 318.669259 
-L 112.886922 319.458854 
-L 112.301331 320.237095 
-L 111.71574 321.004303 
-L 111.13015 321.760787 
-L 110.544559 322.506841 
-L 109.958968 323.242751 
-L 109.373378 323.968788 
-L 108.787787 324.685213 
-L 108.202197 325.392278 
-L 107.616606 326.090224 
-L 107.031015 326.779284 
-L 106.445425 327.45968 
-L 105.859834 328.131629 
-L 105.274243 328.795336 
-L 104.688653 329.451002 
-L 104.103062 330.09882 
-L 103.517471 330.738974 
-L 102.931881 331.371645 
-L 102.34629 331.997005 
-L 101.7607 332.615221 
-L 101.175109 333.226455 
-L 100.589518 333.830862 
-L 100.003928 334.428594 
-L 99.418337 335.019796 
-L 98.832746 335.604609 
-L 98.247156 336.18317 
-L 97.661565 336.755611 
-L 97.075974 337.322061 
-L 96.490384 337.882643 
-L 95.904793 338.437478 
-L 95.319203 338.986682 
-" clip-path="url(#pa763b8a2fd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 123.427553 302.502212 
+L 122.841962 303.574738 
+L 122.256372 304.626421 
+L 121.670781 305.658056 
+L 121.08519 306.670393 
+L 120.4996 307.66414 
+L 119.914009 308.639968 
+L 119.328419 309.598511 
+L 118.742828 310.540372 
+L 118.157237 311.466122 
+L 117.571647 312.376301 
+L 116.986056 313.271426 
+L 116.400465 314.151986 
+L 115.814875 315.018447 
+L 115.229284 315.871254 
+L 114.643693 316.710831 
+L 114.058103 317.537581 
+L 113.472512 318.351892 
+L 112.886922 319.154131 
+L 112.301331 319.944651 
+L 111.71574 320.72379 
+L 111.13015 321.491871 
+L 110.544559 322.249204 
+L 109.958968 322.996084 
+L 109.373378 323.732797 
+L 108.787787 324.459616 
+L 108.202197 325.176802 
+L 107.616606 325.884609 
+L 107.031015 326.583277 
+L 106.445425 327.273041 
+L 105.859834 327.954124 
+L 105.274243 328.626741 
+L 104.688653 329.291102 
+L 104.103062 329.947406 
+L 103.517471 330.595846 
+L 102.931881 331.236608 
+L 102.34629 331.869872 
+L 101.7607 332.495812 
+L 101.175109 333.114595 
+L 100.589518 333.726383 
+L 100.003928 334.331332 
+L 99.418337 334.929593 
+L 98.832746 335.521313 
+L 98.247156 336.106634 
+L 97.661565 336.685691 
+L 97.075974 337.258618 
+L 96.490384 337.825544 
+L 95.904793 338.386591 
+L 95.319203 338.941883 
+" clip-path="url(#p2893819ee3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.775937 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6203,34 +6203,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6290,31 +6285,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6355,14 +6325,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6401,109 +6371,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa763b8a2fd">
+  <clipPath id="p2893819ee3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3a7c799188" d="M 0 0 
+       <path id="me3d7810ba7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3a7c799188" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3a7c799188" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3a7c799188" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3a7c799188" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3a7c799188" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3a7c799188" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3a7c799188" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me3d7810ba7" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc0a4d440d5" d="M 0 0 
+       <path id="m81ba0308e4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc0a4d440d5" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ba0308e4" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc0a4d440d5" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ba0308e4" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc0a4d440d5" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81ba0308e4" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mcab3e70a5a" d="M 0 0 
+       <path id="me3a9f50beb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mcab3e70a5a" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me3a9f50beb" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p94c1ad601a)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pfc36f9d8d9)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mebc4961ad0" d="M -2.5 2.5 
+     <path id="m8ddb55214d" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#mebc4961ad0" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mebc4961ad0" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m8ddb55214d" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8ddb55214d" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m4fce55f4fb" d="M 0 -2.5 
+     <path id="mcbf383a595" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#m4fce55f4fb" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4fce55f4fb" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#mcbf383a595" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbf383a595" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mf4dabc54d2" d="M -0 3.535534 
+     <path id="m4d8e3b0c73" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#mf4dabc54d2" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4dabc54d2" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m4d8e3b0c73" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8e3b0c73" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mcb00914121" d="M -0.833333 2.5 
+     <path id="m8488fd6fe9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#mcb00914121" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb00914121" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m8488fd6fe9" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8488fd6fe9" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m8a4daf15ff" d="M -1.25 2.5 
+     <path id="m7e6bcd8302" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#m8a4daf15ff" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8a4daf15ff" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m7e6bcd8302" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e6bcd8302" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="me5a01b8ed7" d="M 0 -2.5 
+     <path id="m03f1766d82" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#me5a01b8ed7" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me5a01b8ed7" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m03f1766d82" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m03f1766d82" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="md0d4f31ad3" d="M 0 -2.5 
+     <path id="m868fd11540" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#md0d4f31ad3" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d4f31ad3" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m868fd11540" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m868fd11540" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mc34803d6eb" d="M 0 3.5 
+      <path id="m06a46da345" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mc34803d6eb" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m06a46da345" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mebc4961ad0" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8ddb55214d" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m4fce55f4fb" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcbf383a595" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mf4dabc54d2" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4d8e3b0c73" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mcb00914121" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8488fd6fe9" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m8a4daf15ff" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7e6bcd8302" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#me5a01b8ed7" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m03f1766d82" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#md0d4f31ad3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m868fd11540" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p94c1ad601a)">
-     <use xlink:href="#mc34803d6eb" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc34803d6eb" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pfc36f9d8d9)">
+     <use xlink:href="#m06a46da345" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m06a46da345" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p94c1ad601a">
+  <clipPath id="pfc36f9d8d9">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m03d2a7346d" d="M 0 0 
+       <path id="md107af069b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m03d2a7346d" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m03d2a7346d" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m03d2a7346d" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m03d2a7346d" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m03d2a7346d" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m03d2a7346d" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m03d2a7346d" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md107af069b" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb1d52b6d78" d="M 0 0 
+       <path id="m52008f6d16" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb1d52b6d78" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52008f6d16" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb1d52b6d78" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52008f6d16" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb1d52b6d78" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52008f6d16" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="me3247ecb44" d="M 0 0 
+       <path id="m04f4f19cbb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#me3247ecb44" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m04f4f19cbb" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p5cd1fd6151)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pe31f86e90f)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mf92c10e21c" d="M -2.5 2.5 
+     <path id="mb5c41ea296" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#mf92c10e21c" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf92c10e21c" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#mb5c41ea296" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5c41ea296" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m3bee84cc3f" d="M 0 -2.5 
+     <path id="m6649876d69" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#m3bee84cc3f" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3bee84cc3f" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#m6649876d69" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6649876d69" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m5f3193de51" d="M -0 3.535534 
+     <path id="med309b2552" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#m5f3193de51" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f3193de51" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#med309b2552" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#med309b2552" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m5355812c33" d="M -0.833333 2.5 
+     <path id="m2de533c0f2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#m5355812c33" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5355812c33" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#m2de533c0f2" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2de533c0f2" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="ma5d036e8ce" d="M -1.25 2.5 
+     <path id="made024d64b" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#ma5d036e8ce" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5d036e8ce" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#made024d64b" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#made024d64b" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="mf0eaed6baa" d="M 0 -2.5 
+     <path id="m23bccdf4af" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#mf0eaed6baa" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf0eaed6baa" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#m23bccdf4af" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m23bccdf4af" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m71f83d5ff4" d="M 0 -2.5 
+     <path id="md11f286c08" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#m71f83d5ff4" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m71f83d5ff4" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#md11f286c08" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md11f286c08" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m948dafe498" d="M 0 3.5 
+      <path id="m58ad3be433" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m948dafe498" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m58ad3be433" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mf92c10e21c" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb5c41ea296" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m3bee84cc3f" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6649876d69" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m5f3193de51" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#med309b2552" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m5355812c33" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2de533c0f2" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#ma5d036e8ce" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#made024d64b" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#mf0eaed6baa" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m23bccdf4af" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m71f83d5ff4" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md11f286c08" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p5cd1fd6151)">
-     <use xlink:href="#m948dafe498" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m948dafe498" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pe31f86e90f)">
+     <use xlink:href="#m58ad3be433" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m58ad3be433" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5cd1fd6151">
+  <clipPath id="pe31f86e90f">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="md7db54098a" d="M 0 0 
+       <path id="m166dc9d3ec" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md7db54098a" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m166dc9d3ec" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md7db54098a" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m166dc9d3ec" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mc264559f84" d="M 0 0 
+       <path id="me2628a614b" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc264559f84" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc264559f84" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc264559f84" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc264559f84" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc264559f84" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc264559f84" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc264559f84" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc264559f84" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc264559f84" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc264559f84" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc264559f84" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc264559f84" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc264559f84" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc264559f84" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc264559f84" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc264559f84" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc264559f84" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc264559f84" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc264559f84" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc264559f84" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me2628a614b" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mf60ff63485" d="M 0 0 
+       <path id="m9de5e9f3e7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf60ff63485" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de5e9f3e7" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#pca8e1cb20e)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pbce84ea252)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m7131fef42f" d="M 0 3 
+     <path id="m71160f0dc3" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m7131fef42f" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m71160f0dc3" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="me3495c8e01" d="M 0 3 
+     <path id="m565731d7f1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#me3495c8e01" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m565731d7f1" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m20e36a6d9e" d="M 0 3 
+     <path id="m8f7d887760" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m20e36a6d9e" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m8f7d887760" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mf0ed1d3ba3" d="M 0 5 
+     <path id="m34262db8b6" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#mf0ed1d3ba3" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m34262db8b6" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m47b980df42" d="M 0 3 
+     <path id="m9d403304f0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m47b980df42" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m9d403304f0" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m9b755445f6" d="M 0 3 
+     <path id="m3ad6408a59" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m9b755445f6" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m3ad6408a59" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m069795f67f" d="M 0 3 
+     <path id="mf0ee440873" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m069795f67f" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#mf0ee440873" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m618219c650" d="M 0 3 
+     <path id="m1f0010e8bc" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pca8e1cb20e)">
-     <use xlink:href="#m618219c650" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pbce84ea252)">
+     <use xlink:href="#m1f0010e8bc" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pca8e1cb20e">
+  <clipPath id="pbce84ea252">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8fb2e0b435" d="M 0 0 
+       <path id="m60de59094c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8fb2e0b435" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60de59094c" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8fb2e0b435" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m60de59094c" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m1014638eca" d="M 0 0 
+       <path id="mb2240dd22e" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1014638eca" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1014638eca" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1014638eca" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1014638eca" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1014638eca" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1014638eca" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1014638eca" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1014638eca" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1014638eca" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1014638eca" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1014638eca" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1014638eca" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1014638eca" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1014638eca" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1014638eca" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1014638eca" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1014638eca" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1014638eca" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1014638eca" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1014638eca" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb2240dd22e" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m6227b97556" d="M 0 0 
+       <path id="m79f87d595c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6227b97556" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79f87d595c" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#p45b5c84c02)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pe69e390d9c)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m11bcb722ca" d="M 0 3 
+     <path id="mceb2c84336" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m11bcb722ca" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#mceb2c84336" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m515fc12602" d="M 0 3 
+     <path id="m03ad1b8251" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m515fc12602" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#m03ad1b8251" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m4e0ae64abd" d="M 0 3 
+     <path id="m4a8e9bfa73" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m4e0ae64abd" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#m4a8e9bfa73" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="ma93ab875ce" d="M 0 5 
+     <path id="m134b74195c" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#ma93ab875ce" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#m134b74195c" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m605a0dec69" d="M 0 3 
+     <path id="m6db886e71b" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m605a0dec69" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#m6db886e71b" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m7bb0c2f104" d="M 0 3 
+     <path id="md87fbd1b43" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m7bb0c2f104" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#md87fbd1b43" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m95b3c6216f" d="M 0 3 
+     <path id="mb244ee9bf7" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#m95b3c6216f" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#mb244ee9bf7" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="mee8ce6a54f" d="M 0 3 
+     <path id="m02ef192fad" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p45b5c84c02)">
-     <use xlink:href="#mee8ce6a54f" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pe69e390d9c)">
+     <use xlink:href="#m02ef192fad" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p45b5c84c02">
+  <clipPath id="pe69e390d9c">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#ped6e7d4958)">
+   <g clip-path="url(#p69daa5491c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imaged0d405070b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAklEQVR4nO3Yv6ueZx3H8fPknDQxJ81JgtZiFdEUl1oFF4mgU0EQHdwdRP8CFycncXJ1UEcXt1KcJEM7CvG3dbJYf+APQmxMGkuanpycx7/gPUi5+MrD6/UXfOC+ue73fW1Ob/1wu7eDjn98Y3rCEmdfeH56wjKbpz4wPWGJ7W9/Nz1hic0nnpuesMT2wf3pCcvc/uZL0xOWeOo7X5yesMTm6vunJ6xx/GB6wTKnP9/N8/7M9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLmP8cvbadHrHD479vTE5Z449KF6QnLvH3y1vSEJT705vH0hCXefN/T0xOWON2eTk9Y5srB1ekJa9z5y/SCJe5f2c3n9eSf/zA9YZntxz49PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSDwzu3pjesceHy9IIlttvj6QnLfPCVX05PWOOFL0wvWOLojX9OT1jj9GR6wTqHO3p+nLs4vWCJS//aze/z3Q9fm56wzJW/vTo9YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaPHp8Yzs9YoX923+anrDErSefmJ6wzFuP7k1PWOLaX+9NT1ji5OOfmZ6wxIOT+9MTljnavzw9YYnt67+YnrDEw48+Pz1hifOv3pyesMw7n7w+PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vzk9W9sp0escPX84fSEJV67d2d6wjJf/96vpycs8Ztvf2l6whJH546mJyzxrZ/9anrCMp975vz0hCW+fO369IQlXvn7zekJS1w8u5vv4d7e3t6Lf7w7PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2jx6fGM7PWKFu+/cnp6wxOHBpekJy7x27/fTE5Z49vJz0xOW2G5PpycscfFkd/+h/3G6m+fiM4fPTk9Y4uHjB9MTltjVs2Nvb29v/8zB9IQldvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrY3xxMb1jivftXpyessf/E9IJljs4dTU9Y4vDg0vSEJR5vT6YnLHF6dnf/oZ/eXpiewP9gV7/Px9uH0xOWuf/O7ekJS+zuqQgAwLsmFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASJvT05e30yNWePT9H0xPWOLs174yPWGdMwfTC5bY3nx5esISm+ufn56wxtv3phcs8/C7P5qesMS5r352esISpx/51PSEJc789MXpCetceM/0giXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAADpvx9umTWu9YozAAAAAElFTkSuQmCC" id="image2d7dda09a7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8c5e2a6a5b" d="M 0 0 
+       <path id="me30f276119" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8c5e2a6a5b" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me30f276119" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m564702f0c8" d="M 0 0 
+       <path id="m0e5f07caef" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m564702f0c8" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e5f07caef" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1225,10 +1225,10 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- +0 -->
+    <!-- +1 -->
     <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1404,10 +1404,10 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- +4 -->
+    <!-- +5 -->
     <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image2556eddb28" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image0a7c5aeb41" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3f2b12b95d" d="M 0 0 
+       <path id="m1158211d4c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3f2b12b95d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1158211d4c" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3f2b12b95d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1158211d4c" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3f2b12b95d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1158211d4c" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3f2b12b95d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1158211d4c" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3f2b12b95d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1158211d4c" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.844609 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(47.059766 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,16 +2870,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="ped6e7d4958">
+  <clipPath id="p69daa5491c">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p16c5d5a47d)">
+   <g clip-path="url(#p4b354ca2db)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image01369b88a4" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image9138cffa41" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m67a4cf9836" d="M 0 0 
+       <path id="mb87f8413e9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m67a4cf9836" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m67a4cf9836" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m67a4cf9836" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m67a4cf9836" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m67a4cf9836" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m67a4cf9836" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m67a4cf9836" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m67a4cf9836" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m67a4cf9836" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m67a4cf9836" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m67a4cf9836" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m67a4cf9836" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb87f8413e9" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m460237052a" d="M 0 0 
+       <path id="ma4b1ea6b53" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m460237052a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma4b1ea6b53" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image8356163aef" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image7f20b5b0b6" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4ae08881cd" d="M 0 0 
+       <path id="md8b2cbd55a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4ae08881cd" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8b2cbd55a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4ae08881cd" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8b2cbd55a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4ae08881cd" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8b2cbd55a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4ae08881cd" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8b2cbd55a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4ae08881cd" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8b2cbd55a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.775937 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2872,14 +2872,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p16c5d5a47d">
+  <clipPath id="p4b354ca2db">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.848125pt" height="386.202469pt" viewBox="0 0 568.848125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.848125 386.202469 
-L 568.848125 0 
+L 568.591094 386.202469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.549062 104.1264 
-L 291.174062 104.1264 
-L 291.174062 74.7432 
-L 186.549062 74.7432 
+    <path d="M 186.420547 104.1264 
+L 291.045547 104.1264 
+L 291.045547 74.7432 
+L 186.420547 74.7432 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.174062 104.1264 
-L 395.799062 104.1264 
-L 395.799062 74.7432 
-L 291.174062 74.7432 
+    <path d="M 291.045547 104.1264 
+L 395.670547 104.1264 
+L 395.670547 74.7432 
+L 291.045547 74.7432 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.799062 104.1264 
-L 500.424062 104.1264 
-L 500.424062 74.7432 
-L 395.799062 74.7432 
+    <path d="M 395.670547 104.1264 
+L 500.295547 104.1264 
+L 500.295547 74.7432 
+L 395.670547 74.7432 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.549062 133.5096 
-L 291.174062 133.5096 
-L 291.174062 104.1264 
-L 186.549062 104.1264 
+    <path d="M 186.420547 133.5096 
+L 291.045547 133.5096 
+L 291.045547 104.1264 
+L 186.420547 104.1264 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.174062 133.5096 
-L 395.799062 133.5096 
-L 395.799062 104.1264 
-L 291.174062 104.1264 
+    <path d="M 291.045547 133.5096 
+L 395.670547 133.5096 
+L 395.670547 104.1264 
+L 291.045547 104.1264 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.799062 133.5096 
-L 500.424062 133.5096 
-L 500.424062 104.1264 
-L 395.799062 104.1264 
+    <path d="M 395.670547 133.5096 
+L 500.295547 133.5096 
+L 500.295547 104.1264 
+L 395.670547 104.1264 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.549062 162.8928 
-L 291.174062 162.8928 
-L 291.174062 133.5096 
-L 186.549062 133.5096 
+    <path d="M 186.420547 162.8928 
+L 291.045547 162.8928 
+L 291.045547 133.5096 
+L 186.420547 133.5096 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.174062 162.8928 
-L 395.799062 162.8928 
-L 395.799062 133.5096 
-L 291.174062 133.5096 
+    <path d="M 291.045547 162.8928 
+L 395.670547 162.8928 
+L 395.670547 133.5096 
+L 291.045547 133.5096 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.799062 162.8928 
-L 500.424062 162.8928 
-L 500.424062 133.5096 
-L 395.799062 133.5096 
+    <path d="M 395.670547 162.8928 
+L 500.295547 162.8928 
+L 500.295547 133.5096 
+L 395.670547 133.5096 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.549062 192.276 
-L 291.174062 192.276 
-L 291.174062 162.8928 
-L 186.549062 162.8928 
+    <path d="M 186.420547 192.276 
+L 291.045547 192.276 
+L 291.045547 162.8928 
+L 186.420547 162.8928 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.174062 192.276 
-L 395.799062 192.276 
-L 395.799062 162.8928 
-L 291.174062 162.8928 
+    <path d="M 291.045547 192.276 
+L 395.670547 192.276 
+L 395.670547 162.8928 
+L 291.045547 162.8928 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.799062 192.276 
-L 500.424062 192.276 
-L 500.424062 162.8928 
-L 395.799062 162.8928 
+    <path d="M 395.670547 192.276 
+L 500.295547 192.276 
+L 500.295547 162.8928 
+L 395.670547 162.8928 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.549062 221.6592 
-L 291.174062 221.6592 
-L 291.174062 192.276 
-L 186.549062 192.276 
+    <path d="M 186.420547 221.6592 
+L 291.045547 221.6592 
+L 291.045547 192.276 
+L 186.420547 192.276 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.174062 221.6592 
-L 395.799062 221.6592 
-L 395.799062 192.276 
-L 291.174062 192.276 
+    <path d="M 291.045547 221.6592 
+L 395.670547 221.6592 
+L 395.670547 192.276 
+L 291.045547 192.276 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.799062 221.6592 
-L 500.424062 221.6592 
-L 500.424062 192.276 
-L 395.799062 192.276 
+    <path d="M 395.670547 221.6592 
+L 500.295547 221.6592 
+L 500.295547 192.276 
+L 395.670547 192.276 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.549062 251.0424 
-L 291.174062 251.0424 
-L 291.174062 221.6592 
-L 186.549062 221.6592 
+    <path d="M 186.420547 251.0424 
+L 291.045547 251.0424 
+L 291.045547 221.6592 
+L 186.420547 221.6592 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.174062 251.0424 
-L 395.799062 251.0424 
-L 395.799062 221.6592 
-L 291.174062 221.6592 
+    <path d="M 291.045547 251.0424 
+L 395.670547 251.0424 
+L 395.670547 221.6592 
+L 291.045547 221.6592 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.799062 251.0424 
-L 500.424062 251.0424 
-L 500.424062 221.6592 
-L 395.799062 221.6592 
+    <path d="M 395.670547 251.0424 
+L 500.295547 251.0424 
+L 500.295547 221.6592 
+L 395.670547 221.6592 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.549062 280.4256 
-L 291.174062 280.4256 
-L 291.174062 251.0424 
-L 186.549062 251.0424 
+    <path d="M 186.420547 280.4256 
+L 291.045547 280.4256 
+L 291.045547 251.0424 
+L 186.420547 251.0424 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.174062 280.4256 
-L 395.799062 280.4256 
-L 395.799062 251.0424 
-L 291.174062 251.0424 
+    <path d="M 291.045547 280.4256 
+L 395.670547 280.4256 
+L 395.670547 251.0424 
+L 291.045547 251.0424 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.799062 280.4256 
-L 500.424062 280.4256 
-L 500.424062 251.0424 
-L 395.799062 251.0424 
+    <path d="M 395.670547 280.4256 
+L 500.295547 280.4256 
+L 500.295547 251.0424 
+L 395.670547 251.0424 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.549062 309.8088 
-L 291.174062 309.8088 
-L 291.174062 280.4256 
-L 186.549062 280.4256 
+    <path d="M 186.420547 309.8088 
+L 291.045547 309.8088 
+L 291.045547 280.4256 
+L 186.420547 280.4256 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.174062 309.8088 
-L 395.799062 309.8088 
-L 395.799062 280.4256 
-L 291.174062 280.4256 
+    <path d="M 291.045547 309.8088 
+L 395.670547 309.8088 
+L 395.670547 280.4256 
+L 291.045547 280.4256 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.799062 309.8088 
-L 500.424062 309.8088 
-L 500.424062 280.4256 
-L 395.799062 280.4256 
+    <path d="M 395.670547 309.8088 
+L 500.295547 309.8088 
+L 500.295547 280.4256 
+L 395.670547 280.4256 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.549062 339.192 
-L 291.174062 339.192 
-L 291.174062 309.8088 
-L 186.549062 309.8088 
+    <path d="M 186.420547 339.192 
+L 291.045547 339.192 
+L 291.045547 309.8088 
+L 186.420547 309.8088 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.174062 339.192 
-L 395.799062 339.192 
-L 395.799062 309.8088 
-L 291.174062 309.8088 
+    <path d="M 291.045547 339.192 
+L 395.670547 339.192 
+L 395.670547 309.8088 
+L 291.045547 309.8088 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.799062 339.192 
-L 500.424062 339.192 
-L 500.424062 309.8088 
-L 395.799062 309.8088 
+    <path d="M 395.670547 339.192 
+L 500.295547 339.192 
+L 500.295547 309.8088 
+L 395.670547 309.8088 
 z
-" clip-path="url(#pc8a2fb006e)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4dd9a07de4)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.536328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.820547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.392656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.744375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.474062 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.410313 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.851562 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.476562 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.112187 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.410313 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.396563 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.476562 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.805312 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.410313 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.396563 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.476562 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.837812 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.410313 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.396563 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.476562 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.375312 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.410313 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,106 +1552,22 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.396563 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.476562 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- miniz_oxide -->
-    <g transform="translate(110.681562 238.44705) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-6e" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063 
-L 3263 -1509 
-L -63 -1509 
-L -63 -1063 
-L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-78" d="M 3513 3500 
-L 2247 1797 
-L 3578 0 
-L 2900 0 
-L 1881 1375 
-L 863 0 
-L 184 0 
-L 1544 1831 
-L 300 3500 
-L 978 3500 
-L 1906 2253 
-L 2834 3500 
-L 3513 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-6d"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
-     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- 0.322 -->
-    <g transform="translate(227.410313 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(338.396563 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 532 -->
-    <g transform="translate(440.476562 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.183437 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,9 +1674,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_26">
     <!-- 0.332 -->
-    <g transform="translate(226.209688 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.081172 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1852,43 +1768,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- 35 -->
-    <g transform="translate(337.920312 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 264 -->
-    <g transform="translate(439.762187 267.9415) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 36 -->
+    <g transform="translate(337.791797 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-36" d="M 2316 2303 
 Q 2000 2303 1842 2098 
@@ -1920,34 +1802,106 @@ Q 2900 4744 3203 4694
 Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 263 -->
+    <g transform="translate(439.633672 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- miniz_oxide -->
+    <g transform="translate(110.553047 267.83025) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(125.195312 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-7a" transform="translate(216.357422 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(268.847656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.847656 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(376.904297 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(436.083984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(463.867188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- 0.322 -->
+    <g transform="translate(227.281797 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- 36 -->
+    <g transform="translate(338.268047 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 532 -->
+    <g transform="translate(440.348047 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.298437 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2012,7 +1966,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.410313 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2022,21 +1976,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.396563 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.021563 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.893047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.519687 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2047,7 +2001,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.410313 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2057,13 +2011,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.941562 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.111562 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2079,7 +2033,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.025781 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.897266 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2193,7 +2147,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-02T03:14:29Z  ·  Linux chungus x86_64  ·  commit addf545a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-02T23:35:31Z  ·  Linux chungus x86_64  ·  commit 40fc2855  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2334,14 +2288,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2380,110 +2334,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3133.007812 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3196.484375 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3231.689453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3295.3125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3358.935547 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3422.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3483.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.412109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3642.773438 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.080078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3856.738281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.078125 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.259766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.439453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4140.962891 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.076172 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4215.767578 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.550781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.353516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4429.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.355469 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.046875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.226562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4649.849609 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.636719 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.259766 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4808.882812 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4840.669922 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.292969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.376953 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.240234 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5097.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.630859 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.417969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.992188 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5256.779297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5295.988281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.367188 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.230469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.412109 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5522.791016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.267578 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.646484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.123047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.501953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5815.710938 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.498047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.074219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.486328 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.009766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.486328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.548828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6337.927734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6369.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6421.814453 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.472656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6609.949219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.427734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.609375 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6825.818359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.509766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.296875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.410156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6993.689453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7032.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7060.681641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7121.863281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.650391 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.533203 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7328.796875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.320312 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.416016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7627.828125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.611328 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7718.990234 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7746.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7798.873047 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.082031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7865.865234 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3225.683594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc8a2fb006e">
-   <rect x="81.924063" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p4dd9a07de4">
+   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.710781pt" height="386.202469pt" viewBox="0 0 570.710781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.280469pt" height="386.202469pt" viewBox="0 0 568.280469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.710781 386.202469 
-L 570.710781 0 
+L 568.280469 386.202469 
+L 568.280469 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.480391 104.1264 
-L 292.105391 104.1264 
-L 292.105391 74.7432 
-L 187.480391 74.7432 
+    <path d="M 186.265234 104.1264 
+L 290.890234 104.1264 
+L 290.890234 74.7432 
+L 186.265234 74.7432 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.105391 104.1264 
-L 396.730391 104.1264 
-L 396.730391 74.7432 
-L 292.105391 74.7432 
+    <path d="M 290.890234 104.1264 
+L 395.515234 104.1264 
+L 395.515234 74.7432 
+L 290.890234 74.7432 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.730391 104.1264 
-L 501.355391 104.1264 
-L 501.355391 74.7432 
-L 396.730391 74.7432 
+    <path d="M 395.515234 104.1264 
+L 500.140234 104.1264 
+L 500.140234 74.7432 
+L 395.515234 74.7432 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.480391 133.5096 
-L 292.105391 133.5096 
-L 292.105391 104.1264 
-L 187.480391 104.1264 
+    <path d="M 186.265234 133.5096 
+L 290.890234 133.5096 
+L 290.890234 104.1264 
+L 186.265234 104.1264 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.105391 133.5096 
-L 396.730391 133.5096 
-L 396.730391 104.1264 
-L 292.105391 104.1264 
+    <path d="M 290.890234 133.5096 
+L 395.515234 133.5096 
+L 395.515234 104.1264 
+L 290.890234 104.1264 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.730391 133.5096 
-L 501.355391 133.5096 
-L 501.355391 104.1264 
-L 396.730391 104.1264 
+    <path d="M 395.515234 133.5096 
+L 500.140234 133.5096 
+L 500.140234 104.1264 
+L 395.515234 104.1264 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.480391 162.8928 
-L 292.105391 162.8928 
-L 292.105391 133.5096 
-L 187.480391 133.5096 
+    <path d="M 186.265234 162.8928 
+L 290.890234 162.8928 
+L 290.890234 133.5096 
+L 186.265234 133.5096 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.105391 162.8928 
-L 396.730391 162.8928 
-L 396.730391 133.5096 
-L 292.105391 133.5096 
+    <path d="M 290.890234 162.8928 
+L 395.515234 162.8928 
+L 395.515234 133.5096 
+L 290.890234 133.5096 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.730391 162.8928 
-L 501.355391 162.8928 
-L 501.355391 133.5096 
-L 396.730391 133.5096 
+    <path d="M 395.515234 162.8928 
+L 500.140234 162.8928 
+L 500.140234 133.5096 
+L 395.515234 133.5096 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.480391 192.276 
-L 292.105391 192.276 
-L 292.105391 162.8928 
-L 187.480391 162.8928 
+    <path d="M 186.265234 192.276 
+L 290.890234 192.276 
+L 290.890234 162.8928 
+L 186.265234 162.8928 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.105391 192.276 
-L 396.730391 192.276 
-L 396.730391 162.8928 
-L 292.105391 162.8928 
+    <path d="M 290.890234 192.276 
+L 395.515234 192.276 
+L 395.515234 162.8928 
+L 290.890234 162.8928 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.730391 192.276 
-L 501.355391 192.276 
-L 501.355391 162.8928 
-L 396.730391 162.8928 
+    <path d="M 395.515234 192.276 
+L 500.140234 192.276 
+L 500.140234 162.8928 
+L 395.515234 162.8928 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.480391 221.6592 
-L 292.105391 221.6592 
-L 292.105391 192.276 
-L 187.480391 192.276 
+    <path d="M 186.265234 221.6592 
+L 290.890234 221.6592 
+L 290.890234 192.276 
+L 186.265234 192.276 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.105391 221.6592 
-L 396.730391 221.6592 
-L 396.730391 192.276 
-L 292.105391 192.276 
+    <path d="M 290.890234 221.6592 
+L 395.515234 221.6592 
+L 395.515234 192.276 
+L 290.890234 192.276 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.730391 221.6592 
-L 501.355391 221.6592 
-L 501.355391 192.276 
-L 396.730391 192.276 
+    <path d="M 395.515234 221.6592 
+L 500.140234 221.6592 
+L 500.140234 192.276 
+L 395.515234 192.276 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.480391 251.0424 
-L 292.105391 251.0424 
-L 292.105391 221.6592 
-L 187.480391 221.6592 
+    <path d="M 186.265234 251.0424 
+L 290.890234 251.0424 
+L 290.890234 221.6592 
+L 186.265234 221.6592 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.105391 251.0424 
-L 396.730391 251.0424 
-L 396.730391 221.6592 
-L 292.105391 221.6592 
+    <path d="M 290.890234 251.0424 
+L 395.515234 251.0424 
+L 395.515234 221.6592 
+L 290.890234 221.6592 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.730391 251.0424 
-L 501.355391 251.0424 
-L 501.355391 221.6592 
-L 396.730391 221.6592 
+    <path d="M 395.515234 251.0424 
+L 500.140234 251.0424 
+L 500.140234 221.6592 
+L 395.515234 221.6592 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.480391 280.4256 
-L 292.105391 280.4256 
-L 292.105391 251.0424 
-L 187.480391 251.0424 
+    <path d="M 186.265234 280.4256 
+L 290.890234 280.4256 
+L 290.890234 251.0424 
+L 186.265234 251.0424 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.105391 280.4256 
-L 396.730391 280.4256 
-L 396.730391 251.0424 
-L 292.105391 251.0424 
+    <path d="M 290.890234 280.4256 
+L 395.515234 280.4256 
+L 395.515234 251.0424 
+L 290.890234 251.0424 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.730391 280.4256 
-L 501.355391 280.4256 
-L 501.355391 251.0424 
-L 396.730391 251.0424 
+    <path d="M 395.515234 280.4256 
+L 500.140234 280.4256 
+L 500.140234 251.0424 
+L 395.515234 251.0424 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.480391 309.8088 
-L 292.105391 309.8088 
-L 292.105391 280.4256 
-L 187.480391 280.4256 
+    <path d="M 186.265234 309.8088 
+L 290.890234 309.8088 
+L 290.890234 280.4256 
+L 186.265234 280.4256 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.105391 309.8088 
-L 396.730391 309.8088 
-L 396.730391 280.4256 
-L 292.105391 280.4256 
+    <path d="M 290.890234 309.8088 
+L 395.515234 309.8088 
+L 395.515234 280.4256 
+L 290.890234 280.4256 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.730391 309.8088 
-L 501.355391 309.8088 
-L 501.355391 280.4256 
-L 396.730391 280.4256 
+    <path d="M 395.515234 309.8088 
+L 500.140234 309.8088 
+L 500.140234 280.4256 
+L 395.515234 280.4256 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.480391 339.192 
-L 292.105391 339.192 
-L 292.105391 309.8088 
-L 187.480391 309.8088 
+    <path d="M 186.265234 339.192 
+L 290.890234 339.192 
+L 290.890234 309.8088 
+L 186.265234 309.8088 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.105391 339.192 
-L 396.730391 339.192 
-L 396.730391 309.8088 
-L 292.105391 309.8088 
+    <path d="M 290.890234 339.192 
+L 395.515234 339.192 
+L 395.515234 309.8088 
+L 290.890234 309.8088 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.730391 339.192 
-L 501.355391 339.192 
-L 501.355391 309.8088 
-L 396.730391 309.8088 
+    <path d="M 395.515234 339.192 
+L 500.140234 339.192 
+L 500.140234 309.8088 
+L 395.515234 309.8088 
 z
-" clip-path="url(#pda03e5e3d5)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfc6b3c0f6d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.467656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.2525 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.751875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.536719 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.323984 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.108828 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.675703 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.460547 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.405391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.190234 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.341641 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.782891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.567734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.407891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.043516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.828359 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.341641 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.327891 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.407891 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.736641 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.521484 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.341641 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.327891 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.407891 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.769141 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.553984 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.341641 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.327891 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.407891 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.306641 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.091484 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.341641 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.327891 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.407891 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.114766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.899609 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1676,7 +1676,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.332 -->
-    <g transform="translate(227.141016 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(225.925859 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1769,60 +1769,51 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(338.851641 238.5583) scale(0.08 -0.08)">
+    <!-- 37 -->
+    <g transform="translate(337.636484 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 181 -->
-    <g transform="translate(440.693516 238.5583) scale(0.08 -0.08)">
+    <!-- 258 -->
+    <g transform="translate(439.478359 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
@@ -1865,14 +1856,14 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(111.612891 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(110.397734 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1931,7 +1922,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(228.341641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1941,14 +1932,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(339.327891 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 532 -->
-    <g transform="translate(441.407891 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.192734 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1956,7 +1947,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.229766 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.014609 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2021,7 +2012,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.341641 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2031,21 +2022,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.327891 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.112734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.952891 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.737734 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.451016 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.235859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2056,7 +2047,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.341641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.126484 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2066,13 +2057,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.872891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.657734 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.042891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.827734 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2088,7 +2079,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.957109 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.741953 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2161,6 +2152,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2202,7 +2223,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-02T15:47:48Z  ·  Linux chungus x86_64  ·  commit 2aea7107  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2341,16 +2362,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2389,110 +2410,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3255.957031 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3319.580078 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3383.203125 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3446.826172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3510.449219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3542.236328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3574.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3605.810547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3637.597656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3669.384766 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3697.167969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3758.691406 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3819.970703 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3883.349609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3946.826172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3985.689453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4046.871094 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4106.050781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4167.574219 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4208.6875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4242.378906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4270.162109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4331.685547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4392.964844 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4456.34375 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4519.966797 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4553.658203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4612.837891 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4676.460938 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4708.248047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4771.871094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4835.494141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4867.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4930.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4966.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5005.851562 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5060.832031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5124.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5156.242188 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5188.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5219.816406 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5251.603516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5283.390625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5322.599609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5385.978516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5424.841797 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5486.023438 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5549.402344 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5612.878906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5676.257812 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5739.734375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5803.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5842.322266 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5874.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5957.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5989.685547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6087.097656 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6148.621094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6212.097656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6239.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6364.539062 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6396.326172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6448.425781 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6511.804688 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6573.083984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6636.560547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6688.660156 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6752.039062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6813.220703 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6852.429688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6886.121094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6917.908203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6959.021484 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7020.300781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7059.509766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7087.292969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7148.474609 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7180.261719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7208.044922 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7260.144531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7291.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7355.408203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7416.931641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7456.140625 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7517.664062 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7557.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7654.439453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7682.222656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7773.384766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7825.484375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7864.693359 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7892.476562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pda03e5e3d5">
-   <rect x="82.855391" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pfc6b3c0f6d">
+   <rect x="81.640234" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-02T03:14:29Z",
+  "date": "2026-07-02T23:35:31Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "addf545a",
+  "git_commit": "40fc2855",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 49.16,
-   "decompress_mbps": 188.85
+   "compress_mbps": 52.43,
+   "decompress_mbps": 189.31
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 38.13,
-   "decompress_mbps": 214.78
+   "compress_mbps": 40.49,
+   "decompress_mbps": 216.25
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.91,
-   "decompress_mbps": 234.81
+   "compress_mbps": 37.08,
+   "decompress_mbps": 235.76
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.91,
-   "decompress_mbps": 236.89
+   "compress_mbps": 29.04,
+   "decompress_mbps": 237.64
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 27.03,
-   "decompress_mbps": 239.25
+   "compress_mbps": 28.13,
+   "decompress_mbps": 239.01
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.12,
-   "decompress_mbps": 245.84
+   "compress_mbps": 26.03,
+   "decompress_mbps": 246.49
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 20.25,
-   "decompress_mbps": 246.34
+   "compress_mbps": 20.87,
+   "decompress_mbps": 246.74
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.26,
-   "decompress_mbps": 245.82
+   "compress_mbps": 9.49,
+   "decompress_mbps": 245.99
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 53059,
    "ratio": 0.3489,
-   "compress_mbps": 3.14,
-   "decompress_mbps": 245.65
+   "compress_mbps": 3.19,
+   "decompress_mbps": 245.22
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 45.27,
-   "decompress_mbps": 181.0
+   "compress_mbps": 47.82,
+   "decompress_mbps": 181.25
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 196.72
+   "compress_mbps": 37.77,
+   "decompress_mbps": 196.41
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 214.61
+   "compress_mbps": 35.09,
+   "decompress_mbps": 214.41
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 218.27
+   "compress_mbps": 26.78,
+   "decompress_mbps": 218.69
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 219.47
+   "compress_mbps": 26.18,
+   "decompress_mbps": 220.2
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 24.07,
-   "decompress_mbps": 223.68
+   "compress_mbps": 24.77,
+   "decompress_mbps": 225.83
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 21.54,
-   "decompress_mbps": 223.98
+   "compress_mbps": 22.21,
+   "decompress_mbps": 225.79
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.98,
-   "decompress_mbps": 223.97
+   "compress_mbps": 8.81,
+   "decompress_mbps": 226.29
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 47620,
    "ratio": 0.3804,
-   "compress_mbps": 3.37,
-   "decompress_mbps": 224.27
+   "compress_mbps": 3.34,
+   "decompress_mbps": 225.07
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 38.83,
-   "decompress_mbps": 217.63
+   "compress_mbps": 39.58,
+   "decompress_mbps": 217.52
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 33.95,
-   "decompress_mbps": 222.93
+   "compress_mbps": 34.7,
+   "decompress_mbps": 225.37
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 33.04,
-   "decompress_mbps": 227.9
+   "compress_mbps": 33.6,
+   "decompress_mbps": 228.91
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.9,
-   "decompress_mbps": 236.58
+   "compress_mbps": 31.37,
+   "decompress_mbps": 238.26
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.42,
-   "decompress_mbps": 244.22
+   "compress_mbps": 30.98,
+   "decompress_mbps": 245.17
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.46,
-   "decompress_mbps": 244.35
+   "compress_mbps": 30.04,
+   "decompress_mbps": 246.61
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.93,
-   "decompress_mbps": 248.2
+   "compress_mbps": 26.41,
+   "decompress_mbps": 249.72
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.77,
-   "decompress_mbps": 247.98
+   "compress_mbps": 9.57,
+   "decompress_mbps": 249.44
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7801,
    "ratio": 0.3171,
-   "compress_mbps": 4.15,
-   "decompress_mbps": 247.66
+   "compress_mbps": 4.19,
+   "decompress_mbps": 248.6
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 25.95,
-   "decompress_mbps": 152.58
+   "compress_mbps": 25.98,
+   "decompress_mbps": 151.49
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.25,
-   "decompress_mbps": 151.66
+   "compress_mbps": 23.71,
+   "decompress_mbps": 153.59
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.96,
-   "decompress_mbps": 155.05
+   "compress_mbps": 23.36,
+   "decompress_mbps": 156.95
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.73,
-   "decompress_mbps": 157.92
+   "compress_mbps": 22.07,
+   "decompress_mbps": 159.41
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.56,
-   "decompress_mbps": 158.78
+   "compress_mbps": 21.86,
+   "decompress_mbps": 160.79
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 154.83
+   "compress_mbps": 21.43,
+   "decompress_mbps": 161.52
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.31,
-   "decompress_mbps": 159.96
+   "compress_mbps": 19.27,
+   "decompress_mbps": 161.42
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.1,
-   "decompress_mbps": 160.09
+   "compress_mbps": 6.96,
+   "decompress_mbps": 162.57
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 4.09,
-   "decompress_mbps": 160.11
+   "compress_mbps": 4.1,
+   "decompress_mbps": 162.69
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 71.27
+   "compress_mbps": 12.37,
+   "decompress_mbps": 71.35
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.7,
-   "decompress_mbps": 70.61
+   "compress_mbps": 11.8,
+   "decompress_mbps": 71.64
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.63,
-   "decompress_mbps": 70.49
+   "compress_mbps": 11.73,
+   "decompress_mbps": 71.85
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.46,
-   "decompress_mbps": 71.06
+   "compress_mbps": 11.51,
+   "decompress_mbps": 72.27
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.5,
-   "decompress_mbps": 71.15
+   "compress_mbps": 11.51,
+   "decompress_mbps": 72.27
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 71.45
+   "compress_mbps": 11.5,
+   "decompress_mbps": 72.64
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.23,
-   "decompress_mbps": 71.27
+   "compress_mbps": 11.26,
+   "decompress_mbps": 72.68
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.87,
-   "decompress_mbps": 71.47
+   "compress_mbps": 3.79,
+   "decompress_mbps": 72.64
   },
   {
    "compressor": "native",
@@ -455,7 +455,7 @@
    "out_size": 1205,
    "ratio": 0.3238,
    "compress_mbps": 3.42,
-   "decompress_mbps": 71.35
+   "decompress_mbps": 72.78
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 97.35,
-   "decompress_mbps": 345.48
+   "compress_mbps": 107.69,
+   "decompress_mbps": 345.54
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 63.72,
-   "decompress_mbps": 373.91
+   "compress_mbps": 68.46,
+   "decompress_mbps": 375.66
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 62.6,
-   "decompress_mbps": 396.15
+   "compress_mbps": 66.86,
+   "decompress_mbps": 397.88
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 59.49,
-   "decompress_mbps": 416.35
+   "compress_mbps": 63.0,
+   "decompress_mbps": 417.91
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 58.16,
-   "decompress_mbps": 400.31
+   "compress_mbps": 60.54,
+   "decompress_mbps": 401.74
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 54.48,
-   "decompress_mbps": 414.43
+   "compress_mbps": 57.17,
+   "decompress_mbps": 415.76
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.71,
-   "decompress_mbps": 414.68
+   "compress_mbps": 20.61,
+   "decompress_mbps": 418.45
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.37,
-   "decompress_mbps": 423.15
+   "compress_mbps": 7.41,
+   "decompress_mbps": 423.17
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 183445,
    "ratio": 0.1781,
-   "compress_mbps": 2.62,
-   "decompress_mbps": 426.48
+   "compress_mbps": 2.6,
+   "decompress_mbps": 425.84
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 54.81,
-   "decompress_mbps": 198.43
+   "compress_mbps": 58.19,
+   "decompress_mbps": 199.07
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 41.84,
-   "decompress_mbps": 215.2
+   "compress_mbps": 43.63,
+   "decompress_mbps": 215.32
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 38.27,
-   "decompress_mbps": 239.61
+   "compress_mbps": 39.25,
+   "decompress_mbps": 239.89
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 30.28,
-   "decompress_mbps": 244.1
+   "compress_mbps": 31.25,
+   "decompress_mbps": 244.25
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 29.24,
-   "decompress_mbps": 246.31
+   "compress_mbps": 30.34,
+   "decompress_mbps": 245.3
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 27.11,
-   "decompress_mbps": 250.02
+   "compress_mbps": 28.04,
+   "decompress_mbps": 252.45
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 22.45,
-   "decompress_mbps": 252.69
+   "compress_mbps": 23.07,
+   "decompress_mbps": 251.37
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 10.03,
-   "decompress_mbps": 252.42
+   "compress_mbps": 10.3,
+   "decompress_mbps": 253.05
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 140996,
    "ratio": 0.3304,
-   "compress_mbps": 3.14,
-   "decompress_mbps": 252.25
+   "compress_mbps": 3.2,
+   "decompress_mbps": 252.96
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 46.41,
-   "decompress_mbps": 171.64
+   "compress_mbps": 49.96,
+   "decompress_mbps": 172.87
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 36.21,
-   "decompress_mbps": 190.5
+   "compress_mbps": 37.95,
+   "decompress_mbps": 192.27
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 33.21,
-   "decompress_mbps": 210.16
+   "compress_mbps": 34.86,
+   "decompress_mbps": 211.34
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.92,
-   "decompress_mbps": 213.3
+   "compress_mbps": 24.66,
+   "decompress_mbps": 215.4
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 23.01,
-   "decompress_mbps": 212.51
+   "compress_mbps": 23.77,
+   "decompress_mbps": 214.74
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 215.9
+   "compress_mbps": 21.91,
+   "decompress_mbps": 218.25
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 18.35,
-   "decompress_mbps": 216.65
+   "compress_mbps": 18.89,
+   "decompress_mbps": 219.15
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.11,
-   "decompress_mbps": 217.36
+   "compress_mbps": 8.39,
+   "decompress_mbps": 218.4
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 190711,
    "ratio": 0.3958,
-   "compress_mbps": 2.92,
-   "decompress_mbps": 216.31
+   "compress_mbps": 2.97,
+   "decompress_mbps": 218.38
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 152.75,
-   "decompress_mbps": 475.58
+   "compress_mbps": 158.82,
+   "decompress_mbps": 472.86
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 113.07,
-   "decompress_mbps": 501.92
+   "compress_mbps": 117.33,
+   "decompress_mbps": 504.45
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 96.86,
-   "decompress_mbps": 537.41
+   "compress_mbps": 100.19,
+   "decompress_mbps": 542.2
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 77.28,
-   "decompress_mbps": 454.94
+   "compress_mbps": 79.41,
+   "decompress_mbps": 459.44
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 74.19,
-   "decompress_mbps": 494.14
+   "compress_mbps": 75.98,
+   "decompress_mbps": 490.99
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 66.07,
-   "decompress_mbps": 538.65
+   "compress_mbps": 67.53,
+   "decompress_mbps": 538.52
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53529,
    "ratio": 0.1043,
-   "compress_mbps": 36.63,
-   "decompress_mbps": 573.2
+   "compress_mbps": 38.29,
+   "decompress_mbps": 573.97
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.34,
-   "decompress_mbps": 616.46
+   "compress_mbps": 16.68,
+   "decompress_mbps": 617.07
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 628.27
+   "compress_mbps": 3.27,
+   "decompress_mbps": 629.52
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 29.1,
-   "decompress_mbps": 185.41
+   "compress_mbps": 29.0,
+   "decompress_mbps": 185.59
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 26.03,
-   "decompress_mbps": 190.81
+   "compress_mbps": 26.66,
+   "decompress_mbps": 190.21
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 193.55
+   "compress_mbps": 26.1,
+   "decompress_mbps": 193.42
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.17,
-   "decompress_mbps": 200.99
+   "compress_mbps": 23.6,
+   "decompress_mbps": 200.54
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.72,
-   "decompress_mbps": 210.77
+   "compress_mbps": 23.2,
+   "decompress_mbps": 210.17
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.63,
-   "decompress_mbps": 215.04
+   "compress_mbps": 21.95,
+   "decompress_mbps": 214.53
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.55,
-   "decompress_mbps": 216.11
+   "compress_mbps": 17.66,
+   "decompress_mbps": 215.24
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.25,
-   "decompress_mbps": 218.24
+   "compress_mbps": 5.24,
+   "decompress_mbps": 217.26
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12501,
    "ratio": 0.3269,
-   "compress_mbps": 3.29,
-   "decompress_mbps": 220.21
+   "compress_mbps": 3.3,
+   "decompress_mbps": 220.51
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 13.9,
-   "decompress_mbps": 78.06
+   "compress_mbps": 13.77,
+   "decompress_mbps": 77.33
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.93,
-   "decompress_mbps": 77.85
+   "compress_mbps": 13.18,
+   "decompress_mbps": 77.16
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 77.84
+   "compress_mbps": 13.18,
+   "decompress_mbps": 77.22
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.75,
-   "decompress_mbps": 78.85
+   "compress_mbps": 12.93,
+   "decompress_mbps": 78.13
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.74,
-   "decompress_mbps": 78.36
+   "compress_mbps": 13.02,
+   "decompress_mbps": 77.99
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.73,
-   "decompress_mbps": 78.56
+   "compress_mbps": 13.02,
+   "decompress_mbps": 78.02
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.6,
-   "decompress_mbps": 78.42
+   "compress_mbps": 12.89,
+   "decompress_mbps": 78.0
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 78.57
+   "compress_mbps": 4.15,
+   "decompress_mbps": 78.16
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 3.91,
-   "decompress_mbps": 78.33
+   "compress_mbps": 3.96,
+   "decompress_mbps": 78.1
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 48.78,
-   "decompress_mbps": 175.86
+   "compress_mbps": 52.24,
+   "decompress_mbps": 176.18
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 37.75,
-   "decompress_mbps": 190.56
+   "compress_mbps": 39.85,
+   "decompress_mbps": 192.28
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 34.37,
-   "decompress_mbps": 211.79
+   "compress_mbps": 36.33,
+   "decompress_mbps": 213.09
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.33,
-   "decompress_mbps": 214.09
+   "compress_mbps": 26.86,
+   "decompress_mbps": 213.98
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 25.46,
-   "decompress_mbps": 214.39
+   "compress_mbps": 26.35,
+   "decompress_mbps": 214.12
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.22,
-   "decompress_mbps": 218.6
+   "compress_mbps": 24.14,
+   "decompress_mbps": 208.74
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 19.68,
-   "decompress_mbps": 219.87
+   "compress_mbps": 20.2,
+   "decompress_mbps": 218.73
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.68,
-   "decompress_mbps": 227.57
+   "compress_mbps": 9.16,
+   "decompress_mbps": 227.72
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3790405,
    "ratio": 0.3719,
-   "compress_mbps": 3.06,
-   "decompress_mbps": 221.09
+   "compress_mbps": 3.09,
+   "decompress_mbps": 230.3
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 62.0,
-   "decompress_mbps": 187.2
+   "compress_mbps": 68.81,
+   "decompress_mbps": 189.03
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 51.49,
-   "decompress_mbps": 199.3
+   "compress_mbps": 54.53,
+   "decompress_mbps": 194.11
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 48.13,
-   "decompress_mbps": 206.46
+   "compress_mbps": 50.93,
+   "decompress_mbps": 204.47
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 39.61,
-   "decompress_mbps": 211.97
+   "compress_mbps": 41.37,
+   "decompress_mbps": 211.85
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 37.7,
-   "decompress_mbps": 220.84
+   "compress_mbps": 39.37,
+   "decompress_mbps": 220.74
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 33.38,
-   "decompress_mbps": 225.37
+   "compress_mbps": 34.11,
+   "decompress_mbps": 227.83
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 20251341,
    "ratio": 0.3954,
-   "compress_mbps": 22.08,
-   "decompress_mbps": 219.69
+   "compress_mbps": 22.47,
+   "decompress_mbps": 224.97
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.76,
-   "decompress_mbps": 226.57
+   "compress_mbps": 7.02,
+   "decompress_mbps": 226.82
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18705121,
    "ratio": 0.3652,
-   "compress_mbps": 3.14,
-   "decompress_mbps": 225.93
+   "compress_mbps": 3.18,
+   "decompress_mbps": 223.21
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 60.66,
-   "decompress_mbps": 209.76
+   "compress_mbps": 68.63,
+   "decompress_mbps": 210.5
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 50.95,
-   "decompress_mbps": 215.52
+   "compress_mbps": 54.68,
+   "decompress_mbps": 217.81
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 44.74,
-   "decompress_mbps": 223.94
+   "compress_mbps": 47.49,
+   "decompress_mbps": 236.56
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 32.05,
-   "decompress_mbps": 209.62
+   "compress_mbps": 33.34,
+   "decompress_mbps": 210.6
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.39,
-   "decompress_mbps": 206.05
+   "compress_mbps": 31.61,
+   "decompress_mbps": 205.94
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.65,
-   "decompress_mbps": 212.23
+   "compress_mbps": 28.81,
+   "decompress_mbps": 212.9
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3704150,
    "ratio": 0.3715,
-   "compress_mbps": 20.48,
-   "decompress_mbps": 214.24
+   "compress_mbps": 21.5,
+   "decompress_mbps": 212.83
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 7.92,
-   "decompress_mbps": 229.17
+   "compress_mbps": 8.31,
+   "decompress_mbps": 228.85
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3594656,
    "ratio": 0.3605,
-   "compress_mbps": 2.92,
-   "decompress_mbps": 229.3
+   "compress_mbps": 2.99,
+   "decompress_mbps": 227.68
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 180.43,
-   "decompress_mbps": 538.19
+   "compress_mbps": 203.2,
+   "decompress_mbps": 605.06
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 120.12,
-   "decompress_mbps": 673.51
+   "compress_mbps": 124.51,
+   "decompress_mbps": 671.49
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 100.81,
-   "decompress_mbps": 751.03
+   "compress_mbps": 104.13,
+   "decompress_mbps": 749.4
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 86.41,
-   "decompress_mbps": 745.51
+   "compress_mbps": 90.57,
+   "decompress_mbps": 747.06
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 84.53,
-   "decompress_mbps": 829.64
+   "compress_mbps": 87.65,
+   "decompress_mbps": 831.4
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 76.85,
-   "decompress_mbps": 888.21
+   "compress_mbps": 79.75,
+   "decompress_mbps": 882.59
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3125083,
    "ratio": 0.0931,
-   "compress_mbps": 43.23,
-   "decompress_mbps": 899.32
+   "compress_mbps": 43.66,
+   "decompress_mbps": 904.67
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.64,
-   "decompress_mbps": 859.66
+   "compress_mbps": 23.09,
+   "decompress_mbps": 857.32
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 3024127,
    "ratio": 0.0901,
    "compress_mbps": 2.71,
-   "decompress_mbps": 916.02
+   "decompress_mbps": 897.43
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 45.38,
-   "decompress_mbps": 130.42
+   "compress_mbps": 48.56,
+   "decompress_mbps": 129.68
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 38.79,
-   "decompress_mbps": 133.17
+   "compress_mbps": 41.04,
+   "decompress_mbps": 132.57
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 37.83,
-   "decompress_mbps": 137.18
+   "compress_mbps": 39.47,
+   "decompress_mbps": 137.38
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 31.15,
-   "decompress_mbps": 145.95
+   "compress_mbps": 32.26,
+   "decompress_mbps": 144.3
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 30.57,
-   "decompress_mbps": 150.45
+   "compress_mbps": 31.78,
+   "decompress_mbps": 149.87
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 29.18,
-   "decompress_mbps": 153.38
+   "compress_mbps": 30.52,
+   "decompress_mbps": 152.31
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3232621,
    "ratio": 0.5254,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 153.96
+   "compress_mbps": 26.68,
+   "decompress_mbps": 152.75
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.7,
-   "decompress_mbps": 160.9
+   "compress_mbps": 6.94,
+   "decompress_mbps": 159.67
   },
   {
    "compressor": "native",
@@ -4415,7 +4415,7 @@
    "out_size": 3054135,
    "ratio": 0.4964,
    "compress_mbps": 3.73,
-   "decompress_mbps": 158.03
+   "decompress_mbps": 156.68
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 73.11,
-   "decompress_mbps": 218.92
+   "compress_mbps": 78.48,
+   "decompress_mbps": 230.83
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 55.49,
-   "decompress_mbps": 226.51
+   "compress_mbps": 58.46,
+   "decompress_mbps": 239.63
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 54.25,
-   "decompress_mbps": 232.36
+   "compress_mbps": 57.04,
+   "decompress_mbps": 244.7
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 48.72,
-   "decompress_mbps": 243.87
+   "compress_mbps": 51.24,
+   "decompress_mbps": 257.87
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 48.02,
-   "decompress_mbps": 245.86
+   "compress_mbps": 50.97,
+   "decompress_mbps": 261.27
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 49.1,
-   "decompress_mbps": 254.54
+   "compress_mbps": 50.51,
+   "decompress_mbps": 270.07
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 45.74,
-   "decompress_mbps": 258.33
+   "compress_mbps": 47.45,
+   "decompress_mbps": 274.44
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.92,
-   "decompress_mbps": 269.06
+   "compress_mbps": 12.73,
+   "decompress_mbps": 266.59
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3693258,
    "ratio": 0.3662,
-   "compress_mbps": 4.88,
-   "decompress_mbps": 275.29
+   "compress_mbps": 4.93,
+   "decompress_mbps": 270.67
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 60.29,
-   "decompress_mbps": 218.41
+   "compress_mbps": 65.8,
+   "decompress_mbps": 222.31
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 44.32,
-   "decompress_mbps": 250.64
+   "compress_mbps": 46.58,
+   "decompress_mbps": 233.51
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 38.09,
-   "decompress_mbps": 275.11
+   "compress_mbps": 38.94,
+   "decompress_mbps": 255.92
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 27.06,
-   "decompress_mbps": 264.59
+   "compress_mbps": 27.66,
+   "decompress_mbps": 263.99
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.7,
-   "decompress_mbps": 268.24
+   "compress_mbps": 25.28,
+   "decompress_mbps": 263.25
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.38,
-   "decompress_mbps": 294.83
+   "compress_mbps": 20.82,
+   "decompress_mbps": 273.97
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1868263,
    "ratio": 0.2819,
-   "compress_mbps": 13.11,
-   "decompress_mbps": 300.22
+   "compress_mbps": 13.3,
+   "decompress_mbps": 274.93
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.43,
-   "decompress_mbps": 277.06
+   "compress_mbps": 7.79,
+   "decompress_mbps": 290.98
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1793832,
    "ratio": 0.2707,
    "compress_mbps": 2.42,
-   "decompress_mbps": 294.33
+   "decompress_mbps": 294.05
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 87.96,
-   "decompress_mbps": 277.87
+   "compress_mbps": 94.08,
+   "decompress_mbps": 296.74
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 65.87,
-   "decompress_mbps": 314.96
+   "compress_mbps": 69.93,
+   "decompress_mbps": 316.41
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 60.59,
-   "decompress_mbps": 327.74
+   "compress_mbps": 63.24,
+   "decompress_mbps": 327.71
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 48.79,
-   "decompress_mbps": 336.48
+   "compress_mbps": 51.14,
+   "decompress_mbps": 338.14
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 47.85,
-   "decompress_mbps": 344.41
+   "compress_mbps": 49.44,
+   "decompress_mbps": 345.42
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 44.26,
-   "decompress_mbps": 354.85
+   "compress_mbps": 45.92,
+   "decompress_mbps": 355.03
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5829595,
    "ratio": 0.2698,
-   "compress_mbps": 32.82,
-   "decompress_mbps": 356.66
+   "compress_mbps": 33.82,
+   "decompress_mbps": 356.85
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.52,
-   "decompress_mbps": 330.8
+   "compress_mbps": 13.05,
+   "decompress_mbps": 329.52
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5225578,
    "ratio": 0.2419,
-   "compress_mbps": 3.56,
-   "decompress_mbps": 357.7
+   "compress_mbps": 3.59,
+   "decompress_mbps": 360.17
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 38.64,
-   "decompress_mbps": 128.04
+   "compress_mbps": 41.66,
+   "decompress_mbps": 129.7
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 132.4
+   "compress_mbps": 35.17,
+   "decompress_mbps": 131.93
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 32.0,
-   "decompress_mbps": 136.32
+   "compress_mbps": 33.34,
+   "decompress_mbps": 136.26
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 26.82,
-   "decompress_mbps": 138.91
+   "compress_mbps": 27.82,
+   "decompress_mbps": 139.59
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 26.23,
-   "decompress_mbps": 138.76
+   "compress_mbps": 27.14,
+   "decompress_mbps": 136.79
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 139.42
+   "compress_mbps": 26.42,
+   "decompress_mbps": 138.72
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 141.15
+   "compress_mbps": 25.16,
+   "decompress_mbps": 139.54
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.15,
-   "decompress_mbps": 141.4
+   "compress_mbps": 6.48,
+   "decompress_mbps": 136.49
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5301868,
    "ratio": 0.7311,
-   "compress_mbps": 3.67,
-   "decompress_mbps": 140.53
+   "compress_mbps": 3.71,
+   "decompress_mbps": 140.99
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 64.13,
-   "decompress_mbps": 214.56
+   "compress_mbps": 68.56,
+   "decompress_mbps": 226.92
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 49.57,
-   "decompress_mbps": 244.33
+   "compress_mbps": 52.25,
+   "decompress_mbps": 246.37
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 45.87,
-   "decompress_mbps": 263.93
+   "compress_mbps": 48.33,
+   "decompress_mbps": 266.34
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 36.49,
-   "decompress_mbps": 268.86
+   "compress_mbps": 38.52,
+   "decompress_mbps": 271.01
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 35.88,
-   "decompress_mbps": 274.67
+   "compress_mbps": 36.95,
+   "decompress_mbps": 275.61
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 281.73
+   "compress_mbps": 33.28,
+   "decompress_mbps": 283.4
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.78,
-   "decompress_mbps": 281.77
+   "compress_mbps": 25.3,
+   "decompress_mbps": 284.37
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.06,
-   "decompress_mbps": 270.17
+   "compress_mbps": 11.72,
+   "decompress_mbps": 284.09
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11868965,
    "ratio": 0.2863,
-   "compress_mbps": 3.22,
-   "decompress_mbps": 282.23
+   "compress_mbps": 3.28,
+   "decompress_mbps": 283.03
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 36.38,
-   "decompress_mbps": 126.85
+   "compress_mbps": 39.06,
+   "decompress_mbps": 125.53
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 35.2,
-   "decompress_mbps": 128.04
+   "compress_mbps": 37.96,
+   "decompress_mbps": 127.53
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 35.3,
-   "decompress_mbps": 129.22
+   "compress_mbps": 38.06,
+   "decompress_mbps": 128.86
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 117.65
+   "compress_mbps": 35.54,
+   "decompress_mbps": 116.3
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 118.81
+   "compress_mbps": 35.52,
+   "decompress_mbps": 117.88
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.02,
-   "decompress_mbps": 119.35
+   "compress_mbps": 35.51,
+   "decompress_mbps": 119.25
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 33.3,
-   "decompress_mbps": 119.46
+   "compress_mbps": 35.47,
+   "decompress_mbps": 118.53
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.78,
-   "decompress_mbps": 121.33
+   "compress_mbps": 4.88,
+   "decompress_mbps": 120.14
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5949045,
    "ratio": 0.702,
-   "compress_mbps": 4.44,
-   "decompress_mbps": 122.05
+   "compress_mbps": 4.61,
+   "decompress_mbps": 120.68
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 139.99,
-   "decompress_mbps": 423.97
+   "compress_mbps": 147.92,
+   "decompress_mbps": 450.55
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 97.67,
-   "decompress_mbps": 510.11
+   "compress_mbps": 101.83,
+   "decompress_mbps": 510.64
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 86.16,
-   "decompress_mbps": 516.87
+   "compress_mbps": 89.57,
+   "decompress_mbps": 566.43
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 69.69,
-   "decompress_mbps": 556.72
+   "compress_mbps": 71.43,
+   "decompress_mbps": 560.29
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 67.32,
-   "decompress_mbps": 610.23
+   "compress_mbps": 69.44,
+   "decompress_mbps": 611.56
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 61.63,
-   "decompress_mbps": 657.26
+   "compress_mbps": 63.74,
+   "decompress_mbps": 662.12
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 702400,
    "ratio": 0.1314,
-   "compress_mbps": 41.42,
-   "decompress_mbps": 669.34
+   "compress_mbps": 42.32,
+   "decompress_mbps": 671.79
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 19.95,
-   "decompress_mbps": 605.03
+   "compress_mbps": 20.28,
+   "decompress_mbps": 603.75
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 656466,
    "ratio": 0.1228,
-   "compress_mbps": 2.89,
-   "decompress_mbps": 662.33
+   "compress_mbps": 2.9,
+   "decompress_mbps": 669.89
   },
   {
    "compressor": "zlib",
@@ -17264,7 +17264,7 @@
    "level": 10,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.79,
+   "compress_mbps": 1.78,
    "decompress_mbps": null
   },
   {
@@ -17274,7 +17274,7 @@
    "level": 10,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.07,
+   "compress_mbps": 2.05,
    "decompress_mbps": null
   },
   {
@@ -17284,7 +17284,7 @@
    "level": 10,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 2.38,
+   "compress_mbps": 2.39,
    "decompress_mbps": null
   },
   {
@@ -17294,7 +17294,7 @@
    "level": 10,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.34,
    "decompress_mbps": null
   },
   {
@@ -17304,7 +17304,7 @@
    "level": 10,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 2.09,
+   "compress_mbps": 2.1,
    "decompress_mbps": null
   },
   {
@@ -17324,7 +17324,7 @@
    "level": 10,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.81,
+   "compress_mbps": 1.83,
    "decompress_mbps": null
   },
   {
@@ -17334,7 +17334,7 @@
    "level": 10,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.76,
+   "compress_mbps": 1.77,
    "decompress_mbps": null
   },
   {
@@ -17344,7 +17344,7 @@
    "level": 10,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 1.07,
+   "compress_mbps": 1.08,
    "decompress_mbps": null
   },
   {
@@ -17354,7 +17354,7 @@
    "level": 10,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.84,
+   "compress_mbps": 1.83,
    "decompress_mbps": null
   },
   {
@@ -17364,7 +17364,7 @@
    "level": 10,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.49,
+   "compress_mbps": 2.51,
    "decompress_mbps": null
   },
   {
@@ -17374,7 +17374,7 @@
    "level": 10,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.78,
+   "compress_mbps": 1.77,
    "decompress_mbps": null
   },
   {
@@ -17384,7 +17384,7 @@
    "level": 10,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.64,
+   "compress_mbps": 1.63,
    "decompress_mbps": null
   },
   {
@@ -17414,7 +17414,7 @@
    "level": 10,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 2.28,
+   "compress_mbps": 2.26,
    "decompress_mbps": null
   },
   {
@@ -17424,7 +17424,7 @@
    "level": 10,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 2.75,
+   "compress_mbps": 2.72,
    "decompress_mbps": null
   },
   {
@@ -17434,7 +17434,7 @@
    "level": 10,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 1.14,
+   "compress_mbps": 1.15,
    "decompress_mbps": null
   },
   {
@@ -17454,7 +17454,7 @@
    "level": 10,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.61,
+   "compress_mbps": 2.59,
    "decompress_mbps": null
   },
   {
@@ -17464,7 +17464,7 @@
    "level": 10,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.6,
+   "compress_mbps": 1.61,
    "decompress_mbps": null
   },
   {
@@ -17474,7 +17474,7 @@
    "level": 10,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.45,
+   "compress_mbps": 3.57,
    "decompress_mbps": null
   },
   {

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-02T15:47:48Z",
+  "date": "2026-07-03T00:31:25Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "2aea7107",
+  "git_commit": "e5a3c7f7",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,48 +14,48 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 51.39,
-   "decompress_mbps": 112.02
+   "compress_mbps": 54.97,
+   "decompress_mbps": 187.38
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 2,
-   "out_size": 56050,
-   "ratio": 0.3685,
-   "compress_mbps": 38.73,
-   "decompress_mbps": 123.74
+   "out_size": 56316,
+   "ratio": 0.3703,
+   "compress_mbps": 42.23,
+   "decompress_mbps": 213.15
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 3,
-   "out_size": 55543,
-   "ratio": 0.3652,
-   "compress_mbps": 36.01,
-   "decompress_mbps": 134.69
+   "out_size": 55646,
+   "ratio": 0.3659,
+   "compress_mbps": 38.03,
+   "decompress_mbps": 233.09
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 4,
-   "out_size": 54765,
-   "ratio": 0.3601,
-   "compress_mbps": 29.02,
-   "decompress_mbps": 138.83
+   "out_size": 54782,
+   "ratio": 0.3602,
+   "compress_mbps": 29.85,
+   "decompress_mbps": 235.95
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 5,
-   "out_size": 54681,
-   "ratio": 0.3595,
-   "compress_mbps": 27.99,
-   "decompress_mbps": 146.35
+   "out_size": 54700,
+   "ratio": 0.3597,
+   "compress_mbps": 28.77,
+   "decompress_mbps": 238.04
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 25.85,
-   "decompress_mbps": 151.1
+   "compress_mbps": 26.45,
+   "decompress_mbps": 244.69
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54385,
    "ratio": 0.3576,
-   "compress_mbps": 21.07,
-   "decompress_mbps": 151.12
+   "compress_mbps": 21.24,
+   "decompress_mbps": 245.06
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.34,
-   "decompress_mbps": 151.46
+   "compress_mbps": 9.54,
+   "decompress_mbps": 245.55
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 53059,
    "ratio": 0.3489,
-   "compress_mbps": 3.31,
-   "decompress_mbps": 151.07
+   "compress_mbps": 3.3,
+   "decompress_mbps": 242.78
   },
   {
    "compressor": "native",
@@ -104,48 +104,48 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 46.8,
-   "decompress_mbps": 105.71
+   "compress_mbps": 49.96,
+   "decompress_mbps": 180.32
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 2,
-   "out_size": 50023,
-   "ratio": 0.3996,
-   "compress_mbps": 36.67,
-   "decompress_mbps": 113.37
+   "out_size": 50187,
+   "ratio": 0.4009,
+   "compress_mbps": 38.94,
+   "decompress_mbps": 196.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 3,
-   "out_size": 49768,
-   "ratio": 0.3976,
-   "compress_mbps": 34.31,
-   "decompress_mbps": 123.02
+   "out_size": 49810,
+   "ratio": 0.3979,
+   "compress_mbps": 35.79,
+   "decompress_mbps": 214.24
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 4,
-   "out_size": 49034,
+   "out_size": 49036,
    "ratio": 0.3917,
-   "compress_mbps": 26.95,
-   "decompress_mbps": 126.87
+   "compress_mbps": 27.82,
+   "decompress_mbps": 218.14
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 5,
-   "out_size": 48992,
+   "out_size": 48994,
    "ratio": 0.3914,
-   "compress_mbps": 26.35,
-   "decompress_mbps": 133.05
+   "compress_mbps": 26.92,
+   "decompress_mbps": 219.56
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 24.88,
-   "decompress_mbps": 135.67
+   "compress_mbps": 25.58,
+   "decompress_mbps": 223.98
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48874,
    "ratio": 0.3904,
-   "compress_mbps": 22.45,
-   "decompress_mbps": 137.11
+   "compress_mbps": 22.82,
+   "decompress_mbps": 224.04
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 9.05,
-   "decompress_mbps": 137.29
+   "compress_mbps": 9.34,
+   "decompress_mbps": 223.94
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 47620,
    "ratio": 0.3804,
-   "compress_mbps": 3.46,
-   "decompress_mbps": 137.0
+   "compress_mbps": 3.45,
+   "decompress_mbps": 224.53
   },
   {
    "compressor": "native",
@@ -194,48 +194,48 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 37.4,
-   "decompress_mbps": 125.17
+   "compress_mbps": 39.89,
+   "decompress_mbps": 217.23
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 2,
-   "out_size": 8112,
-   "ratio": 0.3297,
-   "compress_mbps": 32.62,
-   "decompress_mbps": 129.26
+   "out_size": 8271,
+   "ratio": 0.3362,
+   "compress_mbps": 35.22,
+   "decompress_mbps": 224.64
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 3,
-   "out_size": 8053,
-   "ratio": 0.3273,
-   "compress_mbps": 32.02,
-   "decompress_mbps": 132.12
+   "out_size": 8158,
+   "ratio": 0.3316,
+   "compress_mbps": 34.4,
+   "decompress_mbps": 229.75
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 4,
-   "out_size": 7968,
-   "ratio": 0.3239,
-   "compress_mbps": 30.1,
-   "decompress_mbps": 138.48
+   "out_size": 7991,
+   "ratio": 0.3248,
+   "compress_mbps": 31.43,
+   "decompress_mbps": 238.21
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 5,
-   "out_size": 7961,
-   "ratio": 0.3236,
-   "compress_mbps": 29.74,
-   "decompress_mbps": 142.9
+   "out_size": 7984,
+   "ratio": 0.3245,
+   "compress_mbps": 30.95,
+   "decompress_mbps": 244.99
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.79,
-   "decompress_mbps": 144.25
+   "compress_mbps": 29.76,
+   "decompress_mbps": 246.58
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 25.49,
-   "decompress_mbps": 145.7
+   "compress_mbps": 25.95,
+   "decompress_mbps": 248.55
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.72,
-   "decompress_mbps": 145.64
+   "compress_mbps": 9.94,
+   "decompress_mbps": 249.94
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7801,
    "ratio": 0.3171,
-   "compress_mbps": 4.28,
-   "decompress_mbps": 145.46
+   "compress_mbps": 4.27,
+   "decompress_mbps": 249.31
   },
   {
    "compressor": "native",
@@ -284,28 +284,28 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 25.51,
-   "decompress_mbps": 100.99
+   "compress_mbps": 26.08,
+   "decompress_mbps": 151.57
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 2,
-   "out_size": 3227,
-   "ratio": 0.2894,
-   "compress_mbps": 23.28,
-   "decompress_mbps": 104.02
+   "out_size": 3269,
+   "ratio": 0.2932,
+   "compress_mbps": 24.14,
+   "decompress_mbps": 153.81
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 3,
-   "out_size": 3183,
-   "ratio": 0.2855,
-   "compress_mbps": 22.9,
-   "decompress_mbps": 107.33
+   "out_size": 3208,
+   "ratio": 0.2877,
+   "compress_mbps": 23.41,
+   "decompress_mbps": 157.24
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.88,
-   "decompress_mbps": 109.7
+   "compress_mbps": 21.89,
+   "decompress_mbps": 159.6
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.59,
-   "decompress_mbps": 110.91
+   "compress_mbps": 21.61,
+   "decompress_mbps": 161.54
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.21,
-   "decompress_mbps": 111.96
+   "compress_mbps": 21.34,
+   "decompress_mbps": 161.88
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.39,
-   "decompress_mbps": 111.73
+   "compress_mbps": 19.27,
+   "decompress_mbps": 162.27
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.13,
-   "decompress_mbps": 112.01
+   "compress_mbps": 7.18,
+   "decompress_mbps": 162.33
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 112.54
+   "compress_mbps": 4.2,
+   "decompress_mbps": 162.59
   },
   {
    "compressor": "native",
@@ -374,28 +374,28 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.27,
-   "decompress_mbps": 57.05
+   "compress_mbps": 12.51,
+   "decompress_mbps": 71.4
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 2,
-   "out_size": 1223,
-   "ratio": 0.3287,
-   "compress_mbps": 11.56,
-   "decompress_mbps": 57.54
+   "out_size": 1225,
+   "ratio": 0.3292,
+   "compress_mbps": 11.95,
+   "decompress_mbps": 72.06
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 3,
-   "out_size": 1222,
-   "ratio": 0.3284,
-   "compress_mbps": 11.54,
-   "decompress_mbps": 57.79
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 11.84,
+   "decompress_mbps": 71.99
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.42,
-   "decompress_mbps": 58.67
+   "compress_mbps": 11.56,
+   "decompress_mbps": 72.48
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 59.47
+   "compress_mbps": 11.56,
+   "decompress_mbps": 72.47
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.35,
-   "decompress_mbps": 59.66
+   "compress_mbps": 11.54,
+   "decompress_mbps": 72.81
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.03,
-   "decompress_mbps": 59.7
+   "compress_mbps": 11.28,
+   "decompress_mbps": 72.93
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.85,
-   "decompress_mbps": 59.6
+   "compress_mbps": 3.89,
+   "decompress_mbps": 72.82
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 3.5,
-   "decompress_mbps": 59.56
+   "compress_mbps": 3.52,
+   "decompress_mbps": 72.8
   },
   {
    "compressor": "native",
@@ -464,18 +464,18 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 94.78,
-   "decompress_mbps": 210.02
+   "compress_mbps": 104.94,
+   "decompress_mbps": 342.73
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 2,
-   "out_size": 242564,
+   "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 61.99,
-   "decompress_mbps": 226.27
+   "compress_mbps": 78.17,
+   "decompress_mbps": 371.99
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 61.26,
-   "decompress_mbps": 236.15
+   "compress_mbps": 65.23,
+   "decompress_mbps": 393.88
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 59.27,
-   "decompress_mbps": 242.58
+   "compress_mbps": 60.31,
+   "decompress_mbps": 413.35
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 58.18,
-   "decompress_mbps": 238.8
+   "compress_mbps": 59.44,
+   "decompress_mbps": 399.75
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 54.21,
-   "decompress_mbps": 244.81
+   "compress_mbps": 54.76,
+   "decompress_mbps": 413.34
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 214282,
    "ratio": 0.2081,
-   "compress_mbps": 20.89,
-   "decompress_mbps": 248.01
+   "compress_mbps": 19.77,
+   "decompress_mbps": 416.68
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.49,
-   "decompress_mbps": 251.17
+   "compress_mbps": 7.22,
+   "decompress_mbps": 423.75
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 183445,
    "ratio": 0.1781,
-   "compress_mbps": 2.65,
-   "decompress_mbps": 250.66
+   "compress_mbps": 2.55,
+   "decompress_mbps": 425.93
   },
   {
    "compressor": "native",
@@ -554,58 +554,58 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 57.1,
-   "decompress_mbps": 120.65
+   "compress_mbps": 61.26,
+   "decompress_mbps": 198.55
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 2,
-   "out_size": 148848,
-   "ratio": 0.3488,
-   "compress_mbps": 42.44,
-   "decompress_mbps": 129.78
+   "out_size": 149787,
+   "ratio": 0.351,
+   "compress_mbps": 46.35,
+   "decompress_mbps": 214.99
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 3,
-   "out_size": 147739,
-   "ratio": 0.3462,
-   "compress_mbps": 39.11,
-   "decompress_mbps": 142.89
+   "out_size": 148055,
+   "ratio": 0.3469,
+   "compress_mbps": 41.66,
+   "decompress_mbps": 239.44
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 4,
-   "out_size": 145779,
-   "ratio": 0.3416,
-   "compress_mbps": 31.65,
-   "decompress_mbps": 148.08
+   "out_size": 145888,
+   "ratio": 0.3419,
+   "compress_mbps": 32.45,
+   "decompress_mbps": 243.15
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 5,
-   "out_size": 145631,
-   "ratio": 0.3413,
-   "compress_mbps": 30.54,
-   "decompress_mbps": 155.21
+   "out_size": 145758,
+   "ratio": 0.3416,
+   "compress_mbps": 31.54,
+   "decompress_mbps": 245.89
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 145374,
-   "ratio": 0.3407,
-   "compress_mbps": 27.97,
-   "decompress_mbps": 158.27
+   "out_size": 145454,
+   "ratio": 0.3408,
+   "compress_mbps": 28.96,
+   "decompress_mbps": 250.68
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 145077,
    "ratio": 0.34,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 158.45
+   "compress_mbps": 23.62,
+   "decompress_mbps": 251.84
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 10.13,
-   "decompress_mbps": 158.64
+   "compress_mbps": 10.43,
+   "decompress_mbps": 251.15
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 140996,
    "ratio": 0.3304,
-   "compress_mbps": 3.31,
-   "decompress_mbps": 158.17
+   "compress_mbps": 3.3,
+   "decompress_mbps": 251.73
   },
   {
    "compressor": "native",
@@ -644,48 +644,48 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 48.26,
-   "decompress_mbps": 99.85
+   "compress_mbps": 52.3,
+   "decompress_mbps": 171.03
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 2,
-   "out_size": 199922,
-   "ratio": 0.4149,
-   "compress_mbps": 36.8,
-   "decompress_mbps": 109.34
+   "out_size": 199981,
+   "ratio": 0.415,
+   "compress_mbps": 38.93,
+   "decompress_mbps": 190.63
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 3,
-   "out_size": 198538,
-   "ratio": 0.412,
-   "compress_mbps": 33.58,
-   "decompress_mbps": 119.89
+   "out_size": 198551,
+   "ratio": 0.4121,
+   "compress_mbps": 35.02,
+   "decompress_mbps": 210.44
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 4,
-   "out_size": 195796,
+   "out_size": 195797,
    "ratio": 0.4063,
-   "compress_mbps": 24.99,
-   "decompress_mbps": 123.43
+   "compress_mbps": 25.64,
+   "decompress_mbps": 213.72
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 5,
-   "out_size": 195460,
+   "out_size": 195462,
    "ratio": 0.4056,
-   "compress_mbps": 23.99,
-   "decompress_mbps": 129.87
+   "compress_mbps": 24.25,
+   "decompress_mbps": 212.05
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 22.12,
-   "decompress_mbps": 133.23
+   "compress_mbps": 22.38,
+   "decompress_mbps": 216.14
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194724,
    "ratio": 0.4041,
-   "compress_mbps": 19.19,
-   "decompress_mbps": 134.02
+   "compress_mbps": 19.43,
+   "decompress_mbps": 216.49
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.59,
-   "decompress_mbps": 134.54
+   "compress_mbps": 8.84,
+   "decompress_mbps": 216.66
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 190711,
    "ratio": 0.3958,
-   "compress_mbps": 3.09,
-   "decompress_mbps": 134.63
+   "compress_mbps": 3.13,
+   "decompress_mbps": 216.38
   },
   {
    "compressor": "native",
@@ -734,68 +734,68 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 152.68,
-   "decompress_mbps": 346.27
+   "compress_mbps": 160.01,
+   "decompress_mbps": 465.04
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 2,
-   "out_size": 57685,
-   "ratio": 0.1124,
-   "compress_mbps": 112.87,
-   "decompress_mbps": 363.79
+   "out_size": 58873,
+   "ratio": 0.1147,
+   "compress_mbps": 123.86,
+   "decompress_mbps": 497.18
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 3,
-   "out_size": 57118,
-   "ratio": 0.1113,
-   "compress_mbps": 97.03,
-   "decompress_mbps": 385.81
+   "out_size": 58327,
+   "ratio": 0.1137,
+   "compress_mbps": 108.63,
+   "decompress_mbps": 536.07
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 4,
-   "out_size": 55724,
-   "ratio": 0.1086,
-   "compress_mbps": 77.94,
-   "decompress_mbps": 359.31
+   "out_size": 56347,
+   "ratio": 0.1098,
+   "compress_mbps": 85.54,
+   "decompress_mbps": 451.63
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 5,
-   "out_size": 55673,
-   "ratio": 0.1085,
-   "compress_mbps": 74.95,
-   "decompress_mbps": 381.31
+   "out_size": 56324,
+   "ratio": 0.1097,
+   "compress_mbps": 83.2,
+   "decompress_mbps": 479.66
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55441,
-   "ratio": 0.108,
-   "compress_mbps": 66.75,
-   "decompress_mbps": 407.95
+   "out_size": 55811,
+   "ratio": 0.1087,
+   "compress_mbps": 71.72,
+   "decompress_mbps": 525.26
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 53529,
-   "ratio": 0.1043,
-   "compress_mbps": 37.04,
-   "decompress_mbps": 432.23
+   "out_size": 53748,
+   "ratio": 0.1047,
+   "compress_mbps": 38.11,
+   "decompress_mbps": 564.25
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.58,
-   "decompress_mbps": 459.64
+   "compress_mbps": 16.52,
+   "decompress_mbps": 608.15
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 3.26,
-   "decompress_mbps": 471.5
+   "compress_mbps": 3.22,
+   "decompress_mbps": 628.15
   },
   {
    "compressor": "native",
@@ -824,58 +824,58 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 28.69,
-   "decompress_mbps": 114.3
+   "compress_mbps": 29.56,
+   "decompress_mbps": 183.43
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 2,
-   "out_size": 13760,
-   "ratio": 0.3598,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 117.29
+   "out_size": 13825,
+   "ratio": 0.3615,
+   "compress_mbps": 27.04,
+   "decompress_mbps": 188.78
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 3,
-   "out_size": 13727,
-   "ratio": 0.359,
-   "compress_mbps": 25.49,
-   "decompress_mbps": 119.11
+   "out_size": 13751,
+   "ratio": 0.3596,
+   "compress_mbps": 26.18,
+   "decompress_mbps": 191.71
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 4,
-   "out_size": 13371,
-   "ratio": 0.3497,
-   "compress_mbps": 23.61,
-   "decompress_mbps": 124.97
+   "out_size": 13379,
+   "ratio": 0.3499,
+   "compress_mbps": 23.81,
+   "decompress_mbps": 197.48
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 5,
-   "out_size": 13366,
-   "ratio": 0.3495,
-   "compress_mbps": 23.11,
-   "decompress_mbps": 131.24
+   "out_size": 13375,
+   "ratio": 0.3498,
+   "compress_mbps": 23.39,
+   "decompress_mbps": 208.8
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 13369,
+   "out_size": 13368,
    "ratio": 0.3496,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 133.52
+   "compress_mbps": 21.9,
+   "decompress_mbps": 213.07
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13344,
    "ratio": 0.349,
-   "compress_mbps": 17.91,
-   "decompress_mbps": 134.19
+   "compress_mbps": 17.53,
+   "decompress_mbps": 214.82
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.42,
-   "decompress_mbps": 135.84
+   "compress_mbps": 5.34,
+   "decompress_mbps": 217.38
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12501,
    "ratio": 0.3269,
-   "compress_mbps": 3.36,
-   "decompress_mbps": 137.67
+   "compress_mbps": 3.34,
+   "decompress_mbps": 217.78
   },
   {
    "compressor": "native",
@@ -914,28 +914,28 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 13.7,
-   "decompress_mbps": 58.46
+   "compress_mbps": 13.91,
+   "decompress_mbps": 77.53
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 2,
-   "out_size": 1741,
-   "ratio": 0.4119,
-   "compress_mbps": 13.06,
-   "decompress_mbps": 59.12
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 13.36,
+   "decompress_mbps": 76.84
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 3,
-   "out_size": 1740,
-   "ratio": 0.4116,
-   "compress_mbps": 13.07,
-   "decompress_mbps": 59.0
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 13.31,
+   "decompress_mbps": 77.6
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.83,
-   "decompress_mbps": 60.64
+   "compress_mbps": 13.12,
+   "decompress_mbps": 78.13
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.82,
-   "decompress_mbps": 60.87
+   "compress_mbps": 13.14,
+   "decompress_mbps": 78.25
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.82,
-   "decompress_mbps": 60.95
+   "compress_mbps": 13.12,
+   "decompress_mbps": 78.28
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.55,
-   "decompress_mbps": 60.87
+   "compress_mbps": 12.95,
+   "decompress_mbps": 78.07
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.22,
-   "decompress_mbps": 60.86
+   "compress_mbps": 4.29,
+   "decompress_mbps": 78.52
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 4.02,
-   "decompress_mbps": 60.65
+   "compress_mbps": 4.06,
+   "decompress_mbps": 78.24
   },
   {
    "compressor": "zlib",
@@ -3974,48 +3974,48 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 50.59,
-   "decompress_mbps": 105.27
+   "compress_mbps": 55.48,
+   "decompress_mbps": 175.13
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 2,
-   "out_size": 3970599,
-   "ratio": 0.3896,
-   "compress_mbps": 38.59,
-   "decompress_mbps": 113.0
+   "out_size": 3977395,
+   "ratio": 0.3902,
+   "compress_mbps": 41.33,
+   "decompress_mbps": 190.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 3,
-   "out_size": 3943113,
-   "ratio": 0.3869,
-   "compress_mbps": 35.04,
-   "decompress_mbps": 124.93
+   "out_size": 3945296,
+   "ratio": 0.3871,
+   "compress_mbps": 36.93,
+   "decompress_mbps": 209.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 4,
-   "out_size": 3888008,
+   "out_size": 3888037,
    "ratio": 0.3815,
-   "compress_mbps": 26.93,
-   "decompress_mbps": 128.53
+   "compress_mbps": 27.75,
+   "decompress_mbps": 213.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 5,
-   "out_size": 3882303,
+   "out_size": 3882328,
    "ratio": 0.3809,
-   "compress_mbps": 26.45,
-   "decompress_mbps": 134.77
+   "compress_mbps": 27.19,
+   "decompress_mbps": 212.35
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 24.34,
-   "decompress_mbps": 138.46
+   "compress_mbps": 24.92,
+   "decompress_mbps": 218.0
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3866648,
    "ratio": 0.3794,
-   "compress_mbps": 20.49,
-   "decompress_mbps": 138.35
+   "compress_mbps": 20.84,
+   "decompress_mbps": 217.98
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 9.05,
-   "decompress_mbps": 139.18
+   "compress_mbps": 9.49,
+   "decompress_mbps": 226.2
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3790405,
    "ratio": 0.3719,
-   "compress_mbps": 3.15,
-   "decompress_mbps": 139.99
+   "compress_mbps": 3.22,
+   "decompress_mbps": 219.59
   },
   {
    "compressor": "native",
@@ -4064,68 +4064,68 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 65.94,
-   "decompress_mbps": 134.69
+   "compress_mbps": 70.17,
+   "decompress_mbps": 192.7
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 2,
-   "out_size": 20636431,
-   "ratio": 0.4029,
-   "compress_mbps": 51.31,
-   "decompress_mbps": 140.64
+   "out_size": 20802983,
+   "ratio": 0.4061,
+   "compress_mbps": 56.03,
+   "decompress_mbps": 200.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 3,
-   "out_size": 20554782,
-   "ratio": 0.4013,
-   "compress_mbps": 48.3,
-   "decompress_mbps": 144.21
+   "out_size": 20665485,
+   "ratio": 0.4035,
+   "compress_mbps": 52.53,
+   "decompress_mbps": 200.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 4,
-   "out_size": 20408622,
-   "ratio": 0.3984,
-   "compress_mbps": 40.34,
-   "decompress_mbps": 148.61
+   "out_size": 20427823,
+   "ratio": 0.3988,
+   "compress_mbps": 41.38,
+   "decompress_mbps": 210.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 5,
-   "out_size": 20393572,
-   "ratio": 0.3982,
-   "compress_mbps": 38.33,
-   "decompress_mbps": 161.84
+   "out_size": 20413947,
+   "ratio": 0.3986,
+   "compress_mbps": 39.25,
+   "decompress_mbps": 224.27
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 20370310,
-   "ratio": 0.3977,
-   "compress_mbps": 33.93,
-   "decompress_mbps": 166.98
+   "out_size": 20373541,
+   "ratio": 0.3978,
+   "compress_mbps": 34.33,
+   "decompress_mbps": 224.75
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 20251341,
+   "out_size": 20251873,
    "ratio": 0.3954,
-   "compress_mbps": 22.67,
-   "decompress_mbps": 166.36
+   "compress_mbps": 22.16,
+   "decompress_mbps": 225.66
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.88,
-   "decompress_mbps": 167.09
+   "compress_mbps": 6.94,
+   "decompress_mbps": 226.33
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18705121,
    "ratio": 0.3652,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 166.63
+   "compress_mbps": 3.18,
+   "decompress_mbps": 224.78
   },
   {
    "compressor": "native",
@@ -4154,68 +4154,68 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 62.37,
-   "decompress_mbps": 123.29
+   "compress_mbps": 68.39,
+   "decompress_mbps": 205.5
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 2,
-   "out_size": 3733442,
-   "ratio": 0.3744,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 130.0
+   "out_size": 3734957,
+   "ratio": 0.3746,
+   "compress_mbps": 53.45,
+   "decompress_mbps": 214.49
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 3,
-   "out_size": 3708043,
+   "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 43.96,
-   "decompress_mbps": 139.63
+   "compress_mbps": 46.13,
+   "decompress_mbps": 224.58
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 4,
-   "out_size": 3713154,
+   "out_size": 3712990,
    "ratio": 0.3724,
-   "compress_mbps": 32.11,
-   "decompress_mbps": 133.21
+   "compress_mbps": 32.72,
+   "decompress_mbps": 208.12
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 5,
-   "out_size": 3707604,
-   "ratio": 0.3719,
-   "compress_mbps": 30.33,
-   "decompress_mbps": 139.61
+   "out_size": 3707399,
+   "ratio": 0.3718,
+   "compress_mbps": 31.1,
+   "decompress_mbps": 203.21
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3701198,
+   "out_size": 3701112,
    "ratio": 0.3712,
-   "compress_mbps": 27.84,
-   "decompress_mbps": 145.49
+   "compress_mbps": 28.43,
+   "decompress_mbps": 196.91
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3704150,
+   "out_size": 3704320,
    "ratio": 0.3715,
-   "compress_mbps": 21.17,
-   "decompress_mbps": 138.16
+   "compress_mbps": 22.54,
+   "decompress_mbps": 212.23
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.19,
-   "decompress_mbps": 150.11
+   "compress_mbps": 8.27,
+   "decompress_mbps": 228.1
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3594656,
    "ratio": 0.3605,
-   "compress_mbps": 2.95,
-   "decompress_mbps": 154.76
+   "compress_mbps": 2.98,
+   "decompress_mbps": 227.82
   },
   {
    "compressor": "native",
@@ -4244,68 +4244,68 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 184.71,
-   "decompress_mbps": 368.36
+   "compress_mbps": 200.7,
+   "decompress_mbps": 597.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 2,
-   "out_size": 3447001,
-   "ratio": 0.1027,
-   "compress_mbps": 117.7,
-   "decompress_mbps": 406.38
+   "out_size": 3761560,
+   "ratio": 0.1121,
+   "compress_mbps": 129.81,
+   "decompress_mbps": 670.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 3,
-   "out_size": 3338834,
-   "ratio": 0.0995,
-   "compress_mbps": 97.82,
-   "decompress_mbps": 459.22
+   "out_size": 3606997,
+   "ratio": 0.1075,
+   "compress_mbps": 113.5,
+   "decompress_mbps": 745.87
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 4,
-   "out_size": 3233721,
-   "ratio": 0.0964,
-   "compress_mbps": 86.99,
-   "decompress_mbps": 473.38
+   "out_size": 3340261,
+   "ratio": 0.0996,
+   "compress_mbps": 95.64,
+   "decompress_mbps": 742.09
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 5,
-   "out_size": 3225450,
-   "ratio": 0.0961,
-   "compress_mbps": 82.66,
-   "decompress_mbps": 537.19
+   "out_size": 3336190,
+   "ratio": 0.0994,
+   "compress_mbps": 93.91,
+   "decompress_mbps": 830.01
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3207256,
-   "ratio": 0.0956,
-   "compress_mbps": 77.13,
-   "decompress_mbps": 579.31
+   "out_size": 3217453,
+   "ratio": 0.0959,
+   "compress_mbps": 79.07,
+   "decompress_mbps": 839.94
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3125083,
-   "ratio": 0.0931,
-   "compress_mbps": 42.94,
-   "decompress_mbps": 591.07
+   "out_size": 3126259,
+   "ratio": 0.0932,
+   "compress_mbps": 42.73,
+   "decompress_mbps": 903.26
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.6,
-   "decompress_mbps": 579.25
+   "compress_mbps": 22.47,
+   "decompress_mbps": 892.73
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 3024127,
    "ratio": 0.0901,
-   "compress_mbps": 2.78,
-   "decompress_mbps": 608.96
+   "compress_mbps": 2.74,
+   "decompress_mbps": 908.14
   },
   {
    "compressor": "native",
@@ -4334,68 +4334,68 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 46.02,
-   "decompress_mbps": 90.88
+   "compress_mbps": 48.27,
+   "decompress_mbps": 128.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 2,
-   "out_size": 3273720,
-   "ratio": 0.5321,
-   "compress_mbps": 38.85,
-   "decompress_mbps": 94.9
+   "out_size": 3285077,
+   "ratio": 0.534,
+   "compress_mbps": 41.14,
+   "decompress_mbps": 132.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 3,
-   "out_size": 3266820,
-   "ratio": 0.531,
-   "compress_mbps": 37.7,
-   "decompress_mbps": 97.96
+   "out_size": 3272746,
+   "ratio": 0.532,
+   "compress_mbps": 39.54,
+   "decompress_mbps": 137.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 4,
-   "out_size": 3238141,
-   "ratio": 0.5263,
-   "compress_mbps": 32.06,
-   "decompress_mbps": 105.9
+   "out_size": 3238986,
+   "ratio": 0.5265,
+   "compress_mbps": 32.38,
+   "decompress_mbps": 145.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 5,
-   "out_size": 3237094,
-   "ratio": 0.5262,
-   "compress_mbps": 31.27,
-   "decompress_mbps": 109.73
+   "out_size": 3237944,
+   "ratio": 0.5263,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 150.52
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3235481,
-   "ratio": 0.5259,
-   "compress_mbps": 30.07,
-   "decompress_mbps": 112.06
+   "out_size": 3235767,
+   "ratio": 0.526,
+   "compress_mbps": 30.8,
+   "decompress_mbps": 153.53
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3232621,
-   "ratio": 0.5254,
-   "compress_mbps": 26.46,
-   "decompress_mbps": 112.53
+   "out_size": 3232738,
+   "ratio": 0.5255,
+   "compress_mbps": 26.88,
+   "decompress_mbps": 154.07
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.92,
-   "decompress_mbps": 114.49
+   "compress_mbps": 7.02,
+   "decompress_mbps": 156.75
   },
   {
    "compressor": "native",
@@ -4415,7 +4415,7 @@
    "out_size": 3054135,
    "ratio": 0.4964,
    "compress_mbps": 3.83,
-   "decompress_mbps": 114.49
+   "decompress_mbps": 156.25
   },
   {
    "compressor": "native",
@@ -4424,58 +4424,58 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 72.67,
-   "decompress_mbps": 155.0
+   "compress_mbps": 78.07,
+   "decompress_mbps": 230.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 2,
-   "out_size": 3760350,
-   "ratio": 0.3728,
-   "compress_mbps": 54.23,
-   "decompress_mbps": 159.36
+   "out_size": 3792520,
+   "ratio": 0.376,
+   "compress_mbps": 59.51,
+   "decompress_mbps": 238.0
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 3,
-   "out_size": 3754713,
-   "ratio": 0.3723,
-   "compress_mbps": 53.15,
-   "decompress_mbps": 164.26
+   "out_size": 3783171,
+   "ratio": 0.3751,
+   "compress_mbps": 57.57,
+   "decompress_mbps": 242.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 4,
-   "out_size": 3707210,
-   "ratio": 0.3676,
-   "compress_mbps": 48.95,
-   "decompress_mbps": 175.93
+   "out_size": 3709091,
+   "ratio": 0.3678,
+   "compress_mbps": 51.26,
+   "decompress_mbps": 242.19
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 5,
-   "out_size": 3706928,
-   "ratio": 0.3675,
-   "compress_mbps": 48.86,
-   "decompress_mbps": 182.6
+   "out_size": 3708716,
+   "ratio": 0.3677,
+   "compress_mbps": 51.45,
+   "decompress_mbps": 242.31
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3706877,
-   "ratio": 0.3675,
-   "compress_mbps": 49.04,
-   "decompress_mbps": 190.03
+   "out_size": 3707113,
+   "ratio": 0.3676,
+   "compress_mbps": 51.47,
+   "decompress_mbps": 251.84
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 45.5,
-   "decompress_mbps": 193.76
+   "compress_mbps": 47.47,
+   "decompress_mbps": 254.69
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.34,
-   "decompress_mbps": 195.95
+   "compress_mbps": 12.78,
+   "decompress_mbps": 263.77
   },
   {
    "compressor": "native",
@@ -4505,7 +4505,7 @@
    "out_size": 3693258,
    "ratio": 0.3662,
    "compress_mbps": 5.0,
-   "decompress_mbps": 199.22
+   "decompress_mbps": 269.3
   },
   {
    "compressor": "native",
@@ -4514,68 +4514,68 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 63.22,
-   "decompress_mbps": 131.67
+   "compress_mbps": 69.34,
+   "decompress_mbps": 222.38
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 2,
-   "out_size": 2018042,
-   "ratio": 0.3045,
-   "compress_mbps": 45.17,
-   "decompress_mbps": 143.23
+   "out_size": 2044843,
+   "ratio": 0.3086,
+   "compress_mbps": 48.71,
+   "decompress_mbps": 233.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 3,
-   "out_size": 1977555,
-   "ratio": 0.2984,
-   "compress_mbps": 38.84,
-   "decompress_mbps": 154.0
+   "out_size": 1992105,
+   "ratio": 0.3006,
+   "compress_mbps": 39.96,
+   "decompress_mbps": 254.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 4,
-   "out_size": 1911442,
-   "ratio": 0.2884,
-   "compress_mbps": 28.15,
-   "decompress_mbps": 162.46
+   "out_size": 1911755,
+   "ratio": 0.2885,
+   "compress_mbps": 27.89,
+   "decompress_mbps": 257.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1901081,
+   "out_size": 1901448,
    "ratio": 0.2869,
-   "compress_mbps": 25.54,
-   "decompress_mbps": 173.55
+   "compress_mbps": 25.9,
+   "decompress_mbps": 260.08
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1883325,
+   "out_size": 1883344,
    "ratio": 0.2842,
-   "compress_mbps": 20.98,
-   "decompress_mbps": 185.68
+   "compress_mbps": 21.06,
+   "decompress_mbps": 271.62
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1868263,
+   "out_size": 1868258,
    "ratio": 0.2819,
    "compress_mbps": 13.38,
-   "decompress_mbps": 186.66
+   "decompress_mbps": 276.33
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.72,
-   "decompress_mbps": 192.9
+   "compress_mbps": 7.82,
+   "decompress_mbps": 284.02
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1793832,
    "ratio": 0.2707,
-   "compress_mbps": 2.51,
-   "decompress_mbps": 193.81
+   "compress_mbps": 2.48,
+   "decompress_mbps": 290.71
   },
   {
    "compressor": "native",
@@ -4604,68 +4604,68 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 88.24,
-   "decompress_mbps": 198.97
+   "compress_mbps": 95.14,
+   "decompress_mbps": 293.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 2,
-   "out_size": 6008304,
-   "ratio": 0.2781,
-   "compress_mbps": 65.36,
-   "decompress_mbps": 209.81
+   "out_size": 6102377,
+   "ratio": 0.2824,
+   "compress_mbps": 72.18,
+   "decompress_mbps": 313.32
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 3,
-   "out_size": 5963161,
-   "ratio": 0.276,
-   "compress_mbps": 58.82,
-   "decompress_mbps": 216.56
+   "out_size": 6022184,
+   "ratio": 0.2787,
+   "compress_mbps": 66.12,
+   "decompress_mbps": 325.67
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 4,
-   "out_size": 5886640,
-   "ratio": 0.2724,
-   "compress_mbps": 49.36,
-   "decompress_mbps": 226.82
+   "out_size": 5904034,
+   "ratio": 0.2733,
+   "compress_mbps": 52.53,
+   "decompress_mbps": 336.24
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 5,
-   "out_size": 5880979,
-   "ratio": 0.2722,
-   "compress_mbps": 48.28,
-   "decompress_mbps": 240.71
+   "out_size": 5899862,
+   "ratio": 0.2731,
+   "compress_mbps": 50.36,
+   "decompress_mbps": 342.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5873572,
-   "ratio": 0.2718,
-   "compress_mbps": 45.0,
-   "decompress_mbps": 247.52
+   "out_size": 5881527,
+   "ratio": 0.2722,
+   "compress_mbps": 46.19,
+   "decompress_mbps": 351.91
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5829595,
+   "out_size": 5830453,
    "ratio": 0.2698,
    "compress_mbps": 33.41,
-   "decompress_mbps": 249.46
+   "decompress_mbps": 352.37
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.8,
-   "decompress_mbps": 237.37
+   "compress_mbps": 12.96,
+   "decompress_mbps": 327.8
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5225578,
    "ratio": 0.2419,
-   "compress_mbps": 3.69,
-   "decompress_mbps": 250.92
+   "compress_mbps": 3.63,
+   "decompress_mbps": 355.78
   },
   {
    "compressor": "native",
@@ -4694,18 +4694,18 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 37.53,
-   "decompress_mbps": 94.02
+   "compress_mbps": 41.24,
+   "decompress_mbps": 129.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 2,
-   "out_size": 5533873,
+   "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 95.22
+   "compress_mbps": 35.17,
+   "decompress_mbps": 132.08
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 31.52,
-   "decompress_mbps": 98.31
+   "compress_mbps": 33.18,
+   "decompress_mbps": 136.64
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 27.01,
-   "decompress_mbps": 101.84
+   "compress_mbps": 27.91,
+   "decompress_mbps": 139.09
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 104.52
+   "compress_mbps": 26.89,
+   "decompress_mbps": 136.43
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 106.76
+   "compress_mbps": 26.32,
+   "decompress_mbps": 138.94
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5496371,
    "ratio": 0.7579,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 108.38
+   "compress_mbps": 25.01,
+   "decompress_mbps": 138.15
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.31,
-   "decompress_mbps": 108.39
+   "compress_mbps": 6.35,
+   "decompress_mbps": 141.33
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5301868,
    "ratio": 0.7311,
-   "compress_mbps": 3.73,
-   "decompress_mbps": 107.63
+   "compress_mbps": 3.77,
+   "decompress_mbps": 141.55
   },
   {
    "compressor": "native",
@@ -4784,58 +4784,58 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 65.93,
-   "decompress_mbps": 137.91
+   "compress_mbps": 71.12,
+   "decompress_mbps": 223.0
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 2,
-   "out_size": 12582079,
-   "ratio": 0.3035,
-   "compress_mbps": 49.41,
-   "decompress_mbps": 150.32
+   "out_size": 12940398,
+   "ratio": 0.3121,
+   "compress_mbps": 54.34,
+   "decompress_mbps": 241.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 3,
-   "out_size": 12448952,
-   "ratio": 0.3003,
-   "compress_mbps": 46.04,
-   "decompress_mbps": 161.92
+   "out_size": 12703756,
+   "ratio": 0.3064,
+   "compress_mbps": 50.41,
+   "decompress_mbps": 262.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 4,
-   "out_size": 12257878,
-   "ratio": 0.2957,
-   "compress_mbps": 38.21,
-   "decompress_mbps": 169.59
+   "out_size": 12294598,
+   "ratio": 0.2966,
+   "compress_mbps": 39.65,
+   "decompress_mbps": 267.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12229398,
-   "ratio": 0.295,
-   "compress_mbps": 36.58,
-   "decompress_mbps": 177.84
+   "out_size": 12269076,
+   "ratio": 0.2959,
+   "compress_mbps": 37.96,
+   "decompress_mbps": 272.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12184501,
+   "out_size": 12184584,
    "ratio": 0.2939,
-   "compress_mbps": 33.07,
-   "decompress_mbps": 182.37
+   "compress_mbps": 33.32,
+   "decompress_mbps": 269.98
   },
   {
    "compressor": "native",
@@ -4845,7 +4845,7 @@
    "out_size": 12109369,
    "ratio": 0.2921,
    "compress_mbps": 25.31,
-   "decompress_mbps": 179.74
+   "decompress_mbps": 281.5
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.57,
-   "decompress_mbps": 184.86
+   "compress_mbps": 11.79,
+   "decompress_mbps": 282.72
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11868965,
    "ratio": 0.2863,
-   "compress_mbps": 3.33,
-   "decompress_mbps": 185.71
+   "compress_mbps": 3.34,
+   "decompress_mbps": 282.41
   },
   {
    "compressor": "native",
@@ -4874,38 +4874,38 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 35.95,
-   "decompress_mbps": 77.85
+   "compress_mbps": 39.06,
+   "decompress_mbps": 126.15
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 2,
-   "out_size": 6392125,
+   "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 35.3,
-   "decompress_mbps": 79.76
+   "compress_mbps": 37.61,
+   "decompress_mbps": 126.96
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 3,
-   "out_size": 6392122,
+   "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 34.75,
-   "decompress_mbps": 81.05
+   "compress_mbps": 37.91,
+   "decompress_mbps": 128.38
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 4,
-   "out_size": 6368721,
+   "out_size": 6368722,
    "ratio": 0.7515,
-   "compress_mbps": 33.47,
-   "decompress_mbps": 80.01
+   "compress_mbps": 35.88,
+   "decompress_mbps": 116.53
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.75,
-   "decompress_mbps": 83.35
+   "compress_mbps": 35.44,
+   "decompress_mbps": 117.83
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 33.5,
-   "decompress_mbps": 83.64
+   "compress_mbps": 35.43,
+   "decompress_mbps": 118.63
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 33.52,
-   "decompress_mbps": 83.89
+   "compress_mbps": 35.68,
+   "decompress_mbps": 118.83
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.82,
-   "decompress_mbps": 85.09
+   "compress_mbps": 4.9,
+   "decompress_mbps": 120.21
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5949045,
    "ratio": 0.702,
-   "compress_mbps": 4.48,
-   "decompress_mbps": 84.92
+   "compress_mbps": 4.53,
+   "decompress_mbps": 121.14
   },
   {
    "compressor": "native",
@@ -4964,68 +4964,68 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 135.55,
-   "decompress_mbps": 271.5
+   "compress_mbps": 151.44,
+   "decompress_mbps": 419.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 2,
-   "out_size": 762011,
-   "ratio": 0.1426,
-   "compress_mbps": 95.56,
-   "decompress_mbps": 302.11
+   "out_size": 846807,
+   "ratio": 0.1584,
+   "compress_mbps": 101.03,
+   "decompress_mbps": 455.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 3,
-   "out_size": 743137,
-   "ratio": 0.139,
-   "compress_mbps": 84.79,
-   "decompress_mbps": 337.46
+   "out_size": 806798,
+   "ratio": 0.1509,
+   "compress_mbps": 92.34,
+   "decompress_mbps": 503.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 4,
-   "out_size": 725534,
-   "ratio": 0.1357,
-   "compress_mbps": 69.83,
-   "decompress_mbps": 338.1
+   "out_size": 746239,
+   "ratio": 0.1396,
+   "compress_mbps": 73.56,
+   "decompress_mbps": 547.92
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 721655,
-   "ratio": 0.135,
-   "compress_mbps": 67.9,
-   "decompress_mbps": 379.13
+   "out_size": 743257,
+   "ratio": 0.139,
+   "compress_mbps": 71.46,
+   "decompress_mbps": 596.7
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 715547,
-   "ratio": 0.1339,
-   "compress_mbps": 62.0,
-   "decompress_mbps": 397.07
+   "out_size": 721315,
+   "ratio": 0.1349,
+   "compress_mbps": 64.91,
+   "decompress_mbps": 648.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 702400,
-   "ratio": 0.1314,
-   "compress_mbps": 41.69,
-   "decompress_mbps": 409.12
+   "out_size": 703742,
+   "ratio": 0.1317,
+   "compress_mbps": 42.29,
+   "decompress_mbps": 664.81
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.62,
-   "decompress_mbps": 420.37
+   "compress_mbps": 20.92,
+   "decompress_mbps": 676.13
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 656466,
    "ratio": 0.1228,
-   "compress_mbps": 3.01,
-   "decompress_mbps": 440.93
+   "compress_mbps": 2.96,
+   "decompress_mbps": 664.14
   },
   {
    "compressor": "zlib",
@@ -17264,7 +17264,7 @@
    "level": 10,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.82,
+   "compress_mbps": 1.83,
    "decompress_mbps": null
   },
   {
@@ -17274,7 +17274,7 @@
    "level": 10,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.1,
+   "compress_mbps": 2.08,
    "decompress_mbps": null
   },
   {
@@ -17284,7 +17284,7 @@
    "level": 10,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.4,
    "decompress_mbps": null
   },
   {
@@ -17304,7 +17304,7 @@
    "level": 10,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 2.12,
+   "compress_mbps": 2.14,
    "decompress_mbps": null
   },
   {
@@ -17314,7 +17314,7 @@
    "level": 10,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.19,
+   "compress_mbps": 1.18,
    "decompress_mbps": null
   },
   {
@@ -17324,7 +17324,7 @@
    "level": 10,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.85,
+   "compress_mbps": 1.87,
    "decompress_mbps": null
   },
   {
@@ -17344,7 +17344,7 @@
    "level": 10,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 1.07,
+   "compress_mbps": 1.05,
    "decompress_mbps": null
   },
   {
@@ -17354,7 +17354,7 @@
    "level": 10,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.85,
+   "compress_mbps": 1.82,
    "decompress_mbps": null
   },
   {
@@ -17364,7 +17364,7 @@
    "level": 10,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.51,
+   "compress_mbps": 2.54,
    "decompress_mbps": null
   },
   {
@@ -17394,7 +17394,7 @@
    "level": 10,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 1.27,
+   "compress_mbps": 1.25,
    "decompress_mbps": null
   },
   {
@@ -17404,7 +17404,7 @@
    "level": 10,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.9,
+   "compress_mbps": 0.88,
    "decompress_mbps": null
   },
   {
@@ -17424,7 +17424,7 @@
    "level": 10,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 2.76,
+   "compress_mbps": 2.77,
    "decompress_mbps": null
   },
   {
@@ -17434,7 +17434,7 @@
    "level": 10,
    "out_size": 1724560,
    "ratio": 0.2602,
-   "compress_mbps": 1.18,
+   "compress_mbps": 1.17,
    "decompress_mbps": null
   },
   {
@@ -17454,7 +17454,7 @@
    "level": 10,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.6,
+   "compress_mbps": 2.59,
    "decompress_mbps": null
   },
   {
@@ -17464,7 +17464,7 @@
    "level": 10,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.63,
+   "compress_mbps": 1.62,
    "decompress_mbps": null
   },
   {
@@ -17474,7 +17474,7 @@
    "level": 10,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.47,
+   "compress_mbps": 3.45,
    "decompress_mbps": null
   },
   {
@@ -17484,7 +17484,7 @@
    "level": 10,
    "out_size": 637424,
    "ratio": 0.1192,
-   "compress_mbps": 1.19,
+   "compress_mbps": 1.18,
    "decompress_mbps": null
   }
  ]

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -18,6 +18,15 @@ cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
 
 OUT="bench/results/latest.json"
 
+# Pin every *measurement* process to one CPU (#2739): unpinned runs migrate
+# between cores mid-sweep and pick up multi-MB/s run-to-run drift on a busy
+# box. Builds and plotting stay unpinned. Default: the last physical core
+# (on an SMT machine, core N pairs with hyperthread N + nproc/2, so this also
+# keeps the sibling of core 0 free). Override with BENCH_PIN=<cpu>, or
+# BENCH_PIN=none to disable (e.g. single-core CI runners).
+BENCH_PIN="${BENCH_PIN:-$(( $(nproc) / 2 - 1 ))}"
+if [ "$BENCH_PIN" = "none" ]; then PIN=""; else PIN="taskset -c $BENCH_PIN"; fi
+
 in_project_shell() {
   if [ -n "${IN_NIX_SHELL:-}" ]; then bash -c "$1"; else nix-shell --run "$1"; fi
 }
@@ -35,8 +44,8 @@ in_project_shell() {
 if [ "${1:-}" = "--native-only" ]; then
   [ -f "$OUT" ] || { echo "no existing $OUT to splice into — run a full bench/run.sh first" >&2; exit 1; }
   TMP="$(mktemp --suffix=.json)"
-  in_project_shell "lake build bench-report \
-    && lake env .lake/build/bin/bench-report --native-only $TMP ${2:-}"
+  in_project_shell "lake build bench-report"
+  in_project_shell "$PIN lake env .lake/build/bin/bench-report --native-only $TMP ${2:-}"
   in_project_shell "python3 bench/merge_native.py $OUT $TMP $OUT \
     && python bench/plot.py $OUT bench/graphs"
   rm -f "$TMP"
@@ -60,15 +69,15 @@ fi
 #    corpus files only (pattern "<corpus>/<file>", e.g. "canterbury/alice29.txt");
 #    --dump-payloads writes the corpus bytes under bench/payloads/<corpus>/ for the
 #    external comparators.
-in_project_shell "lake build bench-report \
-  && lake env .lake/build/bin/bench-report $OUT \
-  && lake env .lake/build/bin/bench-report --dump-payloads bench/payloads"
+in_project_shell "lake build bench-report"
+in_project_shell "$PIN lake env .lake/build/bin/bench-report $OUT"
+in_project_shell "lake env .lake/build/bin/bench-report --dump-payloads bench/payloads"
 
 # 3. External-language comparators: build (own toolchains) then run + merge.
 #    node + python3 must be on PATH for the JS comparator and the driver.
 bash bench/comparators/build_all.sh
 nix-shell -p nodejs python3 --run \
-  "python3 bench/comparators/run_external.py bench/payloads $OUT"
+  "$PIN python3 bench/comparators/run_external.py bench/payloads $OUT"
 
 # 3b. Decode-density experiment (the decompression analogue of the compress
 #    Pareto): fix the encoder to libdeflate, dump its raw-DEFLATE streams for
@@ -78,9 +87,9 @@ nix-shell -p nodejs python3 --run \
 #    sibling decode_density.json that plot.py renders as
 #    <corpus>_decode_density.svg.
 DD="bench/results/decode_density.json"
-in_project_shell "lake env .lake/build/bin/bench-report --decode-density $DD bench/payloads-deflate"
+in_project_shell "$PIN lake env .lake/build/bin/bench-report --decode-density $DD bench/payloads-deflate"
 nix-shell -p nodejs python3 --run \
-  "python3 bench/decode_density.py bench/payloads-deflate $DD"
+  "$PIN python3 bench/decode_density.py bench/payloads-deflate $DD"
 
 # 4. Render (project shell: python + matplotlib). plot.py auto-detects the
 #    sibling decode_density.json and emits the decode-density chart too.

--- a/progress/rc-allocator-tax-2739.md
+++ b/progress/rc-allocator-tax-2739.md
@@ -1,0 +1,90 @@
+# Progress: attribute and cut the RC/allocator tax (#2739)
+
+**Date**: 2026-07-02 UTC
+**Session type**: Feature
+**Issue**: #2739
+
+## Step 1: attribution (done)
+
+DWARF unwinding does not work on leanc-built binaries (verified with a
+controlled pair: the same test program unwinds fully when built with gcc,
+drops all intermediate frames when built with leanc), so `perf record
+--call-graph dwarf` yields self==children for every symbol. **Hardware branch
+sampling** (`perf record -j any_call,u -e cycles:u`, Zen 5) works instead:
+every sampled `call` into an allocator symbol names its caller exactly, no
+unwinding involved. Steady-state `compress-pareto` runs on chungus.
+
+### L1/dickens (tax = 9.3% `lean_dec_ref_cold` + 4.3% `mi_free` + 3.4% `mi_malloc_small` ≈ 17%)
+
+Two shapes explain essentially all of it:
+
+| shape | share of `mi_malloc_small` calls | matching frees |
+|---|---|---|
+| `BitWriter.flushAcc` builds a fresh writer per `writeBits`/`writeHuffCode` | 59% | `writeHuffCode`/`writeBits` dec_ref (~55%) |
+| `updateHashesFastU` allocates the `(hashTable, prev)` result pair per match | 41% | `lz77ChainIterP.mainLoop` destructuring it (~40%) |
+
+**#2631's share is ~zero**: `lean_copy_expand_array` (push-doubling reallocs)
+got 2 branch samples out of 45k. The BitWriter *output buffer* doubling is not
+where the tax is; that issue's win must come from wide stores.
+
+### L8/xml (tax ≈ 14.6%, plus 14.3% `findTableCode.go` self time)
+
+| caller of `mi_malloc_small` | share | note |
+|---|---|---|
+| `findTableCode.go` | 38% | boxed sizing/emit path: `findLengthCode`/`findDistCode` allocate `some (a,b,c)` per reference, freed in `tokenFreqs.go` / `emitTokensWithCodes`; also a **linear scan** (14.3% self) where the packed path uses O(1) `lenCodeWordTab` |
+| `updateHashesFastU` | 23% | same pair churn as L1 |
+| `BitWriter.flushAcc` | 19% | same writer churn as L1 |
+| `List.setTR.go` | 8% | `computeCodeLengths`' `List.set` folds (2.29% self time) — superseded if #2737 lands |
+| `ptokens.map unpackTok` | 6% | boxed token materialization for the split path (the "stage D" gap) |
+| `chooseSplitsHeuristic` loop | 3% | `forIn` loop-state tuples |
+
+## Step 2: fixes
+
+1. **BitWriter ctor reuse** (landed): `flushAcc` split into `flushBytes`
+   (byte pushes, returns only the `ByteArray`) + `dropBytes` (leftover
+   accumulator); `writeBits`/`writeHuffCode` construct the result writer
+   themselves, where reset/reuse fires (verified in IR: in-place `set`/`sset`
+   on the unique path). Proof cost: `flushAcc_eq` + restated defining
+   equations; 4 proof lines in `BitWriterCorrect` switched from
+   `simp only [writeBits]` to `rw [writeBits_def]`.
+
+2. **updateHashes pair threading** (measured-negative, retired): the packed
+   matcher main loops threaded the chain state as one `(hashTable, prev)` pair
+   (`updateHashesFastUSt`/`updateHashesGuardedSt`) so ctor reuse recycles a
+   single pair cell instead of allocating one per match. Built, proven
+   (lockstep `_eq` lemmas, `lake exe test` green), and verified in the
+   generated C (`lean_is_exclusive` + in-place `lean_ctor_set` on the hot
+   path) — but pinned interleaved A/B measured **−1.9% L1 / −1.2% L8** vs the
+   BitWriter fix alone: the reuse turns one alloc+free *per match* into an
+   `isShared` check + two cell stores *per position* (and per insertion in
+   the walk), which costs more than it saves. Reverted; patch preserved in
+   the session scratchpad. A cleaner kill would merge `hashTable`/`prev` into
+   one array (no pair exists anywhere), but that refactors `chainWalkPacked`
+   indexing + the whole LZ77Chain proof column for a bounded ~3–5% prize.
+
+3. **Not fixed here, attributed**: the L8 boxed-lookup churn (`findTableCode`)
+   wants the split path moved onto packed words (stage D) — the sizing 2/3
+   overlaps #2737's sizing-pass retirement; the emit 1/3 survives #2737 and
+   remains available as a follow-up. `List.setTR` (#2737) and
+   `chooseSplitsHeuristic` loop tuples (3%) also left.
+
+## Measurements (compress-pareto, `taskset -c 43`, interleaved A/B)
+
+| | L1/dickens | L8/xml | L6/dickens | L9/xml |
+|---|---|---|---|---|
+| baseline (f00d7cc7) | 51.6 MB/s | 21.1 MB/s | 24.5 | 2.93 |
+| + BitWriter ctor reuse | **56.7 (+9.9%)** | **21.9 (+3.8%)** | 25.4 | 3.01 |
+| + pair threading (retired) | 55.6 (−1.9%) | 21.8 (−1.2%) | 25.2 | 3.04 |
+
+Output byte-identical in every cell (L1 out=4259646, L8 out=674362,
+L6 out=3873339, L9 out=656466).
+
+## Method notes for future perf sessions
+
+- Pin benchmark runs to one core: `taskset -c 40 .lake/build/bin/bench …`.
+- For caller attribution on this box use branch sampling, not DWARF:
+  `perf record -j any_call,u -e cycles:u -F 1997 -o out.data <cmd>`, then
+  `perf script -F brstacksym | tr ' ' '\n' | grep "/<symbol>" | awk -F/ '{print $1}' | sort | uniq -c | sort -rn`.
+- Check ctor-reuse hypotheses in IR before trusting them:
+  prepend `set_option trace.compiler.ir.result true` and look for
+  `set`/`sset` + `isShared` instead of `ctor` on the hot path.


### PR DESCRIPTION
This PR attribute the compress-path RC/allocator tax (#2739) with hardware branch sampling and land the top fix: constructing the result `BitWriter` in `writeBits`/`writeHuffCode` instead of inside the `flushAcc` loop, so the compiler's ctor-reuse recycles one writer cell per stream instead of allocating and freeing one per field written. Measured on chungus (`compress-pareto`, pinned `taskset -c 43`, interleaved A/B vs master): L1/dickens 51.6 → 56.7 MB/s (+9.9%), L8/xml 21.1 → 21.9 MB/s (+3.8%), L6/dickens 24.5 → 25.4, L9/xml 2.93 → 3.01; output byte-identical everywhere. Proof cost is small: `flushAcc` and `flushAcc_spec` stay as the reference form, `flushAcc_eq` proves the split (`flushBytes`/`dropBytes`) form equal, and `writeBits_def`/`writeHuffCode_def` restate the old defining equations for the four unfold sites in `BitWriterCorrect`.

Attribution notes (in `progress/rc-allocator-tax-2739.md`): DWARF unwinding produces no usable call graphs on leanc-built binaries, but branch sampling (`perf record -j any_call,u`) attributes every sampled call into `mi_malloc_small`/`mi_free`/`lean_dec_ref_cold` to its exact caller. On L1 the tax was ~59% BitWriter ctor churn and ~41% `updateHashes` result-pair churn; on L8 the boxed split path (`findTableCode` scans + Option/tuple churn, `unpackTok` map, `List.setTR`) dominates alongside the same two shapes. The #2631 pre-size share is ~zero (2 branch samples of push-doubling reallocs out of 45k), so that issue's win must come from wide stores, not fewer reallocs.

A second fix (threading the matcher chain state as one pair for ctor reuse) was built, proven, and measured **negative** (−1.9% L1): the reuse converts one alloc+free per match into an isShared check plus two cell stores per position, which costs more than it saves. It is documented and retired, not landed. The remaining L8 sizing-path churn is handed to #2737 / stage D with the numbers.

🤖 Prepared with Claude Code